### PR TITLE
fix: remove new-tab logic from Stream Deck connect script

### DIFF
--- a/scripts/streamdeck-vm104-connect.sh
+++ b/scripts/streamdeck-vm104-connect.sh
@@ -13,7 +13,7 @@
 #   4. Point it to this script
 #
 # What happens when you press the button:
-#   - Ghostty opens (or gets a new tab if already running)
+#   - Ghostty opens a new window
 #   - SSH connects to vm-104
 #   - tmux auto-attaches (AUTO_ATTACH_TMUX=true on the VM)
 #   - You're in. Run `coda switch` to pick a session.
@@ -32,30 +32,14 @@ on run argv
     set sshHost to item 2 of argv
     set sshCmd to "ssh -t " & sshUser & "@" & sshHost
 
-    -- Check if Ghostty is already running
-    tell application "System Events"
-        set isRunning to (name of processes) contains "Ghostty"
-    end tell
-
-    -- Activate Ghostty (launches it if not running)
     tell application "Ghostty" to activate
+    delay 1.0
 
     tell application "System Events"
         tell process "Ghostty"
-            -- Wait for the window to be ready
-            if isRunning and (count of windows) > 0 then
-                -- Already open with a window: open new tab
-                keystroke "t" using command down
-                delay 0.5
-            else
-                -- Just launched: wait for initial window
-                delay 1.0
-            end if
-
-            -- Type the SSH command and press Enter
             keystroke sshCmd
             delay 0.1
-            key code 36 -- Return
+            key code 36
         end tell
     end tell
 end run


### PR DESCRIPTION
## Summary

- Removes the Ghostty running-check and new-tab (Cmd+T) branch from the connect script — the timing was unreliable when Ghostty was already open.
- Script now simply launches Ghostty, waits for the window, and fires the SSH command.