### PR TITLE
fix: install the published OpenCode npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ configures everything in one pass:
 | 1 | System packages: git, tmux, mosh, curl, build-essential, jq, lsof, etc. |
 | 2 | Neovim (latest release from GitHub, upgrades if installed version is too old) |
 | 3 | Node.js via NodeSource (version-aware, won't skip on outdated installs) |
-| 4 | OpenCode via `npm install -g opencode@latest` |
+| 4 | OpenCode via `npm install -g opencode-ai@latest` |
 | 5 | Claude Code CLI via `npm install -g @anthropic-ai/claude-code` |
 | 6 | fzf (fuzzy finder, binary install) |
 | 7 | yazi (terminal file manager, used by four-pane layout) |

--- a/install.sh
+++ b/install.sh
@@ -204,7 +204,7 @@ elif command -v opencode &>/dev/null; then
     ok "opencode — already installed"
 else
     info "Installing OpenCode..."
-    npm install -g opencode@latest
+    npm install -g opencode-ai@latest
     ok "OpenCode installed"
 fi
 


### PR DESCRIPTION
## Summary
- point the bootstrap script at the published `opencode-ai` npm package so OpenCode installation succeeds
- update the README install step to match the corrected package name
- validated the package lookup with `npm view opencode-ai version`