### PR TITLE
fix: bootstrap new coda projects as bare repos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,9 +20,6 @@ DEFAULT_BRANCH="main"
 # Git remote name
 GIT_REMOTE="origin"
 
-# GitHub organization for 'coda project start --new'
-GIT_ORG="evanstern"
-
 # --- OpenCode ---
 
 # Use Vim for OpenCode's external editor flows (`/editor`, `/export`).

--- a/README.md
+++ b/README.md
@@ -282,16 +282,17 @@ coda project start --repo git@github.com:user/myapp.git
 coda project start --repo https://github.com/user/myapp.git custom-name
 ```
 
-**Create new** — create a new private repo on GitHub (`GIT_ORG`, default:
-`evanstern`), push an initial commit, and clone it locally:
+**Create new** — create a new private repo on GitHub under `evanstern`,
+bootstrap it from a local bare coda project, and push the initial commit:
 
 ```bash
 coda project start --new my-tool
 coda project start --new my-tool -m "CLI for managing widgets"
 ```
 
-When `--message` / `-m` is provided, the text is written to `AGENTS.md` in the
-repo root as initial context for AI coding agents. Requires `gh` CLI.
+When `--message` / `-m` is provided, that message is written verbatim to
+`AGENTS.md` in the repo root as initial context for AI coding agents. Requires
+`gh` CLI.
 
 All modes produce the same project layout:
 ```
@@ -605,7 +606,6 @@ All behaviour is controlled by `.env` in the repo directory. Created from
 | `SESSION_PREFIX` | `coda-` | tmux session name prefix |
 | `DEFAULT_BRANCH` | `main` | Default branch for new worktrees |
 | `GIT_REMOTE` | `origin` | Git remote name |
-| `GIT_ORG` | `evanstern` | GitHub org for `coda project start --new` |
 | `EDITOR` / `VISUAL` | `vim` | Editor for OpenCode `/editor` flows |
 | `OPENCODE_BASE_PORT` | `4096` | First port tried by `coda serve` |
 | `OPENCODE_PORT_RANGE` | `10` | Number of ports to scan |

--- a/man/coda.1
+++ b/man/coda.1
@@ -222,17 +222,15 @@ worktrees instead.
 .
 .TP
 .B coda project start \-\-new \fIrepo-name\fR [\fB\-\-message\fR|\fB\-m\fR \fIdescription\fR]
-Create a new private repository under the
-.B GIT_ORG
-GitHub organization (default:
-.IR evanstern ),
-push an initial commit, and clone it locally as a bare project.
+Create a new private repository under
+.IR evanstern ,
+bootstrap it from a local bare coda project, and push the initial commit.
 .sp
 If
 .B \-\-message
 is provided, the text is written to an
 .B AGENTS.md
-file in the repository root, intended as initial context for AI coding agents.
+file in the repository root verbatim, intended as initial context for AI coding agents.
 .sp
 Requires the GitHub CLI
 .RB ( gh )
@@ -469,7 +467,6 @@ PROJECTS_DIR	~/projects	Root dir for repos
 SESSION_PREFIX	coda-	tmux session name prefix
 DEFAULT_BRANCH	main	Branch for new worktrees
 GIT_REMOTE	origin	Git remote name
-GIT_ORG	evanstern	GitHub org for \fB\-\-new\fR repos
 OPENCODE_BASE_PORT	4096	First port for \fBcoda serve\fR
 OPENCODE_PORT_RANGE	10	Ports to scan
 DEFAULT_LAYOUT	default	Default tmux layout

--- a/shell-functions.sh
+++ b/shell-functions.sh
@@ -16,7 +16,7 @@ PROJECTS_DIR="${PROJECTS_DIR:-$HOME/projects}"
 SESSION_PREFIX="${SESSION_PREFIX:-coda-}"
 DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
 GIT_REMOTE="${GIT_REMOTE:-origin}"
-GIT_ORG="${GIT_ORG:-evanstern}"
+NEW_PROJECT_GITHUB_OWNER="evanstern"
 
 _coda_sanitize_session_name() {
     printf '%s' "$1" | tr '.' '-'
@@ -362,8 +362,9 @@ _coda_project_start_new() {
     local name="$1"
     local message="$2"
     local project_dir="$PROJECTS_DIR/$name"
-    local repo_url="git@github.com:${GIT_ORG}/${name}.git"
+    local repo_url="git@github.com:${NEW_PROJECT_GITHUB_OWNER}/${name}.git"
     local branch="$DEFAULT_BRANCH"
+    local worktree_dir="$project_dir/$branch"
 
     if [ -z "$name" ]; then
         echo "Usage: coda project start --new <repo-name> [--message \"...\"]"
@@ -381,30 +382,56 @@ _coda_project_start_new() {
         return 1
     fi
 
-    echo "Creating repository: ${GIT_ORG}/${name}"
-    if ! gh repo create "${GIT_ORG}/${name}" --private; then
+    echo "Creating repository: ${NEW_PROJECT_GITHUB_OWNER}/${name}"
+    if ! gh repo create "${NEW_PROJECT_GITHUB_OWNER}/${name}" --private; then
         echo "Failed to create repository on GitHub."
         return 1
     fi
 
-    # Bootstrap: temp repo → initial commit → push
-    local tmpdir
-    tmpdir=$(mktemp -d)
-    git init "$tmpdir" --quiet -b "$branch"
-
-    echo "# $name" > "$tmpdir/README.md"
-    if [ -n "$message" ]; then
-        printf '# %s\n\n%s\n' "$name" "$message" > "$tmpdir/AGENTS.md"
+    mkdir -p "$project_dir" "$worktree_dir"
+    if ! git init --bare --initial-branch="$branch" "$project_dir/.bare" --quiet; then
+        rm -rf "$project_dir"
+        echo "Failed to create local bare repository."
+        return 1
     fi
 
-    git -C "$tmpdir" add -A
-    git -C "$tmpdir" commit -m "Initial commit" --quiet
-    git -C "$tmpdir" remote add "$GIT_REMOTE" "$repo_url"
-    git -C "$tmpdir" push -u "$GIT_REMOTE" "$branch" --quiet
-    rm -rf "$tmpdir"
+    printf 'gitdir: ./.bare\n' > "$project_dir/.git"
+    git -C "$project_dir" config worktree.useRelativePaths true
+
+    if ! git --git-dir="$project_dir/.bare" --work-tree="$worktree_dir" \
+        checkout --orphan "$branch" >/dev/null 2>&1; then
+        rm -rf "$project_dir"
+        echo "Failed to create initial worktree."
+        return 1
+    fi
+
+    echo "# $name" > "$worktree_dir/README.md"
+    if [ -n "$message" ]; then
+        printf '%s\n' "$message" > "$worktree_dir/AGENTS.md"
+    fi
+
+    if ! git --git-dir="$project_dir/.bare" --work-tree="$worktree_dir" add -A ||
+        ! git --git-dir="$project_dir/.bare" --work-tree="$worktree_dir" commit -m "Initial commit" --quiet ||
+        ! git --git-dir="$project_dir/.bare" --work-tree="$worktree_dir" remote add "$GIT_REMOTE" "$repo_url" ||
+        ! git -C "$project_dir" config remote."$GIT_REMOTE".fetch \
+            "+refs/heads/*:refs/remotes/${GIT_REMOTE}/*" ||
+        ! git --git-dir="$project_dir/.bare" --work-tree="$worktree_dir" push -u "$GIT_REMOTE" "$branch" --quiet; then
+        rm -rf "$project_dir"
+        echo "Failed to bootstrap the new repository."
+        return 1
+    fi
+
+    rm -rf "$worktree_dir"
+    if ! git -C "$project_dir" worktree add "$worktree_dir" "$branch" >/dev/null 2>&1; then
+        rm -rf "$project_dir"
+        echo "Failed to register the initial worktree."
+        return 1
+    fi
 
     echo ""
-    _coda_project_add "$repo_url" "$name"
+    echo "Project ready: $project_dir"
+    echo "Opening session in $worktree_dir"
+    _coda_attach "$name" "$worktree_dir"
 }
 
 # coda project add <repo-url> [name]  (kept as internal helper; use 'coda project start --repo')


### PR DESCRIPTION
## Summary
- change `coda project start --new` to bootstrap the local project as a bare repo first, then register `main/` as a real linked worktree before attaching
- write `--message` content verbatim to `AGENTS.md` and always create the GitHub repo under `evanstern`
- update the README, man page, and config template to match the new-project bootstrap behavior

## Verification
- `bash -n shell-functions.sh`
- simulated `coda project start --new` against a fake bare GitHub remote with and without `--message`
- verified `git status` works inside `main/` and `git worktree list` shows the registered `main` worktree