### PR TITLE
Add coda project close command

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,29 @@ coda project ls
 
 ---
 
+### `coda project close [--delete]`
+
+Close the tmux sessions for the current project. Must be run from inside a coda
+project directory.
+
+```bash
+cd ~/projects/myapp/main
+
+coda project close
+# closes coda-myapp and any coda-myapp--* sessions
+# keeps ~/projects/myapp/ on disk
+
+coda project close --delete
+# closes the same sessions
+# also removes ~/projects/myapp/
+```
+
+By default, `close` only shuts down the project's tmux sessions. Pass
+`--delete` to also remove the project folder and all worktrees under it.
+Teardown is backgrounded, so the sessions or folders may take a moment to disappear.
+
+---
+
 ### `coda feature start <branch> [base] [project]`
 
 Create a git worktree on a new branch and open an OpenCode session inside it.
@@ -414,7 +437,8 @@ coda <TAB>                     → ls switch serve auth project feature help
 coda feature <TAB>             → start done ls
 coda feature start <TAB>       → [local git branches]
 coda feature done <TAB>        → [branches with active worktrees]
-coda project <TAB>             → start workon ls
+coda project <TAB>             → start workon close ls
+coda project close <TAB>       → --delete
 coda project start <TAB>       → --repo --new --message
 coda switch                    → (no completion needed — interactive fzf)
 ```

--- a/completions/coda.bash
+++ b/completions/coda.bash
@@ -114,7 +114,7 @@ _coda_complete() {
         2)
             case "${words[1]}" in
                 project)
-                    COMPREPLY=($(compgen -W "start workon ls" -- "$cur"))
+                    COMPREPLY=($(compgen -W "start workon close ls" -- "$cur"))
                     ;;
                 feature)
                     COMPREPLY=($(compgen -W "start done finish ls" -- "$cur"))
@@ -187,6 +187,9 @@ _coda_complete() {
                     ;;
                 project)
                     case "${words[2]}" in
+                        close)
+                            COMPREPLY=($(compgen -W "--delete" -- "$cur"))
+                            ;;
                         workon)
                             local projects
                             projects=$(_coda_projects)

--- a/completions/coda.zsh
+++ b/completions/coda.zsh
@@ -129,6 +129,7 @@ _coda_project_args() {
             subcmds=(
                 'start:start a project (reconnect, clone, or create new)'
                 'workon:open a project session (create worktree if needed)'
+                'close:close project sessions, optionally delete folders'
                 'ls:list all projects'
             )
             _describe 'project subcommand' subcmds
@@ -141,6 +142,10 @@ _coda_project_args() {
                         '--new[Create a new repository]:name:' \
                         '(-m --message)--message[Description for AGENTS.md]:message:' \
                         '(-m --message)-m[Description for AGENTS.md]:message:'
+                    ;;
+                close)
+                    _arguments \
+                        '--delete[Also remove the project folder after closing sessions]'
                     ;;
                 workon)
                     _coda_project_workon_args

--- a/man/coda.1
+++ b/man/coda.1
@@ -1,4 +1,4 @@
-.TH CODA 1 "2026-04-05" "coda" "User Commands"
+.TH CODA 1 "2026-04-09" "coda" "User Commands"
 .
 .SH NAME
 coda \- OpenCode session and project manager
@@ -38,6 +38,11 @@ coda \- OpenCode session and project manager
 .I repo-name
 .RB [ \-\-message | \-m
 .IR description ]
+.br
+.B coda
+.B project
+.B close
+.RB [ \-\-delete ]
 .br
 .B coda
 .B project
@@ -232,6 +237,22 @@ file in the repository root, intended as initial context for AI coding agents.
 Requires the GitHub CLI
 .RB ( gh )
 to be installed and authenticated.
+.
+.TP
+.B coda project close \fR[\fB\-\-delete\fR]
+Close all active tmux sessions associated with the current project.
+Must be run from inside a coda project directory (any worktree or the project
+root).
+.sp
+By default, only tmux sessions are closed.
+Use
+.B \-\-delete
+to also remove the entire project directory under
+.BR PROJECTS_DIR ,
+including the bare repository and all worktrees.
+.sp
+Teardown runs in a backgrounded subshell, so sessions or folders may take a
+moment to disappear after the command returns.
 .
 .TP
 .B coda project ls

--- a/shell-functions.sh
+++ b/shell-functions.sh
@@ -556,6 +556,23 @@ _coda_project_close() {
     fi
     project_root="$physical_project_root"
 
+    local physical_projects_dir=""
+    if [ "$delete" = true ]; then
+        physical_projects_dir=$(cd "$PROJECTS_DIR" 2>/dev/null && pwd -P)
+        if [ -z "$physical_projects_dir" ]; then
+            echo "Could not resolve PROJECTS_DIR: $PROJECTS_DIR"
+            return 1
+        fi
+
+        case "$project_root" in
+            "$physical_projects_dir"|"$physical_projects_dir"/*) ;;
+            *)
+                echo "Refusing to delete project outside PROJECTS_DIR: $project_root"
+                return 1
+                ;;
+        esac
+    fi
+
     local project_name
     project_name=$(basename "$project_root")
 
@@ -597,7 +614,8 @@ _coda_project_close() {
             fi
         fi
     ) &
-    disown
+    disown 2>/dev/null || true
+    return 0
 }
 
 # ===========================================================================

--- a/shell-functions.sh
+++ b/shell-functions.sh
@@ -64,6 +64,7 @@ CODA_LAYOUTS_DIR="${CODA_LAYOUTS_DIR:-$HOME/.config/coda/layouts}"
 coda() {
     local _coda_profile="" _coda_layout=""
     local args=()
+    local status=0
 
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -81,27 +82,29 @@ coda() {
     local subcmd="${args[0]:-}"
 
     case "$subcmd" in
-        ls)               _coda_ls ;;
-        switch)           _coda_switch ;;
+        ls)               _coda_ls; status=$? ;;
+        switch)           _coda_switch; status=$? ;;
         attach)           if [ "${#args[@]}" -gt 1 ]; then
                               _coda_attach "${args[1]#"$SESSION_PREFIX"}" "${args[@]:2}"
-                          else
+                           else
                               _coda_attach
-                          fi
+                           fi
+                          status=$?
                           ;;
-        auth)             _coda_auth ;;
-        serve)            _coda_serve "${args[@]:1}" ;;
-        project)          _coda_project "${args[@]:1}" ;;
-        feature)          _coda_feature "${args[@]:1}" ;;
-        layout)           _coda_layout_cmd "${args[@]:1}" ;;
-        profile)          _coda_profile_cmd "${args[@]:1}" ;;
-        watch)            _coda_watch "${args[@]:1}" ;;
-        help|--help|-h)   _coda_help ;;
-        "")               _coda_attach ;;
-        *)                _coda_attach "${args[0]#"$SESSION_PREFIX"}" "${args[@]:1}" ;;
+        auth)             _coda_auth; status=$? ;;
+        serve)            _coda_serve "${args[@]:1}"; status=$? ;;
+        project)          _coda_project "${args[@]:1}"; status=$? ;;
+        feature)          _coda_feature "${args[@]:1}"; status=$? ;;
+        layout)           _coda_layout_cmd "${args[@]:1}"; status=$? ;;
+        profile)          _coda_profile_cmd "${args[@]:1}"; status=$? ;;
+        watch)            _coda_watch "${args[@]:1}"; status=$? ;;
+        help|--help|-h)   _coda_help; status=$? ;;
+        "")               _coda_attach; status=$? ;;
+        *)                _coda_attach "${args[0]#"$SESSION_PREFIX"}" "${args[@]:1}"; status=$? ;;
     esac
 
     unset CODA_PROFILE CODA_LAYOUT
+    return "$status"
 }
 
 # ===========================================================================
@@ -269,9 +272,10 @@ _coda_project() {
         start)  shift; _coda_project_start "$@" ;;
         add)    shift; _coda_project_add "$@" ;;
         workon) shift; _coda_project_workon "$@" ;;
+        close)  shift; _coda_project_close "$@" ;;
         ls)     _coda_project_ls ;;
-        ""|help) echo "Usage: coda project <start|workon|ls>" ;;
-        *)    echo "Unknown project subcommand: $subcmd"; echo "Usage: coda project <start|workon|ls>"; return 1 ;;
+        ""|help) echo "Usage: coda project <start|workon|close|ls>" ;;
+        *)    echo "Unknown project subcommand: $subcmd"; echo "Usage: coda project <start|workon|close|ls>"; return 1 ;;
     esac
 }
 
@@ -523,6 +527,77 @@ _coda_project_ls() {
         echo "No projects found in $PROJECTS_DIR"
         echo "Add one with: coda project start --repo <repo-url>"
     fi
+}
+
+_coda_project_close() {
+    local delete=false
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --delete) delete=true; shift ;;
+            *) echo "Usage: coda project close [--delete]"; return 1 ;;
+        esac
+    done
+
+    local project_root
+    project_root=$(_coda_find_project_root)
+    if [ -z "$project_root" ]; then
+        echo "Not inside a coda project directory."
+        return 1
+    fi
+
+    local requested_project_root="$project_root"
+
+    local physical_project_root
+    physical_project_root=$(cd "$project_root" 2>/dev/null && pwd -P)
+    if [ -z "$physical_project_root" ]; then
+        echo "Could not resolve project path: $project_root"
+        return 1
+    fi
+    project_root="$physical_project_root"
+
+    local project_name
+    project_name=$(basename "$project_root")
+
+    local sanitized
+    sanitized=$(_coda_sanitize_session_name "$project_name")
+
+    local -a sessions=()
+    local session_name
+    while IFS= read -r session_name; do
+        case "$session_name" in
+            "${SESSION_PREFIX}${sanitized}"|"${SESSION_PREFIX}${sanitized}"--*)
+                sessions+=("$session_name")
+                ;;
+        esac
+    done < <(tmux list-sessions -F '#{session_name}' 2>/dev/null || true)
+
+    if [ "$delete" = true ]; then
+        echo "Closing project: $project_name"
+        echo "  Teardown backgrounded (sessions + project folder)."
+    else
+        echo "Closing project: $project_name"
+        echo "  Teardown backgrounded (sessions only)."
+    fi
+
+    (
+        sleep 1
+
+        local session
+        for session in "${sessions[@]}"; do
+            if tmux has-session -t "$session" 2>/dev/null; then
+                tmux kill-session -t "$session"
+            fi
+        done
+
+        if [ "$delete" = true ] && [ -d "$project_root" ]; then
+            rm -rf "$project_root"
+            if [ "$requested_project_root" != "$project_root" ] && [ -L "$requested_project_root" ]; then
+                rm -f "$requested_project_root"
+            fi
+        fi
+    ) &
+    disown
 }
 
 # ===========================================================================
@@ -1055,6 +1130,7 @@ USAGE
   coda project start --repo <url> [name]          Clone a repo as a bare project
   coda project start --new <name> [-m "..."]      Create a new repo on GitHub
   coda project workon <name> [branch]             Open a project session
+  coda project close [--delete]                   Close project sessions, optionally delete folders
   coda project ls                                 List projects in PROJECTS_DIR
 
   coda feature start <branch> [base] [project]   New worktree + session
@@ -1163,11 +1239,7 @@ _coda_list_profiles() {
 _coda_find_project_root() {
     local dir="$PWD"
     while [ "$dir" != "/" ]; do
-        if [ -f "$dir/.git" ] && grep -q "gitdir: ./.bare" "$dir/.git" 2>/dev/null; then
-            echo "$dir"
-            return
-        fi
-        if [ -d "$dir/.bare" ]; then
+        if [ -d "$dir/.bare" ] && [ -f "$dir/.git" ] && grep -q "gitdir: ./.bare" "$dir/.git" 2>/dev/null; then
             echo "$dir"
             return
         fi


### PR DESCRIPTION
## Summary
- add `coda project close` so project sessions can be shut down without deleting the project folder by default
- support `coda project close --delete` for full project-folder cleanup with safer project-root handling and preserved exit codes
- update bash/zsh completions plus README and man page documentation for the new command

## Verification
- `bash -n shell-functions.sh`
- `bash -n completions/coda.bash`
- tmux-backed smoke test covering close-only behavior, `--delete`, symlinked project paths, and rejection of non-coda directories