### PR TITLE
fix: remove session limit and auto-open session on project add

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,9 +32,6 @@ OPENCODE_BASE_PORT=4096
 # Max port range (base + range = highest port)
 OPENCODE_PORT_RANGE=10
 
-# Max concurrent OpenCode sessions
-MAX_CONCURRENT_SESSIONS=5
-
 # Default permission mode for headless sessions
 # Options: '{"*":"allow"}' (autonomous) or '{}' (ask for everything)
 OPENCODE_HEADLESS_PERMISSION='{"*":"allow"}'

--- a/README.md
+++ b/README.md
@@ -204,8 +204,6 @@ coda myapp ~/projects/myapp   # session in a specific directory
 
 - Strips the `coda-` prefix automatically if you type it (both work)
 - If already inside tmux, switches to the session instead of nesting
-- Enforces `MAX_CONCURRENT_SESSIONS` (default: 5)
-
 ---
 
 ### `coda ls`
@@ -448,7 +446,6 @@ All behaviour is controlled by `.env` in the repo directory. Created from
 | `EDITOR` / `VISUAL` | `vim` | Editor for OpenCode `/editor` flows |
 | `OPENCODE_BASE_PORT` | `4096` | First port tried by `coda serve` |
 | `OPENCODE_PORT_RANGE` | `10` | Number of ports to scan |
-| `MAX_CONCURRENT_SESSIONS` | `5` | Cap on parallel sessions |
 | `OPENCODE_HEADLESS_PERMISSION` | `{"*":"allow"}` | Permission policy for `coda serve` |
 | `NODE_MAJOR_VERSION` | `20` | Node.js major version for install |
 | `CODA_WATCH_INTERVAL` | `5` | Watcher poll interval (seconds) |

--- a/man/coda.1
+++ b/man/coda.1
@@ -109,9 +109,6 @@ Passing a name that already includes the prefix is safe — it is stripped
 automatically.
 If already inside tmux, switches to the session rather than creating a nested
 attach.
-Enforces
-.B MAX_CONCURRENT_SESSIONS
-(default: 5).
 .
 .TP
 .B coda ls
@@ -401,7 +398,6 @@ OPENCODE_PORT_RANGE	10	Ports to scan
 DEFAULT_LAYOUT	default	Default tmux layout
 CODA_LAYOUTS_DIR	~/.config/coda/layouts	User layout directory
 CODA_PROFILES_DIR	~/.config/coda/profiles	User profile directory
-MAX_CONCURRENT_SESSIONS	5	Max parallel sessions
 CODA_WATCH_INTERVAL	5	Watcher poll interval (seconds)
 CODA_WATCH_COOLDOWN	60	Min seconds between repeat notifications
 OPENCODE_HEADLESS_PERMISSION	{"*":"allow"}	Permission policy for serve

--- a/shell-functions.sh
+++ b/shell-functions.sh
@@ -18,7 +18,6 @@ DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
 GIT_REMOTE="${GIT_REMOTE:-origin}"
 OPENCODE_BASE_PORT="${OPENCODE_BASE_PORT:-4096}"
 OPENCODE_PORT_RANGE="${OPENCODE_PORT_RANGE:-10}"
-MAX_CONCURRENT_SESSIONS="${MAX_CONCURRENT_SESSIONS:-5}"
 AUTO_ATTACH_TMUX="${AUTO_ATTACH_TMUX:-true}"
 DEFAULT_TMUX_SESSION="${DEFAULT_TMUX_SESSION:-default}"
 DEFAULT_LAYOUT="${DEFAULT_LAYOUT:-default}"
@@ -116,15 +115,6 @@ _coda_attach() {
     fi
 
     if ! tmux has-session -t "$session" 2>/dev/null; then
-        local count
-        count=$(tmux list-sessions -F '#{session_name}' 2>/dev/null \
-            | grep -c "^${SESSION_PREFIX}" || true)
-
-        if [ "$count" -ge "$MAX_CONCURRENT_SESSIONS" ]; then
-            echo "At session limit ($MAX_CONCURRENT_SESSIONS). Use 'coda ls' to see running sessions."
-            return 1
-        fi
-
         _coda_load_layout "$layout" || return 1
 
         if declare -f _layout_init &>/dev/null; then
@@ -286,7 +276,16 @@ _coda_project_add() {
         git -C "$project_dir" fetch --all --quiet
         echo "Worktrees:"
         git -C "$project_dir" worktree list 2>/dev/null | sed 's/^/  /'
-        return 0
+
+        if [ ! -d "$project_dir/$DEFAULT_BRANCH" ]; then
+            git -C "$project_dir" worktree add \
+                "$project_dir/$DEFAULT_BRANCH" "$DEFAULT_BRANCH"
+        fi
+
+        echo ""
+        echo "Opening session in $project_dir/$DEFAULT_BRANCH"
+        _coda_attach "$name" "$project_dir/$DEFAULT_BRANCH"
+        return $?
     fi
 
     if [ -d "$project_dir" ]; then
@@ -312,7 +311,8 @@ _coda_project_add() {
 
     echo ""
     echo "Project ready: $project_dir"
-    echo "  cd $project_dir/$DEFAULT_BRANCH"
+    echo "Opening session in $project_dir/$DEFAULT_BRANCH"
+    _coda_attach "$name" "$project_dir/$DEFAULT_BRANCH"
 }
 
 # coda project workon <name> [branch]


### PR DESCRIPTION
## Summary

- **Remove `MAX_CONCURRENT_SESSIONS` limit**: The hardcoded cap of 5 parallel sessions has been removed entirely — variable declaration, enforcement check, config entry, and all documentation references across `shell-functions.sh`, `.env.example`, `README.md`, and `man/coda.1`.

- **Auto-open session on `coda project add`**: When adding a project that already exists, or after cloning a new one, `coda project add` now automatically opens an OpenCode session in the `main` worktree (equivalent to running `coda <project>` afterward). If the `main` worktree doesn't exist yet, it's created first.