### PR TITLE
feat: add four-pane tmux layout with labeled pane borders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,7 +55,7 @@ CODA_WATCH_COOLDOWN=60
 # --- Layout & Profiles ---
 
 # Default tmux layout when creating sessions (see: coda layout ls)
-# Options: default, wide-twopane, classic, three-pane
+# Options: default, wide-twopane, classic, three-pane, four-pane
 DEFAULT_LAYOUT="default"
 
 # Default Neovim config name (maps to ~/.config/<name>/)

--- a/README.md
+++ b/README.md
@@ -59,10 +59,12 @@ configures everything in one pass:
 | 4 | OpenCode via `npm install -g opencode@latest` |
 | 5 | Claude Code CLI via `npm install -g @anthropic-ai/claude-code` |
 | 6 | fzf (fuzzy finder, binary install) |
-| 7 | Oh My Posh prompt theme engine (user install to `~/.local/bin`) |
-| 8 | tmux Plugin Manager (TPM) |
-| 9 | Tailscale |
-| 10 | Config files, tab completions, man page, Oh My Posh shell init, SSH keepalive, tmux plugins |
+| 7 | yazi (terminal file manager, used by four-pane layout) |
+| 8 | lazygit (terminal git UI, used by four-pane layout) |
+| 9 | Oh My Posh prompt theme engine (user install to `~/.local/bin`) |
+| 10 | tmux Plugin Manager (TPM) |
+| 11 | Tailscale |
+| 12 | Config files, tab completions, man page, Oh My Posh shell init, SSH keepalive, tmux plugins |
 
 To skip optional components:
 
@@ -71,6 +73,8 @@ SKIP_TAILSCALE=true ./install.sh
 SKIP_OPENCODE=true  ./install.sh
 SKIP_CLAUDE=true    ./install.sh
 SKIP_OHMYPOSH=true  ./install.sh
+SKIP_YAZI=true      ./install.sh
+SKIP_LAZYGIT=true   ./install.sh
 ```
 
 ### After install

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,8 @@
 #   SKIP_OPENCODE=true       Skip OpenCode installation
 #   SKIP_CLAUDE=true         Skip Claude Code CLI installation
 #   SKIP_OHMYPOSH=true       Skip Oh My Posh installation
+#   SKIP_YAZI=true           Skip yazi file manager installation
+#   SKIP_LAZYGIT=true        Skip lazygit installation
 #   NODE_MAJOR_VERSION=20    Node.js major version (default: 20)
 #   NVIM_MIN_VERSION=0.11.0  Minimum acceptable Neovim version
 #   PROJECTS_DIR=~/projects  Where git repos live
@@ -56,6 +58,8 @@ SKIP_TAILSCALE="${SKIP_TAILSCALE:-false}"
 SKIP_OPENCODE="${SKIP_OPENCODE:-false}"
 SKIP_CLAUDE="${SKIP_CLAUDE:-false}"
 SKIP_OHMYPOSH="${SKIP_OHMYPOSH:-false}"
+SKIP_YAZI="${SKIP_YAZI:-false}"
+SKIP_LAZYGIT="${SKIP_LAZYGIT:-false}"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -95,13 +99,15 @@ echo "  Tailscale       : $([ "$SKIP_TAILSCALE" = "true" ] && echo "skip" || ech
 echo "  OpenCode        : $([ "$SKIP_OPENCODE"  = "true" ] && echo "skip" || echo "install")"
 echo "  Claude CLI      : $([ "$SKIP_CLAUDE"    = "true" ] && echo "skip" || echo "install")"
 echo "  Oh My Posh      : $([ "$SKIP_OHMYPOSH" = "true" ] && echo "skip" || echo "install")"
+echo "  yazi            : $([ "$SKIP_YAZI"     = "true" ] && echo "skip" || echo "install")"
+echo "  lazygit         : $([ "$SKIP_LAZYGIT"  = "true" ] && echo "skip" || echo "install")"
 echo ""
 
 # ===========================================================================
 # 1. System packages
 # ===========================================================================
 
-step "[1/10] System packages"
+step "[1/12] System packages"
 
 sudo apt-get update -qq
 sudo apt-get upgrade -y -qq
@@ -125,7 +131,7 @@ ok "Core packages installed"
 # 2. Neovim
 # ===========================================================================
 
-step "[2/10] Neovim (>= ${NVIM_MIN_VERSION})"
+step "[2/12] Neovim (>= ${NVIM_MIN_VERSION})"
 
 NVIM_INSTALLED_VERSION=""
 if command -v nvim &>/dev/null; then
@@ -160,7 +166,7 @@ fi
 # 3. Node.js
 # ===========================================================================
 
-step "[3/10] Node.js ${NODE_MAJOR_VERSION}"
+step "[3/12] Node.js ${NODE_MAJOR_VERSION}"
 
 INSTALLED_NODE_MAJOR=0
 if command -v node &>/dev/null; then
@@ -185,7 +191,7 @@ fi
 # 4. OpenCode
 # ===========================================================================
 
-step "[4/10] OpenCode"
+step "[4/12] OpenCode"
 
 mkdir -p ~/.npm-global
 npm config set prefix '~/.npm-global'
@@ -206,7 +212,7 @@ fi
 # 5. Claude Code CLI
 # ===========================================================================
 
-step "[5/10] Claude Code CLI"
+step "[5/12] Claude Code CLI"
 
 if [ "$SKIP_CLAUDE" = "true" ]; then
     info "Skipping (SKIP_CLAUDE=true)"
@@ -222,7 +228,7 @@ fi
 # 6. fzf
 # ===========================================================================
 
-step "[6/10] fzf"
+step "[6/12] fzf"
 
 if command -v fzf &>/dev/null; then
     ok "fzf $(fzf --version 2>/dev/null | head -1) — already installed"
@@ -241,10 +247,71 @@ else
 fi
 
 # ===========================================================================
-# 7. Oh My Posh
+# 7. yazi (terminal file manager — used by four-pane layout)
 # ===========================================================================
 
-step "[7/10] Oh My Posh"
+step "[7/12] yazi"
+
+if [ "$SKIP_YAZI" = "true" ]; then
+    info "Skipping (SKIP_YAZI=true)"
+elif command -v yazi &>/dev/null; then
+    ok "yazi $(yazi --version 2>/dev/null | head -1) — already installed"
+else
+    info "Installing yazi..."
+    case "$(uname -m)" in
+        x86_64)  YAZI_ARCH="x86_64-unknown-linux-gnu" ;;
+        aarch64) YAZI_ARCH="aarch64-unknown-linux-gnu" ;;
+        *)       YAZI_ARCH="" ;;
+    esac
+    if [ -n "$YAZI_ARCH" ]; then
+        TMP_DIR="$(mktemp -d)"
+        curl -fsSL "https://github.com/sxyazi/yazi/releases/latest/download/yazi-${YAZI_ARCH}.zip" \
+            -o "$TMP_DIR/yazi.zip"
+        unzip -o "$TMP_DIR/yazi.zip" -d "$TMP_DIR" >/dev/null
+        sudo install "$TMP_DIR/yazi-${YAZI_ARCH}/yazi" /usr/local/bin/yazi
+        rm -rf "$TMP_DIR"
+        ok "yazi $(yazi --version 2>/dev/null | head -1) installed"
+    else
+        info "Unsupported architecture for yazi: $(uname -m)"
+    fi
+fi
+
+# ===========================================================================
+# 8. lazygit (terminal git UI — used by four-pane layout)
+# ===========================================================================
+
+step "[8/12] lazygit"
+
+if [ "$SKIP_LAZYGIT" = "true" ]; then
+    info "Skipping (SKIP_LAZYGIT=true)"
+elif command -v lazygit &>/dev/null; then
+    ok "lazygit $(lazygit --version 2>/dev/null | sed 's/.*version=//' | cut -d, -f1) — already installed"
+else
+    info "Installing lazygit..."
+    LAZYGIT_VERSION="$(curl -fsSL 'https://api.github.com/repos/jesseduffield/lazygit/releases/latest' | jq -r '.tag_name' | sed 's/v//')"
+    case "$(uname -m)" in
+        x86_64)  LAZYGIT_ARCH="x86_64" ;;
+        aarch64) LAZYGIT_ARCH="arm64"   ;;
+        *)       LAZYGIT_ARCH="" ;;
+    esac
+    if [ -n "$LAZYGIT_ARCH" ]; then
+        TMP_DIR="$(mktemp -d)"
+        curl -fsSL "https://github.com/jesseduffield/lazygit/releases/latest/download/lazygit_${LAZYGIT_VERSION}_Linux_${LAZYGIT_ARCH}.tar.gz" \
+            -o "$TMP_DIR/lazygit.tar.gz"
+        tar xf "$TMP_DIR/lazygit.tar.gz" -C "$TMP_DIR" lazygit
+        sudo install "$TMP_DIR/lazygit" /usr/local/bin/lazygit
+        rm -rf "$TMP_DIR"
+        ok "lazygit ${LAZYGIT_VERSION} installed"
+    else
+        info "Unsupported architecture for lazygit: $(uname -m)"
+    fi
+fi
+
+# ===========================================================================
+# 9. Oh My Posh
+# ===========================================================================
+
+step "[9/12] Oh My Posh"
 
 if [ "$SKIP_OHMYPOSH" = "true" ]; then
     info "Skipping (SKIP_OHMYPOSH=true)"
@@ -258,10 +325,10 @@ else
 fi
 
 # ===========================================================================
-# 8. tmux Plugin Manager (TPM)
+# 10. tmux Plugin Manager (TPM)
 # ===========================================================================
 
-step "[8/10] tmux Plugin Manager (TPM)"
+step "[10/12] tmux Plugin Manager (TPM)"
 
 TPM_DIR="$HOME/.tmux/plugins/tpm"
 
@@ -279,10 +346,10 @@ else
 fi
 
 # ===========================================================================
-# 9. Tailscale
+# 11. Tailscale
 # ===========================================================================
 
-step "[9/10] Tailscale"
+step "[11/12] Tailscale"
 
 if [ "$SKIP_TAILSCALE" = "true" ]; then
     info "Skipping (SKIP_TAILSCALE=true)"
@@ -295,10 +362,10 @@ else
 fi
 
 # ===========================================================================
-# 10. Config files, shell integration, SSH
+# 12. Config files, shell integration, SSH
 # ===========================================================================
 
-step "[10/10] Config files, completions, and man page"
+step "[12/12] Config files, completions, and man page"
 
 # --- tmux config ---
 

--- a/layouts/four-pane.sh
+++ b/layouts/four-pane.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# four-pane.sh — tmux layout: git status (left), file explorer (center),
+#                opencode (right), shell (bottom)
+#
+# Called by _coda_attach / coda layout apply with:
+#   $1 = session name
+#   $2 = working directory
+#   $3 = (unused in this layout)
+#
+# Layout:
+#   ┌──────────┬──────────────────┬──────────────────┐
+#   │   git    │  file explorer   │    opencode       │  80% height
+#   │  status  │    /preview      │                   │
+#   │  (20%)   │     (40%)        │     (40%)         │
+#   ├──────────┴──────────────────┴──────────────────┤
+#   │  $ shell                                        │  20% height
+#   └────────────────────────────────────────────────┘
+#
+# Sidebar tools (first available wins):
+#   File explorer:  yazi > nnn > lf > ranger > plain shell
+#   Git status:     lazygit > gitui > tig > watch git status
+#
+# Note: tmux 3.4 split-window -p (percentage) is broken — use -l (lines/cols).
+
+_four_pane_explorer_cmd() {
+    local cmd="ls -la"
+    command -v ranger &>/dev/null && cmd="ranger"
+    command -v lf     &>/dev/null && cmd="lf"
+    command -v nnn    &>/dev/null && cmd="nnn"
+    command -v yazi   &>/dev/null && cmd="yazi"
+    printf '%s' "$cmd"
+}
+
+_four_pane_git_cmd() {
+    local cmd="watch -n 5 git status"
+    command -v tig     &>/dev/null && cmd="tig status"
+    command -v gitui   &>/dev/null && cmd="gitui"
+    command -v lazygit &>/dev/null && cmd="lazygit"
+    printf '%s' "$cmd"
+}
+
+_layout_init() {
+    local session="$1" dir="$2"
+    local cols="${COLUMNS:-200}" rows="${LINES:-50}"
+
+    local explorer_cmd; explorer_cmd=$(_four_pane_explorer_cmd)
+    local git_cmd;      git_cmd=$(_four_pane_git_cmd)
+
+    tmux new-session -d -s "$session" -x "$cols" -y "$rows" -c "$dir" \
+        "$git_cmd; exec \$SHELL"
+    tmux set-environment -t "$session" EDITOR nvim
+    tmux select-pane -t "$session" -T "Git"
+
+    local avail=$(( rows - 1 ))
+    local bottom=$(( avail * 20 / 100 ))
+    local git_w=$(( cols * 20 / 100 ))
+    local right_area=$(( cols - git_w ))
+    local opencode_w=$(( right_area / 2 ))
+
+    tmux split-window -v -t "$session" -c "$dir" -l "$bottom"
+    tmux select-pane -t "$session" -T "Shell"
+    tmux select-pane -t "$session" -U
+    tmux split-window -h -t "$session" -c "$dir" -l "$right_area" \
+        "$explorer_cmd; exec \$SHELL"
+    tmux select-pane -t "$session" -T "Explorer"
+    tmux split-window -h -t "$session" -c "$dir" -l "$opencode_w" \
+        "opencode; exec \$SHELL"
+    tmux select-pane -t "$session" -T "OpenCode"
+
+    tmux set-option -t "$session" pane-border-status top
+    tmux set-option -t "$session" pane-border-lines heavy
+    tmux set-option -t "$session" pane-border-style 'fg=colour245'
+    tmux set-option -t "$session" pane-active-border-style 'fg=green,bold'
+    tmux set-option -t "$session" pane-border-format \
+        ' #{?pane_active,▸ ,  }#{pane_title} '
+}
+
+_layout_spawn() {
+    local session="$1" dir="$2"
+
+    local script
+    script=$(mktemp "${TMPDIR:-/tmp}/coda-layout.XXXXXX")
+    cat > "$script" <<SETUP
+#!/usr/bin/env bash
+rm -f "\$0"
+tmux set-environment EDITOR nvim
+
+explorer_cmd="ls -la"
+command -v ranger &>/dev/null && explorer_cmd="ranger"
+command -v lf     &>/dev/null && explorer_cmd="lf"
+command -v nnn    &>/dev/null && explorer_cmd="nnn"
+command -v yazi   &>/dev/null && explorer_cmd="yazi"
+
+git_cmd="watch -n 5 git status"
+command -v tig     &>/dev/null && git_cmd="tig status"
+command -v gitui   &>/dev/null && git_cmd="gitui"
+command -v lazygit &>/dev/null && git_cmd="lazygit"
+
+ph=\$(tmux display-message -p '#{pane_height}')
+pw=\$(tmux display-message -p '#{pane_width}')
+bottom=\$(( ph * 20 / 100 ))
+git_w=\$(( pw * 20 / 100 ))
+right_area=\$(( pw - git_w ))
+opencode_w=\$(( right_area / 2 ))
+
+tmux split-window -v -c "$dir" -l "\$bottom"
+tmux select-pane -T "Shell"
+tmux select-pane -U
+tmux select-pane -T "Git"
+tmux split-window -h -c "$dir" -l "\$right_area" "\$explorer_cmd; exec \\\$SHELL"
+tmux select-pane -T "Explorer"
+tmux split-window -h -c "$dir" -l "\$opencode_w" "opencode; exec \\\$SHELL"
+tmux select-pane -T "OpenCode"
+
+tmux set-option pane-border-status top
+tmux set-option pane-border-lines heavy
+tmux set-option pane-border-style 'fg=colour245'
+tmux set-option pane-active-border-style 'fg=green,bold'
+tmux set-option pane-border-format ' #{?pane_active,▸ ,  }#{pane_title} '
+
+\$git_cmd; exec "\$SHELL"
+SETUP
+    chmod +x "$script"
+    tmux new-window -t "$session" -c "$dir" "$script"
+}
+
+_layout_apply() { _layout_init "$@"; }


### PR DESCRIPTION
## Summary

- Adds a new `four-pane` tmux layout: git status (left 20%), file explorer (center 40%), opencode (right 40%), shell (bottom 20%)
- Each pane gets a labeled title bar (`Git`, `Explorer`, `OpenCode`, `Shell`) with heavy borders and green active-pane highlighting for clear visual distinction
- Installs yazi (file manager) and lazygit (git TUI) as dependencies, with `SKIP_YAZI` / `SKIP_LAZYGIT` flags