### PR TITLE
feat: add coda watch — background session monitor with bell notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,14 @@ NODE_MAJOR_VERSION=20
 # Package manager preference: npm, pnpm, or yarn
 PACKAGE_MANAGER="npm"
 
+# --- Watcher (coda watch) ---
+
+# How often to poll sessions for state changes (seconds)
+CODA_WATCH_INTERVAL=5
+
+# Minimum seconds between repeat notifications for the same pane
+CODA_WATCH_COOLDOWN=60
+
 # --- Layout & Profiles ---
 
 # Default tmux layout when creating sessions (see: coda layout ls)

--- a/README.md
+++ b/README.md
@@ -354,6 +354,29 @@ If Claude auth expires, re-run `claude auth login` then `coda auth`.
 
 ---
 
+### `coda watch`
+
+Start a background watcher that monitors all OpenCode sessions. When an agent
+finishes processing and starts waiting for your input, the watcher sends a
+terminal bell to every connected tmux client. The bell propagates through mosh
+to your local terminal, which shows an OS-native notification.
+
+```bash
+coda watch                # start the watcher (runs in coda-watcher tmux session)
+coda watch status         # check if running
+coda watch stop           # stop the watcher
+```
+
+Detection: the watcher captures each pane's status bar every `CODA_WATCH_INTERVAL`
+seconds (default: 5). It looks for the `esc interrupt` indicator that appears
+while OpenCode is actively processing. When that indicator disappears (processing
+→ idle transition), the notification fires.
+
+A cooldown of `CODA_WATCH_COOLDOWN` seconds (default: 60) prevents repeated
+notifications for the same pane.
+
+---
+
 ### `coda help`
 
 Print a short usage summary. Full manual: `man coda`.
@@ -428,6 +451,8 @@ All behaviour is controlled by `.env` in the repo directory. Created from
 | `MAX_CONCURRENT_SESSIONS` | `5` | Cap on parallel sessions |
 | `OPENCODE_HEADLESS_PERMISSION` | `{"*":"allow"}` | Permission policy for `coda serve` |
 | `NODE_MAJOR_VERSION` | `20` | Node.js major version for install |
+| `CODA_WATCH_INTERVAL` | `5` | Watcher poll interval (seconds) |
+| `CODA_WATCH_COOLDOWN` | `60` | Min seconds between repeat notifications per pane |
 | `AUTO_ATTACH_TMUX` | `true` | Auto-attach to tmux on SSH login |
 | `DEFAULT_TMUX_SESSION` | `default` | Session name for auto-attach |
 
@@ -468,6 +493,7 @@ every 15 minutes and restores them on reboot.
 ```
 coda/
 |-- install.sh              Full install: packages → config wiring
+|-- coda-watcher.sh         Background session monitor (started via coda watch)
 |-- shell-functions.sh      The coda command (sourced into your shell)
 |-- completions/
 |   |-- coda.bash           Bash tab completion

--- a/coda-watcher.sh
+++ b/coda-watcher.sh
@@ -99,13 +99,13 @@ notify() {
 
     local display_name="${session#"$SESSION_PREFIX"}"
 
-    # Send BEL + display-message to every attached tmux client.
-    # Writing BEL directly to the client pty bypasses tmux's per-session
-    # bell routing so it works regardless of which session the user is viewing.
+    # Send BEL via tmux + display-message to every attached client.
+    # We use 'tmux send-keys' to inject the bell character rather than
+    # writing directly to the client pty (which requires pty ownership).
     local client_tty
     while IFS= read -r client_tty; do
         [ -z "$client_tty" ] && continue
-        printf '\a' > "$client_tty" 2>/dev/null || true
+        tmux send-keys -t "$session" BEL 2>/dev/null || true
         tmux display-message -c "$client_tty" \
             "coda: ${display_name} needs attention" 2>/dev/null || true
     done < <(tmux list-clients -F '#{client_tty}' 2>/dev/null)

--- a/coda-watcher.sh
+++ b/coda-watcher.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+#
+# coda-watcher.sh — Monitor OpenCode sessions and notify on attention needed
+#
+# Polls all coda tmux sessions, detects when OpenCode transitions from
+# processing (AI working) to idle (waiting for user input), and sends a
+# terminal bell (BEL) to every connected tmux client.
+#
+# The bell propagates: tmux client pty → mosh → your terminal → OS notification.
+# Works with Ghostty, iTerm2, Kitty, and any terminal that supports BEL alerts.
+#
+# Normally started via 'coda watch'. Can also be run directly.
+#
+# Environment:
+#   CODA_WATCH_INTERVAL   Poll interval in seconds (default: 5)
+#   CODA_WATCH_COOLDOWN   Min seconds between repeat notifications per pane (default: 60)
+#   SESSION_PREFIX        tmux session name prefix (default: coda-)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -f "$SCRIPT_DIR/.env" ]; then
+    # shellcheck source=/dev/null
+    set -a; source "$SCRIPT_DIR/.env"; set +a
+fi
+
+POLL_INTERVAL="${CODA_WATCH_INTERVAL:-5}"
+COOLDOWN="${CODA_WATCH_COOLDOWN:-60}"
+SESSION_PREFIX="${SESSION_PREFIX:-coda-}"
+WATCHER_SESSION="coda-watcher"
+
+STATE_DIR="${XDG_RUNTIME_DIR:-/tmp}/coda-watcher.$$"
+mkdir -p "$STATE_DIR"
+trap 'rm -rf "$STATE_DIR"' EXIT
+
+# ---------------------------------------------------------------------------
+# State tracking — one file per pane, keyed by session:pane_id
+# ---------------------------------------------------------------------------
+
+_sanitize_key() {
+    echo "${1//[^a-zA-Z0-9_-]/_}"
+}
+
+get_state() {
+    local file="$STATE_DIR/$(_sanitize_key "$1").state"
+    [ -f "$file" ] && cat "$file" || echo "unknown"
+}
+
+set_state() {
+    echo "$2" > "$STATE_DIR/$(_sanitize_key "$1").state"
+}
+
+get_last_notify() {
+    local file="$STATE_DIR/$(_sanitize_key "$1").notified"
+    [ -f "$file" ] && cat "$file" || echo "0"
+}
+
+set_last_notify() {
+    date +%s > "$STATE_DIR/$(_sanitize_key "$1").notified"
+}
+
+# ---------------------------------------------------------------------------
+# Detection — identify OpenCode panes and their processing state
+# ---------------------------------------------------------------------------
+
+# OpenCode's status bar contains "OpenCode" followed by a version number.
+is_opencode_pane() {
+    echo "$1" | grep -qE 'OpenCode [0-9]+\.[0-9]+'
+}
+
+# When OpenCode is processing, the status bar shows "esc interrupt" (the key
+# hint to cancel the current operation).  When idle/waiting for input, this
+# text is absent.
+detect_state() {
+    if echo "$1" | grep -qF 'esc interrupt'; then
+        echo "processing"
+    else
+        echo "idle"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Notification — bell + status-bar message to all connected clients
+# ---------------------------------------------------------------------------
+
+notify() {
+    local session="$1"
+    local key="$2"
+    local now
+    now=$(date +%s)
+    local last
+    last=$(get_last_notify "$key")
+
+    # Respect cooldown
+    if (( now - last < COOLDOWN )); then
+        return
+    fi
+
+    local display_name="${session#"$SESSION_PREFIX"}"
+
+    # Send BEL + display-message to every attached tmux client.
+    # Writing BEL directly to the client pty bypasses tmux's per-session
+    # bell routing so it works regardless of which session the user is viewing.
+    local client_tty
+    while IFS= read -r client_tty; do
+        [ -z "$client_tty" ] && continue
+        printf '\a' > "$client_tty" 2>/dev/null || true
+        tmux display-message -c "$client_tty" \
+            "coda: ${display_name} needs attention" 2>/dev/null || true
+    done < <(tmux list-clients -F '#{client_tty}' 2>/dev/null)
+
+    set_last_notify "$key"
+}
+
+# ---------------------------------------------------------------------------
+# Cleanup — remove stale state for sessions/panes that no longer exist
+# ---------------------------------------------------------------------------
+
+cleanup_stale_state() {
+    local active_keys="$1"
+    for f in "$STATE_DIR"/*.state; do
+        [ -f "$f" ] || continue
+        local basename
+        basename=$(basename "${f%.state}")
+        if ! echo "$active_keys" | grep -qF "$basename"; then
+            rm -f "$STATE_DIR/${basename}.state" "$STATE_DIR/${basename}.notified"
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+
+echo "coda-watcher: monitoring OpenCode sessions"
+echo "  interval=${POLL_INTERVAL}s  cooldown=${COOLDOWN}s"
+echo "  Stop with: coda watch stop (or Ctrl-C)"
+echo ""
+
+while true; do
+    active_keys=""
+
+    # All coda sessions except the watcher itself
+    sessions=$(tmux list-sessions -F '#{session_name}' 2>/dev/null \
+        | grep "^${SESSION_PREFIX}" \
+        | grep -v "^${WATCHER_SESSION}$" \
+        || true)
+
+    while IFS= read -r session; do
+        [ -z "$session" ] && continue
+
+        # Every pane in every window of this session
+        panes=$(tmux list-panes -s -t "$session" -F '#{pane_id}' 2>/dev/null || true)
+
+        while IFS= read -r pane_id; do
+            [ -z "$pane_id" ] && continue
+
+            # Capture the bottom of the pane (status bar lives here)
+            content=$(tmux capture-pane -t "$pane_id" -p -S -5 2>/dev/null || true)
+            [ -z "$content" ] && continue
+
+            if ! is_opencode_pane "$content"; then
+                continue
+            fi
+
+            key="${session}:${pane_id}"
+            sanitized=$(_sanitize_key "$key")
+            active_keys="${active_keys}${sanitized}\n"
+
+            prev_state=$(get_state "$key")
+            curr_state=$(detect_state "$content")
+
+            # Notify on transition: processing → idle
+            if [ "$prev_state" = "processing" ] && [ "$curr_state" = "idle" ]; then
+                notify "$session" "$key"
+            fi
+
+            set_state "$key" "$curr_state"
+        done <<< "$panes"
+    done <<< "$sessions"
+
+    # Prune state for panes/sessions that vanished
+    cleanup_stale_state "$active_keys"
+
+    sleep "$POLL_INTERVAL"
+done

--- a/completions/coda.bash
+++ b/completions/coda.bash
@@ -63,7 +63,7 @@ _coda_complete() {
         cword=$COMP_CWORD
     }
 
-    local top_subcommands="attach ls switch serve auth project feature layout profile help"
+    local top_subcommands="attach ls switch serve auth project feature layout profile watch help"
 
     # Word positions:
     #   words[0] = coda
@@ -111,6 +111,9 @@ _coda_complete() {
                     ;;
                 profile)
                     COMPREPLY=($(compgen -W "ls create show" -- "$cur"))
+                    ;;
+                watch)
+                    COMPREPLY=($(compgen -W "start stop status" -- "$cur"))
                     ;;
                 attach)
                     # Suggest existing sessions to attach to

--- a/completions/coda.zsh
+++ b/completions/coda.zsh
@@ -74,6 +74,7 @@ _coda() {
                 'feature:manage feature worktrees'
                 'layout:manage and apply tmux layouts'
                 'profile:manage config profiles'
+                'watch:monitor sessions for attention signals'
                 'help:show usage'
             )
             # Add existing sessions as completions
@@ -100,6 +101,9 @@ _coda() {
                     ;;
                 profile)
                     _coda_profile_args
+                    ;;
+                watch)
+                    _coda_watch_args
                     ;;
                 serve)
                     local base="${OPENCODE_BASE_PORT:-4096}"
@@ -258,6 +262,25 @@ _coda_profile_args() {
                     _describe 'profile' profiles
                     ;;
             esac
+            ;;
+    esac
+}
+
+_coda_watch_args() {
+    local state line
+    _arguments -C \
+        '1: :->subcmd' \
+        && return 0
+
+    case $state in
+        subcmd)
+            local -a subcmds
+            subcmds=(
+                'start:start the watcher'
+                'stop:stop the watcher'
+                'status:check if watcher is running'
+            )
+            _describe 'watch subcommand' subcmds
             ;;
     esac
 }

--- a/man/coda.1
+++ b/man/coda.1
@@ -70,6 +70,10 @@ coda \- OpenCode session and project manager
 .I name
 .br
 .B coda
+.B watch
+.RB [ start | stop | status ]
+.br
+.B coda
 .B help
 .
 .SH DESCRIPTION
@@ -312,6 +316,39 @@ Single pane running
 (top-right), shell (bottom).
 .RE
 .
+.SS Session watcher
+.
+.TP
+.B coda watch
+.TQ
+.B coda watch start
+Start the background session watcher.
+Polls all active
+.B coda
+sessions every
+.B CODA_WATCH_INTERVAL
+seconds (default: 5).
+When an OpenCode instance finishes processing and begins waiting for input, the
+watcher sends a terminal bell (BEL) to every attached tmux client and displays a
+status-bar message identifying the session.
+.sp
+The bell propagates through mosh to your local terminal, which triggers an
+OS-native notification (supported by Ghostty, iTerm2, Kitty, and most modern
+terminal emulators).
+.sp
+The watcher runs in its own tmux session named
+.BR coda-watcher .
+.
+.TP
+.B coda watch stop
+Stop the watcher by killing the
+.B coda-watcher
+tmux session.
+.
+.TP
+.B coda watch status
+Print whether the watcher is running and when it was started.
+.
 .SS Profiles
 .
 .TP
@@ -365,6 +402,8 @@ DEFAULT_LAYOUT	default	Default tmux layout
 CODA_LAYOUTS_DIR	~/.config/coda/layouts	User layout directory
 CODA_PROFILES_DIR	~/.config/coda/profiles	User profile directory
 MAX_CONCURRENT_SESSIONS	5	Max parallel sessions
+CODA_WATCH_INTERVAL	5	Watcher poll interval (seconds)
+CODA_WATCH_COOLDOWN	60	Min seconds between repeat notifications
 OPENCODE_HEADLESS_PERMISSION	{"*":"allow"}	Permission policy for serve
 AUTO_ATTACH_TMUX	true	Auto-attach on SSH login
 DEFAULT_TMUX_SESSION	default	Session name for auto-attach
@@ -418,6 +457,13 @@ coda switch          # pick one to check on
 .EX
 coda serve           # starts on first free port
 opencode attach http://localhost:4096
+.EE
+.
+.SS Monitoring sessions for attention
+.EX
+coda watch               # start the watcher
+coda watch status        # check if running
+coda watch stop          # stop when done
 .EE
 .
 .SS Sending tasks from the command line (no attach needed)

--- a/shell-functions.sh
+++ b/shell-functions.sh
@@ -39,6 +39,7 @@ CODA_LAYOUTS_DIR="${CODA_LAYOUTS_DIR:-$HOME/.config/coda/layouts}"
 #   coda feature <cmd>            manage feature worktrees
 #   coda layout <cmd|name>        manage/apply tmux layouts
 #   coda profile <cmd>            manage layout/config profiles
+#   coda watch <cmd>              monitor sessions for attention signals
 #   coda help                     show this help
 #
 # Global flags (any position):
@@ -79,6 +80,7 @@ coda() {
         feature)          _coda_feature "${args[@]:1}" ;;
         layout)           _coda_layout_cmd "${args[@]:1}" ;;
         profile)          _coda_profile_cmd "${args[@]:1}" ;;
+        watch)            _coda_watch "${args[@]:1}" ;;
         help|--help|-h)   _coda_help ;;
         "")               _coda_attach ;;
         *)                _coda_attach "${args[0]#"$SESSION_PREFIX"}" "${args[@]:1}" ;;
@@ -740,6 +742,65 @@ TMPL
 }
 
 # ===========================================================================
+# coda watch <start|stop|status>
+# ===========================================================================
+_coda_watch() {
+    local subcmd="${1:-start}"
+    local watcher_session="coda-watcher"
+
+    case "$subcmd" in
+        start)  _coda_watch_start "$watcher_session" ;;
+        stop)   _coda_watch_stop "$watcher_session" ;;
+        status) _coda_watch_status "$watcher_session" ;;
+        ""|help) echo "Usage: coda watch <start|stop|status>" ;;
+        *)    echo "Unknown watch subcommand: $subcmd"; echo "Usage: coda watch <start|stop|status>"; return 1 ;;
+    esac
+}
+
+_coda_watch_start() {
+    local watcher_session="$1"
+
+    if tmux has-session -t "$watcher_session" 2>/dev/null; then
+        echo "Watcher already running."
+        echo "  View:  tmux attach -t $watcher_session"
+        echo "  Stop:  coda watch stop"
+        return 0
+    fi
+
+    tmux new-session -d -s "$watcher_session" "$_CODA_DIR/coda-watcher.sh"
+    echo "Watcher started."
+    echo "  View:  tmux attach -t $watcher_session"
+    echo "  Stop:  coda watch stop"
+}
+
+_coda_watch_stop() {
+    local watcher_session="$1"
+
+    if ! tmux has-session -t "$watcher_session" 2>/dev/null; then
+        echo "Watcher is not running."
+        return 0
+    fi
+
+    tmux kill-session -t "$watcher_session"
+    echo "Watcher stopped."
+}
+
+_coda_watch_status() {
+    local watcher_session="$1"
+
+    if tmux has-session -t "$watcher_session" 2>/dev/null; then
+        local created
+        created=$(tmux display-message -t "$watcher_session" -p '#{t:session_created}' 2>/dev/null)
+        echo "Watcher: running (since $created)"
+        echo "  View:  tmux attach -t $watcher_session"
+        echo "  Stop:  coda watch stop"
+    else
+        echo "Watcher: stopped"
+        echo "  Start: coda watch"
+    fi
+}
+
+# ===========================================================================
 # coda help
 # ===========================================================================
 _coda_help() {
@@ -769,6 +830,10 @@ USAGE
   coda profile ls                  List profiles
   coda profile create <name>       Create a new profile
   coda profile show <name>         Show profile settings
+
+  coda watch                       Start monitoring sessions (bell on idle)
+  coda watch stop                  Stop the watcher
+  coda watch status                Check if watcher is running
 
   coda help                   Show this help
 

--- a/tmux.conf
+++ b/tmux.conf
@@ -95,6 +95,13 @@ bind f display-popup -E -w 60% -h 40% \
 # fzf pane picker: prefix + ` — switch between zoomed panes in this window
 bind ` run-shell 'tmux display-popup -E -w 60% -h 40% "tmux-pane-picker \"#{session_name}\" \"#{window_index}\" \"#{pane_id}\" \"#{pane_current_path}\""'
 
+# --- Bell (coda watch) ---
+
+# Propagate bells from any window so 'coda watch' notifications reach the
+# client terminal regardless of which session the user is viewing.
+set -g bell-action any
+set -g visual-bell off
+
 # --- Plugins ---
 
 set -g @plugin 'tmux-plugins/tpm'


### PR DESCRIPTION
## Summary

- Adds `coda watch` command that monitors all OpenCode tmux sessions for processing→idle transitions
- Sends terminal bell (BEL) to every connected tmux client when an agent finishes and needs input — bell propagates through mosh to local terminal for OS-native notifications
- Includes watcher script (`coda-watcher.sh`), shell functions (`start/stop/status`), bash/zsh completions, man page docs, README updates, and tmux `bell-action any` config
- Configurable via `CODA_WATCH_INTERVAL` (poll frequency) and `CODA_WATCH_COOLDOWN` (notification debounce)