### PR TITLE
feat: add coda feature finish for agent-safe session teardown

### DIFF
--- a/completions/coda.bash
+++ b/completions/coda.bash
@@ -102,7 +102,7 @@ _coda_complete() {
                     COMPREPLY=($(compgen -W "add workon ls" -- "$cur"))
                     ;;
                 feature)
-                    COMPREPLY=($(compgen -W "start done ls" -- "$cur"))
+                    COMPREPLY=($(compgen -W "start done finish ls" -- "$cur"))
                     ;;
                 layout)
                     local layouts
@@ -163,10 +163,12 @@ _coda_complete() {
                             COMPREPLY=($(compgen -W "$branches" -- "$cur"))
                             ;;
                         done)
-                            # Suggest branches that have a worktree
                             local branches
                             branches=$(_coda_worktree_branches)
                             COMPREPLY=($(compgen -W "$branches" -- "$cur"))
+                            ;;
+                        finish)
+                            COMPREPLY=($(compgen -W "--force" -- "$cur"))
                             ;;
                     esac
                     ;;

--- a/completions/coda.zsh
+++ b/completions/coda.zsh
@@ -169,6 +169,7 @@ _coda_feature_args() {
             subcmds=(
                 'start:create a worktree and session for a branch'
                 'done:teardown a worktree and its session'
+                'finish:teardown current feature (agent-safe, backgrounded)'
                 'ls:list worktrees for the current project'
             )
             _describe 'feature subcommand' subcmds
@@ -182,6 +183,10 @@ _coda_feature_args() {
                 done)
                     local branches=($(_coda_worktree_branches))
                     _describe 'worktree branch' branches
+                    ;;
+                finish)
+                    local -a flags=('--force:discard uncommitted changes and tear down')
+                    _describe 'flag' flags
                     ;;
             esac
             ;;

--- a/man/coda.1
+++ b/man/coda.1
@@ -237,6 +237,21 @@ the branch is deleted regardless of merge status.
 Merge or push your changes before running this command.
 .
 .TP
+.B coda feature finish \fR[\fB\-\-force\fR]
+Agent-safe teardown of the current feature branch.
+Detects the branch and project from the working directory (takes no arguments).
+The teardown (kill session, remove worktree, delete branch) runs in a
+backgrounded subshell so it completes even when called from within the session
+being destroyed.
+.sp
+Refuses to proceed if there are uncommitted or untracked changes.
+Use
+.B \-\-force
+to skip this check and tear down regardless.
+.sp
+Must be run from inside a feature worktree (not the default branch).
+.
+.TP
 .B coda feature ls
 Run
 .B git worktree list

--- a/shell-functions.sh
+++ b/shell-functions.sh
@@ -401,11 +401,12 @@ _coda_project_ls() {
 _coda_feature() {
     local subcmd="${1:-}"
     case "$subcmd" in
-        start) shift; _coda_feature_start "$@" ;;
-        done)  shift; _coda_feature_done "$@" ;;
-        ls)    _coda_feature_ls ;;
-        ""|help) echo "Usage: coda feature <start|done|ls>" ;;
-        *)    echo "Unknown feature subcommand: $subcmd"; echo "Usage: coda feature <start|done|ls>"; return 1 ;;
+        start)  shift; _coda_feature_start "$@" ;;
+        done)   shift; _coda_feature_done "$@" ;;
+        finish) shift; _coda_feature_finish "$@" ;;
+        ls)     _coda_feature_ls ;;
+        ""|help) echo "Usage: coda feature <start|done|finish|ls>" ;;
+        *)    echo "Unknown feature subcommand: $subcmd"; echo "Usage: coda feature <start|done|finish|ls>"; return 1 ;;
     esac
 }
 
@@ -493,6 +494,82 @@ _coda_feature_done() {
     fi
 
     echo "Done."
+}
+
+# coda feature finish [--force]
+_coda_feature_finish() {
+    local force=false
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --force|-f) force=true; shift ;;
+            *) echo "Usage: coda feature finish [--force]"; return 1 ;;
+        esac
+    done
+
+    local project_root
+    project_root=$(_coda_find_project_root)
+    if [ -z "$project_root" ]; then
+        echo "Not inside a coda project directory."
+        return 1
+    fi
+
+    local project_name
+    project_name=$(basename "$project_root")
+
+    local branch
+    branch=$(git -C "$PWD" rev-parse --abbrev-ref HEAD 2>/dev/null)
+    if [ -z "$branch" ]; then
+        echo "Could not detect current branch."
+        return 1
+    fi
+
+    local default_branch
+    default_branch=$(_coda_detect_default_branch "$project_root")
+    if [ "$branch" = "$default_branch" ]; then
+        echo "You are on $default_branch. Switch to a feature branch first."
+        return 1
+    fi
+
+    if [ "$force" = false ]; then
+        if ! git -C "$PWD" diff --quiet 2>/dev/null || ! git -C "$PWD" diff --cached --quiet 2>/dev/null; then
+            echo "Uncommitted changes detected. Commit or stash before finishing."
+            echo "  git status:"
+            git -C "$PWD" status --short
+            echo ""
+            echo "To discard changes and tear down anyway: coda feature finish --force"
+            return 1
+        fi
+
+        if [ -n "$(git -C "$PWD" ls-files --others --exclude-standard 2>/dev/null)" ]; then
+            echo "Untracked files detected. Commit or remove them before finishing."
+            echo "  Untracked:"
+            git -C "$PWD" ls-files --others --exclude-standard | sed 's/^/    /'
+            echo ""
+            echo "To discard and tear down anyway: coda feature finish --force"
+            return 1
+        fi
+    fi
+
+    local session="${SESSION_PREFIX}$(_coda_sanitize_session_name "$project_name")--${branch}"
+    local worktree_dir="$project_root/$branch"
+
+    echo "Finishing feature: $branch"
+
+    (
+        sleep 1
+        if tmux has-session -t "$session" 2>/dev/null; then
+            tmux kill-session -t "$session"
+        fi
+        if [ -d "$worktree_dir" ]; then
+            git -C "$project_root" worktree remove "$worktree_dir" --force 2>/dev/null
+        fi
+        if git -C "$project_root" show-ref --verify --quiet "refs/heads/$branch" 2>/dev/null; then
+            git -C "$project_root" branch -D "$branch" 2>/dev/null
+        fi
+    ) &
+    disown
+
+    echo "  Teardown backgrounded (session, worktree, branch)."
 }
 
 # coda feature ls
@@ -850,6 +927,7 @@ USAGE
 
   coda feature start <branch> [base] [project]   New worktree + session
   coda feature done  <branch> [project]          Teardown worktree + session
+  coda feature finish [--force]                  Teardown current feature (agent-safe)
   coda feature ls                                List worktrees for this project
 
   coda layout <name>                Apply a layout to the current session


### PR DESCRIPTION
## Summary

Implements the missing `coda feature finish` command that `AGENTS.md` references but was never built.

- **Auto-detects** branch and project from `$PWD` — takes no arguments
- **Dirty working tree check** — refuses to proceed if uncommitted changes, staged changes, or untracked files exist. Shows the offending files and tells the user to commit first
- **`--force` / `-f`** — bypasses the dirty check and tears down regardless
- **Default branch guard** — refuses if you're on main/master (must be on a feature branch)
- **Backgrounded teardown** — kill session → remove worktree → delete branch runs in `( sleep 1; ... ) & disown` so it completes even when the agent calls it from within its own session

## Context

`AGENTS.md` instructs OpenCode agents to run `coda feature finish` as the final step when wrapping up a feature ("ship it", "we're done here", etc.). Unlike `coda feature done <branch>` which runs synchronously from a different session, `finish` is designed to be called from *within* the session being destroyed.

## Changes

- `shell-functions.sh` — new `_coda_feature_finish` function + wired into `_coda_feature` dispatch
- `completions/coda.bash` — `finish` subcommand + `--force` flag completion
- `completions/coda.zsh` — `finish` subcommand + `--force` flag completion
- `man/coda.1` — documented `coda feature finish`
- Help text updated

## Usage

```bash
# From inside a feature worktree:
coda feature finish           # refuses if dirty
coda feature finish --force   # tears down regardless
```