### PR TITLE
feat: add CLIProxyAPI provider mode for coda auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,7 +47,7 @@ CLIPROXYAPI_BASE_URL="http://localhost:8317/v1"
 CLIPROXYAPI_API_KEY=""
 
 # Optional health endpoint for `coda provider status`
-CLIPROXYAPI_HEALTH_URL="http://localhost:8317/healthz"
+CLIPROXYAPI_HEALTH_URL=""
 
 # Optional override for the managed OpenCode config path
 CODA_OPENCODE_CONFIG_PATH=""

--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,22 @@ OPENCODE_PORT_RANGE=10
 # Options: '{"*":"allow"}' (autonomous) or '{}' (ask for everything)
 OPENCODE_HEADLESS_PERMISSION='{"*":"allow"}'
 
+# Provider mode for `coda auth`: claude-auth (default) or cliproxyapi
+CODA_PROVIDER_MODE="claude-auth"
+
+# CLIProxyAPI OpenAI-compatible base URL used for OpenCode provider config
+CLIPROXYAPI_BASE_URL="http://localhost:8317/v1"
+
+# Optional proxy API key used for model discovery/status probes and written into
+# the managed OpenCode provider block when set
+CLIPROXYAPI_API_KEY=""
+
+# Optional health endpoint for `coda provider status`
+CLIPROXYAPI_HEALTH_URL="http://localhost:8317/healthz"
+
+# Optional override for the managed OpenCode config path
+CODA_OPENCODE_CONFIG_PATH=""
+
 # --- Node.js ---
 
 # Node.js major version to install

--- a/CLIPROXYAPI-OPENCODE-CODA-DESIGN.md
+++ b/CLIPROXYAPI-OPENCODE-CODA-DESIGN.md
@@ -1,0 +1,375 @@
+# CLIProxyAPI × OpenCode × Coda Design
+
+## Goal
+
+Adapt the basic OpenCode custom-provider pattern from the CLIProxyAPI gist into a Coda-native workflow that fits this repo’s existing architecture:
+
+- shell-first orchestration in `shell-functions.sh`
+- config centralized in `.env`
+- OpenCode launched via `coda` and `coda serve`
+- tmux-driven UX and worktree-per-feature isolation
+
+This design is intentionally tailored to the current repo, not a generic app/server rewrite.
+
+---
+
+## What the example gist proves
+
+The gist shows that OpenCode can talk to CLIProxyAPI as a custom provider by using:
+
+- `npm: "@ai-sdk/openai-compatible"`
+- `options.baseURL: "http://localhost:8317/v1"`
+- a provider-local `models` map in `opencode.json`
+
+That means the integration boundary is simple: OpenCode only needs an OpenAI-compatible endpoint plus model metadata. CLIProxyAPI handles upstream auth and model routing.
+
+---
+
+## What this repo already does today
+
+### Existing integration surfaces
+
+- `shell-functions.sh`
+  - `_coda_auth()` currently wires Claude credentials into OpenCode by installing `opencode-claude-auth`
+  - `_coda_serve()` runs `opencode serve --port ...` with `OPENCODE_HEADLESS_PERMISSION`
+- `.env.example`
+  - already defines the repo’s config contract, including OpenCode port and permission settings
+- `README.md`
+  - documents `coda auth`, `coda serve`, layouts, profiles, and OpenCode workflows
+- `tmux.conf` and `scripts/tmux-opencode-compose.sh`
+  - assume OpenCode is the interactive agent surface and route composed prompts into the correct pane heuristically
+
+### Important constraint
+
+This repo is not an application server. It is a shell/tmux control plane around OpenCode. So the correct design is to add provider/config/auth management around OpenCode, not to build new proxy logic into Coda itself.
+
+---
+
+## Recommended design
+
+### Summary
+
+Treat CLIProxyAPI as an optional Coda-managed upstream for OpenCode.
+
+Coda should:
+
+1. manage the local OpenCode config needed to point at CLIProxyAPI
+2. expose simple shell commands for setup/verification
+3. keep provider defaults in `.env`
+4. preserve existing OpenCode session, layout, and headless workflows unchanged
+
+CLIProxyAPI should remain a separate process/service.
+
+---
+
+## Architecture
+
+```text
+User / tmux / coda
+    |
+    |  coda auth / coda serve / coda <session>
+    v
+OpenCode
+    |
+    |  custom provider via opencode.json
+    v
+CLIProxyAPI (localhost:8317/v1)
+    |
+    |  provider routing + auth handling
+    v
+Claude / Gemini / Qwen / DeepSeek / etc.
+```
+
+### Why this shape fits the repo
+
+- matches the existing shell-first control model
+- keeps `.env` as the configuration source of truth
+- does not interfere with tmux pane detection or session management
+- keeps `coda serve` focused on OpenCode headless mode, not upstream proxy responsibilities
+
+---
+
+## Scope boundaries
+
+### In scope
+
+- Coda-side configuration for using CLIProxyAPI from OpenCode
+- Coda commands for setup, verification, and switching provider mode
+- generated or managed `opencode.json` content for the custom provider
+- documentation for the new flow
+
+### Out of scope
+
+- embedding CLIProxyAPI into this repo
+- rewriting Coda as an HTTP proxy
+- replacing tmux/OpenCode interaction patterns
+- inventing a second auth stack when CLIProxyAPI already manages upstream auth
+
+---
+
+## Design details
+
+## 1. Provider mode becomes explicit in Coda config
+
+Add provider-oriented env settings to `.env.example` so the repo can support both the current Claude-auth path and the new CLIProxyAPI path.
+
+Suggested additions:
+
+```bash
+# Which OpenCode provider mode Coda should configure
+# Options: claude-auth, cliproxyapi
+CODA_PROVIDER_MODE="claude-auth"
+
+# CLIProxyAPI endpoint for OpenCode custom provider
+CLIPROXYAPI_BASE_URL="http://localhost:8317/v1"
+
+# Optional health endpoint used by verification commands
+CLIPROXYAPI_HEALTH_URL="http://localhost:8317/health"
+
+# Path where Coda writes/maintains the OpenCode provider config
+# Leave empty to use OpenCode's default config location
+CODA_OPENCODE_CONFIG_PATH=""
+```
+
+### Why
+
+- preserves the repo’s existing `.env` pattern
+- lets users opt in without breaking today’s Claude-based flow
+- avoids hardcoding CLIProxyAPI assumptions into session creation or tmux logic
+
+---
+
+## 2. `coda auth` becomes provider-aware
+
+Today `_coda_auth()` is Claude-specific:
+
+- checks `claude auth status`
+- checks `~/.claude/.credentials.json`
+- installs `opencode-claude-auth`
+- lists Anthropic models
+
+The design should evolve `coda auth` into a small dispatcher:
+
+- `CODA_PROVIDER_MODE=claude-auth`
+  - keep the current behavior
+- `CODA_PROVIDER_MODE=cliproxyapi`
+  - verify CLIProxyAPI is reachable
+  - write or update the OpenCode custom provider config
+  - optionally probe `/v1/models`
+  - print next-step verification commands
+
+### Recommendation
+
+Keep the command name `coda auth` for continuity, but make its behavior mode-dependent.
+
+Why that is better than adding a completely separate command:
+
+- fits current docs and mental model
+- keeps one “wire OpenCode to its provider” entry point
+- avoids spreading setup across multiple commands too early
+
+---
+
+## 3. Coda should manage `opencode.json`, not ask users to hand-edit it
+
+The gist is manual. This repo should automate it.
+
+### Recommended behavior
+
+When provider mode is `cliproxyapi`, `coda auth` should generate the required OpenCode config block with:
+
+- provider name `cliproxyapi`
+- `npm: "@ai-sdk/openai-compatible"`
+- `options.baseURL` from `CLIPROXYAPI_BASE_URL`
+- a model map sourced from discovery or a curated fallback
+
+### Preferred source of models
+
+1. **First choice:** query CLIProxyAPI dynamically, ideally via `/v1/models`
+2. **Fallback:** ship a curated minimal model set in this repo
+3. **Avoid:** a giant static model catalog copied from the gist
+
+### Why dynamic-first is the right default
+
+The gist’s large model list is useful as proof of compatibility, but it is a poor long-term config source for this repo because it becomes stale and couples Coda to someone else’s local setup.
+
+---
+
+## 4. Keep CLIProxyAPI lifecycle separate from `coda serve`
+
+`_coda_serve()` currently means “run OpenCode headless on a free local port.” That should stay true.
+
+### Recommendation
+
+Do **not** overload `coda serve` to also start CLIProxyAPI.
+
+Instead, add either:
+
+- lightweight verification only, or
+- a separate helper such as `coda provider status` / `coda provider doctor`
+
+### Why
+
+- `coda serve` is already clearly documented as OpenCode headless mode
+- mixing upstream proxy lifecycle into it would blur responsibilities
+- users may run one shared CLIProxyAPI instance for many OpenCode sessions
+
+---
+
+## 5. Add a provider-status command
+
+The repo needs a fast sanity check for the full chain.
+
+Recommended command shape:
+
+```bash
+coda provider status
+```
+
+Expected checks:
+
+1. print active `CODA_PROVIDER_MODE`
+2. verify `opencode` is installed
+3. if mode is `cliproxyapi`, verify `CLIPROXYAPI_BASE_URL` responds
+4. if available, probe `/health`
+5. probe `/v1/models`
+6. report config file path used by OpenCode
+
+This gives a clean operator workflow before users start sessions.
+
+---
+
+## 6. Preserve tmux and layout behavior exactly as-is
+
+No design change is needed in:
+
+- `tmux.conf`
+- `scripts/tmux-opencode-compose.sh`
+- layout scripts under `layouts/`
+- watcher behavior in `coda-watcher.sh`
+
+These parts interact with OpenCode as a terminal application, not with the upstream provider. As long as OpenCode still launches normally, they should remain unchanged.
+
+---
+
+## 7. Documentation should teach two provider paths
+
+The README currently documents the Claude-only setup flow:
+
+1. `claude auth login`
+2. `coda auth`
+
+That needs to become two explicit paths:
+
+### Claude path
+
+Keep the current flow for users who want direct Claude auth.
+
+### CLIProxyAPI path
+
+Document:
+
+1. install/run CLIProxyAPI separately
+2. set `CODA_PROVIDER_MODE=cliproxyapi`
+3. set `CLIPROXYAPI_BASE_URL`
+4. run `coda auth`
+5. run `coda provider status`
+6. start or attach to OpenCode sessions normally
+
+---
+
+## File-level plan
+
+### `shell-functions.sh`
+
+Add:
+
+- provider-mode dispatch inside `_coda_auth()` or a new wrapper around it
+- helpers for:
+  - resolving OpenCode config path
+  - writing/updating custom provider config
+  - probing CLIProxyAPI endpoints
+  - printing provider diagnostics
+- optional new subcommand such as `coda provider status`
+
+Preserve:
+
+- `_coda_serve()` contract
+- session naming with `SESSION_PREFIX`
+- worktree/session behavior
+
+### `.env.example`
+
+Add provider-mode and CLIProxyAPI config variables.
+
+### `README.md`
+
+Update installation/auth sections and add a CLIProxyAPI setup flow.
+
+### `man/coda.1`
+
+Mirror the new provider-aware command behavior.
+
+### `install.sh`
+
+Possibly add soft checks or optional messaging, but do not make CLIProxyAPI a hard dependency for base install.
+
+---
+
+## Rollout plan
+
+## Phase 1 — Minimal useful integration
+
+Deliver:
+
+- env-driven provider mode
+- `coda auth` support for `cliproxyapi`
+- managed custom-provider config generation
+- README/man updates
+
+This gets OpenCode talking to CLIProxyAPI in a way that matches the repo’s architecture.
+
+## Phase 2 — Better diagnostics
+
+Deliver:
+
+- `coda provider status`
+- `/health` and `/v1/models` checks
+- clearer failure messages for bad base URLs or missing models
+
+## Phase 3 — Dynamic model sync polish
+
+Deliver:
+
+- model discovery from CLIProxyAPI
+- stable mapping into generated OpenCode provider config
+- fallback behavior when discovery is unavailable
+
+---
+
+## Explicit recommendation
+
+The best design for this repo is:
+
+1. **keep CLIProxyAPI external**
+2. **make Coda provider-aware through `.env` + `coda auth`**
+3. **generate OpenCode custom-provider config automatically**
+4. **add provider diagnostics instead of overloading `coda serve`**
+5. **leave tmux/layout/session mechanics untouched**
+
+This is the smallest design that is aligned with the current codebase and gives Coda a clean path from today’s Claude plugin flow to a broader CLIProxyAPI-backed provider model.
+
+---
+
+## Open questions to resolve before implementation
+
+1. Where should Coda write the OpenCode config by default: project-local, user-global, or a Coda-managed generated path?
+2. Should `cliproxyapi` mode fully replace `claude-auth`, or should users be able to keep both configured simultaneously?
+3. Do we want a curated default model subset for a stable UX, or full dynamic discovery from the proxy every time?
+4. Do we want optional helper commands for starting/stopping CLIProxyAPI locally, or should process management remain fully outside this repo?
+
+---
+
+## Decision
+
+If we proceed, I recommend implementing **Phase 1 + Phase 2 together**. That yields a usable integration and enough diagnostics to keep support costs reasonable.

--- a/README.md
+++ b/README.md
@@ -673,7 +673,7 @@ All behaviour is controlled by `.env` in the repo directory. Created from
 | `CODA_PROVIDER_MODE` | `claude-auth` | Provider mode for `coda auth`: `claude-auth` or `cliproxyapi` |
 | `CLIPROXYAPI_BASE_URL` | `http://localhost:8317/v1` | OpenAI-compatible base URL written into the managed CLIProxyAPI provider block |
 | `CLIPROXYAPI_API_KEY` | empty | Optional proxy API key used for cliproxy model discovery/status probes and written into the managed provider block when set |
-| `CLIPROXYAPI_HEALTH_URL` | `http://localhost:8317/healthz` | Optional health endpoint used by `coda provider status` |
+| `CLIPROXYAPI_HEALTH_URL` | empty | Optional health endpoint used by `coda provider status`; skipped when unset |
 | `CODA_OPENCODE_CONFIG_PATH` | empty | Optional override for the OpenCode config path; if set, Coda also exports `OPENCODE_CONFIG` |
 | `NODE_MAJOR_VERSION` | `20` | Node.js major version for install |
 | `PACKAGE_MANAGER` | `npm` | Package manager preference (npm, pnpm, or yarn) |

--- a/README.md
+++ b/README.md
@@ -79,12 +79,33 @@ SKIP_LAZYGIT=true   ./install.sh
 
 ### After install
 
+Reload your shell first, then choose one provider path.
+
 ```bash
 sudo tailscale up          # connect to your Tailscale network
 source ~/.bashrc           # pick up coda + completions
-claude auth login          # one-time OAuth flow
-coda auth                  # wire OpenCode to use those credentials
 tmux                       # start your first session
+```
+
+#### Claude path
+
+```bash
+claude auth login          # one-time OAuth flow
+coda auth                  # install Claude plugin + verify
+```
+
+#### CLIProxyAPI path
+
+Run CLIProxyAPI separately, then point Coda at it:
+
+```bash
+# in ~/coda/.env
+CODA_PROVIDER_MODE="cliproxyapi"
+CLIPROXYAPI_BASE_URL="http://localhost:8317/v1"
+CLIPROXYAPI_API_KEY=""      # optional; set if your proxy requires auth
+
+coda auth                  # write/update OpenCode provider config
+coda provider status       # probe config/auth readiness (not runtime proof)
 ```
 
 ---
@@ -98,10 +119,12 @@ tmux                       # start your first session
   │  ./install.sh                                                     │
   │       │                                                           │
   │       ├──▶  sudo tailscale up                                    │
-  │       ├──▶  claude auth login                                    │
-  │       └──▶  coda auth                                            │
-  │                    │                                              │
-  │                    └──▶  ready ✓                                 │
+  │       ├──▶  source ~/.bashrc                                     │
+  │       ├──▶  Claude path: claude auth login -> coda auth         │
+  │       └──▶  CLIProxyAPI path: edit .env -> coda auth ->         │
+  │                             coda provider status                 │
+  │                                    │                              │
+  │                                    └──▶  ready ✓                 │
   └─────────────────────────────────────────────────────────────────┘
 
   ┌─────────────────────────────────────────────────────────────────┐
@@ -443,7 +466,10 @@ curl -X POST http://localhost:4096/session/$SESSION_ID/prompt_async \
 
 ### `coda auth`
 
-One-time setup to wire Claude Code credentials to OpenCode.
+One-time setup to wire the active provider into OpenCode. The behavior depends
+on `CODA_PROVIDER_MODE`.
+
+**Claude path** (`CODA_PROVIDER_MODE=claude-auth`, the default):
 
 ```bash
 claude auth login   # complete OAuth in browser
@@ -454,6 +480,39 @@ opencode models anthropic
 ```
 
 If Claude auth expires, re-run `claude auth login` then `coda auth`.
+
+**CLIProxyAPI path** (`CODA_PROVIDER_MODE=cliproxyapi`):
+
+```bash
+# in ~/coda/.env
+CODA_PROVIDER_MODE="cliproxyapi"
+CLIPROXYAPI_BASE_URL="http://localhost:8317/v1"
+CLIPROXYAPI_API_KEY=""      # optional; set if your proxy requires auth
+
+coda auth             # writes/updates ~/.config/opencode/opencode.json
+coda provider status  # probes config/auth readiness; not end-to-end runtime proof
+```
+
+CLIProxyAPI stays external to this repo. `coda auth` manages the OpenCode
+provider config and includes proxy auth when `CLIPROXYAPI_API_KEY` is set; it
+does not start or stop the proxy.
+
+---
+
+### `coda provider status`
+
+Show provider diagnostics for the current mode.
+
+```bash
+coda provider status
+```
+
+In `cliproxyapi` mode this reports the active mode, effective OpenCode config
+path, whether the managed `cliproxyapi` provider block is present, whether
+optional proxy auth is configured, and probes the base URL, health endpoint,
+and models endpoint. Missing config, unauthorized models access, and probe-only
+success are reported separately so the output does not imply end-to-end runtime
+proof.
 
 ---
 
@@ -536,7 +595,7 @@ Installed automatically by `install.sh` for both bash and zsh.
 
 ```
 coda <TAB>                     → attach ls switch serve auth project feature
-                                 layout profile watch help [active sessions]
+                                 layout profile watch provider help [active sessions]
 coda attach <TAB>              → [active sessions]
 coda feature <TAB>             → start done finish ls
 coda feature start <TAB>       → [local git branches]
@@ -551,6 +610,7 @@ coda layout apply <TAB>        → [available layouts]
 coda profile <TAB>             → ls create show
 coda profile show <TAB>        → [available profiles]
 coda watch <TAB>               → start stop status
+coda provider <TAB>            → status
 coda serve <TAB>               → [port numbers]
 coda switch                    → (no completion needed — interactive fzf)
 coda --profile <TAB>           → [available profiles]
@@ -610,6 +670,11 @@ All behaviour is controlled by `.env` in the repo directory. Created from
 | `OPENCODE_BASE_PORT` | `4096` | First port tried by `coda serve` |
 | `OPENCODE_PORT_RANGE` | `10` | Number of ports to scan |
 | `OPENCODE_HEADLESS_PERMISSION` | `{"*":"allow"}` | Permission policy for `coda serve` |
+| `CODA_PROVIDER_MODE` | `claude-auth` | Provider mode for `coda auth`: `claude-auth` or `cliproxyapi` |
+| `CLIPROXYAPI_BASE_URL` | `http://localhost:8317/v1` | OpenAI-compatible base URL written into the managed CLIProxyAPI provider block |
+| `CLIPROXYAPI_API_KEY` | empty | Optional proxy API key used for cliproxy model discovery/status probes and written into the managed provider block when set |
+| `CLIPROXYAPI_HEALTH_URL` | `http://localhost:8317/healthz` | Optional health endpoint used by `coda provider status` |
+| `CODA_OPENCODE_CONFIG_PATH` | empty | Optional override for the OpenCode config path; if set, Coda also exports `OPENCODE_CONFIG` |
 | `NODE_MAJOR_VERSION` | `20` | Node.js major version for install |
 | `PACKAGE_MANAGER` | `npm` | Package manager preference (npm, pnpm, or yarn) |
 | `DEFAULT_LAYOUT` | `four-pane` | Default tmux layout when creating sessions |

--- a/completions/coda.bash
+++ b/completions/coda.bash
@@ -63,7 +63,7 @@ _coda_complete() {
         cword=$COMP_CWORD
     }
 
-    local top_subcommands="attach ls switch serve auth project feature layout profile watch help"
+    local top_subcommands="attach ls switch serve auth project feature layout profile watch provider help"
 
     # Word positions:
     #   words[0] = coda
@@ -129,6 +129,9 @@ _coda_complete() {
                     ;;
                 watch)
                     COMPREPLY=($(compgen -W "start stop status" -- "$cur"))
+                    ;;
+                provider)
+                    COMPREPLY=($(compgen -W "status" -- "$cur"))
                     ;;
                 attach)
                     local sessions

--- a/completions/coda.zsh
+++ b/completions/coda.zsh
@@ -75,6 +75,7 @@ _coda() {
                 'layout:manage and apply tmux layouts'
                 'profile:manage config profiles'
                 'watch:monitor sessions for attention signals'
+                'provider:manage provider status'
                 'help:show usage'
             )
             # Add existing sessions as completions
@@ -104,6 +105,9 @@ _coda() {
                     ;;
                 watch)
                     _coda_watch_args
+                    ;;
+                provider)
+                    _coda_provider_args
                     ;;
                 serve)
                     local base="${OPENCODE_BASE_PORT:-4096}"
@@ -306,6 +310,23 @@ _coda_watch_args() {
                 'status:check if watcher is running'
             )
             _describe 'watch subcommand' subcmds
+            ;;
+    esac
+}
+
+_coda_provider_args() {
+    local state line
+    _arguments -C \
+        '1: :->subcmd' \
+        && return 0
+
+    case $state in
+        subcmd)
+            local -a subcmds
+            subcmds=(
+                'status:show provider status'
+            )
+            _describe 'provider subcommand' subcmds
             ;;
     esac
 }

--- a/install.sh
+++ b/install.sh
@@ -546,14 +546,19 @@ if [ "$SKIP_TAILSCALE" != "true" ] && command -v tailscale &>/dev/null; then
     fi
 fi
 
-echo "  Sign in to Claude:"
-echo "       claude auth login"
-echo ""
 echo "  Reload your shell:"
 echo "       source ${SHELL_RC:-~/.bashrc}"
 echo ""
-echo "  Enable Claude auth in OpenCode:"
+echo "  Provider-aware OpenCode setup:"
+echo "       # Claude path"
+echo "       claude auth login"
 echo "       coda auth"
+echo ""
+echo "       # CLIProxyAPI path"
+echo "       # edit .env: CODA_PROVIDER_MODE=cliproxyapi"
+echo "       # edit .env: CLIPROXYAPI_BASE_URL=http://localhost:8317/v1"
+echo "       coda auth"
+echo "       coda provider status"
 echo ""
 echo "  Start a tmux session:"
 echo "       tmux"

--- a/man/coda.1
+++ b/man/coda.1
@@ -496,7 +496,7 @@ OPENCODE_PORT_RANGE	10	Ports to scan
 CODA_PROVIDER_MODE	claude-auth	Provider mode for \fBcoda auth\fR
 CLIPROXYAPI_BASE_URL	http://localhost:8317/v1	CLIProxyAPI base URL for the managed provider
 CLIPROXYAPI_API_KEY	empty	Optional proxy API key for cliproxy model probes and managed provider auth
-CLIPROXYAPI_HEALTH_URL	http://localhost:8317/healthz	Health endpoint for \fBcoda provider status\fR
+CLIPROXYAPI_HEALTH_URL	empty	Optional health endpoint for \fBcoda provider status\fR; skipped when unset
 CODA_OPENCODE_CONFIG_PATH	empty	Optional OpenCode config override; also exported as \fBOPENCODE_CONFIG\fR when set
 DEFAULT_LAYOUT	default	Default tmux layout
 CODA_LAYOUTS_DIR	~/.config/coda/layouts	User layout directory

--- a/man/coda.1
+++ b/man/coda.1
@@ -1,4 +1,4 @@
-.TH CODA 1 "2026-04-09" "coda" "User Commands"
+.TH CODA 1 "2026-04-12" "coda" "User Commands"
 .
 .SH NAME
 coda \- OpenCode session and project manager
@@ -19,6 +19,10 @@ coda \- OpenCode session and project manager
 .br
 .B coda
 .B auth
+.br
+.B coda
+.B provider
+.B status
 .br
 .B coda
 .B project
@@ -178,15 +182,35 @@ or submit tasks programmatically via the OpenCode HTTP API.
 .
 .TP
 .B coda auth
-Install the
+Wire the active provider into OpenCode.
+By default this uses
+.B CODA_PROVIDER_MODE=claude-auth
+and installs the
 .B opencode-claude-auth
-plugin globally, which lets OpenCode reuse the OAuth credentials written by
-.BR "claude auth login"
-to
-.IR ~/.claude/.credentials.json .
-Run once after
+plugin so OpenCode can reuse the OAuth credentials written by
 .BR "claude auth login" .
-Re-run if Claude auth expires.
+.sp
+If
+.B CODA_PROVIDER_MODE=cliproxyapi
+, the command writes or updates a managed CLIProxyAPI provider block in the
+resolved OpenCode config file instead.
+If
+.B CLIPROXYAPI_API_KEY
+is set, it is also written into that managed provider block for proxy auth.
+CLIProxyAPI itself remains an external service.
+.
+.SS Provider diagnostics
+.
+.TP
+.B coda provider status
+Show diagnostics for the active provider mode.
+In
+.B cliproxyapi
+mode this reports the effective OpenCode config path, whether the managed
+provider block is present, whether optional proxy auth is configured, and
+probes the configured base URL, health URL, and models endpoint.
+Missing config, unauthorized models access, and probe-only success are reported
+separately so the output does not imply end-to-end runtime proof.
 .
 .SS Project management
 .
@@ -469,6 +493,11 @@ DEFAULT_BRANCH	main	Branch for new worktrees
 GIT_REMOTE	origin	Git remote name
 OPENCODE_BASE_PORT	4096	First port for \fBcoda serve\fR
 OPENCODE_PORT_RANGE	10	Ports to scan
+CODA_PROVIDER_MODE	claude-auth	Provider mode for \fBcoda auth\fR
+CLIPROXYAPI_BASE_URL	http://localhost:8317/v1	CLIProxyAPI base URL for the managed provider
+CLIPROXYAPI_API_KEY	empty	Optional proxy API key for cliproxy model probes and managed provider auth
+CLIPROXYAPI_HEALTH_URL	http://localhost:8317/healthz	Health endpoint for \fBcoda provider status\fR
+CODA_OPENCODE_CONFIG_PATH	empty	Optional OpenCode config override; also exported as \fBOPENCODE_CONFIG\fR when set
 DEFAULT_LAYOUT	default	Default tmux layout
 CODA_LAYOUTS_DIR	~/.config/coda/layouts	User layout directory
 CODA_PROFILES_DIR	~/.config/coda/profiles	User profile directory
@@ -485,8 +514,18 @@ DEFAULT_TMUX_SESSION	default	Session name for auto-attach
 .EX
 \&./install.sh
 sudo tailscale up
+source ~/.bashrc
+
+# Claude path
 claude auth login
 coda auth
+
+# CLIProxyAPI path
+# edit .env: CODA_PROVIDER_MODE=cliproxyapi
+# edit .env: CLIPROXYAPI_BASE_URL=http://localhost:8317/v1
+# edit .env: CLIPROXYAPI_API_KEY=...   (optional, if your proxy requires auth)
+coda auth
+coda provider status
 .EE
 .
 .SS Clone a project and start working

--- a/shell-functions.sh
+++ b/shell-functions.sh
@@ -40,6 +40,10 @@ DEFAULT_LAYOUT="${DEFAULT_LAYOUT:-four-pane}"
 DEFAULT_NVIM_APPNAME="${DEFAULT_NVIM_APPNAME:-nvim}"
 CODA_PROFILES_DIR="${CODA_PROFILES_DIR:-$HOME/.config/coda/profiles}"
 CODA_LAYOUTS_DIR="${CODA_LAYOUTS_DIR:-$HOME/.config/coda/layouts}"
+CODA_PROVIDER_MODE="${CODA_PROVIDER_MODE:-claude-auth}"
+CLIPROXYAPI_BASE_URL="${CLIPROXYAPI_BASE_URL:-http://localhost:8317/v1}"
+CLIPROXYAPI_HEALTH_URL="${CLIPROXYAPI_HEALTH_URL:-http://localhost:8317/healthz}"
+CLIPROXYAPI_API_KEY="${CLIPROXYAPI_API_KEY:-}"
 
 # ===========================================================================
 # coda — main entry point
@@ -49,7 +53,8 @@ CODA_LAYOUTS_DIR="${CODA_LAYOUTS_DIR:-$HOME/.config/coda/layouts}"
 #   coda ls                       list active sessions
 #   coda switch                   fzf session picker
 #   coda serve [port]             headless OpenCode server
-#   coda auth                     wire Claude Code credentials
+#   coda auth                     wire provider credentials/config
+#   coda provider <cmd>           provider commands
 #   coda project <cmd>            manage projects
 #   coda feature <cmd>            manage feature worktrees
 #   coda layout <cmd|name>        manage/apply tmux layouts
@@ -92,6 +97,7 @@ coda() {
                           status=$?
                           ;;
         auth)             _coda_auth; status=$? ;;
+        provider)         _coda_provider "${args[@]:1}"; status=$? ;;
         serve)            _coda_serve "${args[@]:1}"; status=$? ;;
         project)          _coda_project "${args[@]:1}"; status=$? ;;
         feature)          _coda_feature "${args[@]:1}"; status=$? ;;
@@ -228,9 +234,18 @@ _coda_serve() {
 
 # ===========================================================================
 # coda auth
-# Install the opencode-claude-auth plugin to share Claude Code credentials.
 # ===========================================================================
 _coda_auth() {
+    local mode
+    mode=$(_coda_provider_mode) || return 1
+
+    case "$mode" in
+        claude-auth) _coda_auth_claude ;;
+        cliproxyapi) _coda_auth_cliproxyapi ;;
+    esac
+}
+
+_coda_auth_claude() {
     if ! command -v claude &>/dev/null; then
         echo "claude CLI not found. Install Claude Code first (re-run install.sh)."
         return 1
@@ -261,6 +276,142 @@ _coda_auth() {
     echo ""
     echo "Available Anthropic models:"
     opencode models anthropic
+}
+
+_coda_auth_cliproxyapi() {
+    if ! command -v opencode &>/dev/null; then
+        echo "opencode not found. Re-run install.sh."
+        return 1
+    fi
+
+    if ! command -v jq &>/dev/null; then
+        echo "jq not found. Re-run install.sh."
+        return 1
+    fi
+
+    local base_url
+    base_url=$(_coda_normalize_url "$CLIPROXYAPI_BASE_URL") || {
+        echo "Invalid CLIPROXYAPI_BASE_URL: $CLIPROXYAPI_BASE_URL"
+        echo "Expected http://... or https://..."
+        return 1
+    }
+
+    local config_path
+    config_path=$(_coda_resolve_opencode_config_path)
+
+    local config_dir
+    config_dir=$(dirname "$config_path")
+    mkdir -p "$config_dir"
+
+    local models_json=""
+    if ! models_json=$(_coda_discover_cliproxyapi_models "$base_url"); then
+        echo "Warning: could not discover models from ${base_url}/models"
+        echo "Writing fallback CLIProxyAPI provider config instead."
+        models_json=$(_coda_fallback_cliproxyapi_models)
+    fi
+
+    if ! _coda_merge_cliproxyapi_provider "$config_path" "$base_url" "$models_json"; then
+        return 1
+    fi
+
+    echo "Updated OpenCode config: $config_path"
+    echo "Provider mode: cliproxyapi"
+    echo "Base URL: $base_url"
+}
+
+_coda_provider() {
+    local subcmd="${1:-help}"
+
+    case "$subcmd" in
+        status) _coda_provider_status ;;
+        ""|help)
+            echo "Usage: coda provider <status>"
+            ;;
+        *)
+            echo "Unknown provider subcommand: $subcmd"
+            echo "Usage: coda provider <status>"
+            return 1
+            ;;
+    esac
+}
+
+_coda_provider_status() {
+    local mode
+    mode=$(_coda_provider_mode) || return 1
+
+    local config_path
+    config_path=$(_coda_resolve_opencode_config_path)
+    local provider_block_present="unknown"
+    local provider_auth_present="unknown"
+
+    echo "Provider mode: $mode"
+    echo "OpenCode config: $config_path"
+
+    if command -v opencode &>/dev/null; then
+        echo "opencode: found"
+    else
+        echo "opencode: missing"
+    fi
+
+    if command -v jq &>/dev/null && [ -f "$config_path" ]; then
+        if jq -e '.provider.cliproxyapi != null' "$config_path" >/dev/null 2>&1; then
+            provider_block_present="yes"
+            if jq -e '.provider.cliproxyapi.options.apiKey? != null and .provider.cliproxyapi.options.apiKey != ""' "$config_path" >/dev/null 2>&1; then
+                provider_auth_present="yes"
+            else
+                provider_auth_present="no"
+            fi
+        else
+            provider_block_present="no"
+        fi
+    elif [ -f "$config_path" ]; then
+        echo "cliproxyapi provider block: unknown (jq not found)"
+    else
+        echo "cliproxyapi provider block: config file not found (run: coda auth)"
+    fi
+
+    if [ "$mode" = "cliproxyapi" ]; then
+        local base_url health_url models_url
+
+        base_url=$(_coda_normalize_url "$CLIPROXYAPI_BASE_URL") || {
+            echo "Base URL: invalid ($CLIPROXYAPI_BASE_URL)"
+            return 1
+        }
+
+        health_url=$(_coda_normalize_url "$CLIPROXYAPI_HEALTH_URL") || {
+            echo "Health URL: invalid ($CLIPROXYAPI_HEALTH_URL)"
+            return 1
+        }
+
+        models_url="${base_url}/models"
+
+        if [ "$provider_block_present" = "yes" ]; then
+            if [ -n "$CLIPROXYAPI_API_KEY" ] && [ "$provider_auth_present" = "no" ]; then
+                echo "cliproxyapi provider block: present, but missing proxy auth (re-run: coda auth)"
+            else
+                echo "cliproxyapi provider block: present (configuration ready; runtime not proven)"
+            fi
+
+            if [ "$provider_auth_present" = "yes" ]; then
+                echo "Managed proxy auth: present in provider block"
+            else
+                echo "Managed proxy auth: absent from provider block"
+            fi
+        elif [ "$provider_block_present" = "no" ]; then
+            echo "cliproxyapi provider block: absent (run: coda auth)"
+        fi
+
+        if [ -n "$CLIPROXYAPI_API_KEY" ]; then
+            echo "Proxy API key env: set in CLIPROXYAPI_API_KEY"
+        else
+            echo "Proxy API key env: not set (optional)"
+        fi
+
+        _coda_print_url_status "Base URL" "$base_url"
+        _coda_print_url_status "Health URL" "$health_url"
+        _coda_print_models_status "$models_url"
+        echo "Readiness note: config and HTTP probes are not end-to-end runtime proof."
+    fi
 }
 
 # ===========================================================================
@@ -1169,7 +1320,8 @@ USAGE
   coda ls                     List active sessions
   coda switch                 fzf session picker with preview
   coda serve [port]           Start OpenCode in headless server mode
-  coda auth                   Wire Claude Code credentials to OpenCode
+  coda auth                   Wire the active provider into OpenCode
+  coda provider status        Show provider diagnostics
 
   coda project start                              Reconnect to main/master session
   coda project start --repo <url> [name]          Clone a repo as a bare project
@@ -1230,6 +1382,262 @@ _coda_list_layouts() {
         seen="$seen|$name|"
         echo "$name"
     done
+}
+
+_coda_provider_mode() {
+    case "${CODA_PROVIDER_MODE:-claude-auth}" in
+        ""|claude-auth)
+            echo "claude-auth"
+            ;;
+        cliproxyapi)
+            echo "cliproxyapi"
+            ;;
+        *)
+            echo "Invalid CODA_PROVIDER_MODE: ${CODA_PROVIDER_MODE}" >&2
+            echo "Expected: claude-auth or cliproxyapi" >&2
+            return 1
+            ;;
+    esac
+}
+
+_coda_expand_path() {
+    case "$1" in
+        "~") printf '%s\n' "$HOME" ;;
+        "~/"*) printf '%s/%s\n' "$HOME" "${1#~/}" ;;
+        *) printf '%s\n' "$1" ;;
+    esac
+}
+
+_coda_resolve_opencode_config_path() {
+    if [ -n "${CODA_OPENCODE_CONFIG_PATH:-}" ]; then
+        _coda_expand_path "$CODA_OPENCODE_CONFIG_PATH"
+    else
+        echo "$HOME/.config/opencode/opencode.json"
+    fi
+}
+
+if [ -n "${CODA_OPENCODE_CONFIG_PATH:-}" ]; then
+    export OPENCODE_CONFIG="$(_coda_resolve_opencode_config_path)"
+fi
+
+_coda_normalize_url() {
+    local url="${1:-}"
+    url="${url%/}"
+
+    case "$url" in
+        http://*|https://*)
+            echo "$url"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+_coda_probe_url() {
+    local url="$1"
+
+    if ! command -v curl &>/dev/null; then
+        echo "curl not found"
+        return 2
+    fi
+
+    curl --silent --show-error --output /dev/null --write-out '%{http_code}' --max-time 5 "$url" 2>/dev/null
+}
+
+_coda_print_url_status() {
+    local label="$1"
+    local url="$2"
+    local code
+
+    code=$(_coda_probe_url "$url")
+    case "$?" in
+        0)
+            if [ "$code" = "000" ]; then
+                echo "$label: unreachable ($url)"
+            elif [ "$code" -ge 200 ] && [ "$code" -lt 300 ]; then
+                echo "$label: reachable ($url, HTTP $code)"
+            else
+                echo "$label: reachable with non-2xx response ($url, HTTP $code)"
+            fi
+            ;;
+        2)
+            echo "$label: unavailable (curl not found)"
+            ;;
+        *)
+            echo "$label: unreachable ($url)"
+            ;;
+    esac
+}
+
+_coda_print_models_status() {
+    local models_url="$1"
+
+    if ! command -v curl &>/dev/null; then
+        echo "Models endpoint: unavailable (curl not found)"
+        return 0
+    fi
+
+    if ! command -v jq &>/dev/null; then
+        echo "Models endpoint: unavailable (jq not found)"
+        return 0
+    fi
+
+    local response
+    if ! response=$(_coda_fetch_cliproxyapi_models_response "$models_url"); then
+        echo "Models endpoint: unreachable ($models_url)"
+        return 0
+    fi
+
+    local http_code response_body
+    http_code=${response##*$'\n'}
+    response_body=${response%$'\n'*}
+
+    if [ "$http_code" = "000" ]; then
+        echo "Models endpoint: unreachable ($models_url)"
+        return 0
+    fi
+
+    if [ "$http_code" = "401" ] || [ "$http_code" = "403" ]; then
+        if [ -n "$CLIPROXYAPI_API_KEY" ]; then
+            echo "Models endpoint: unauthorized ($models_url, HTTP $http_code; configured proxy API key was rejected)"
+        else
+            echo "Models endpoint: unauthorized ($models_url, HTTP $http_code; set CLIPROXYAPI_API_KEY if your proxy requires auth)"
+        fi
+        return 0
+    fi
+
+    if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+        echo "Models endpoint: reachable with non-2xx response ($models_url, HTTP $http_code)"
+        return 0
+    fi
+
+    local count
+    count=$(printf '%s' "$response_body" | jq -r 'if ((.data? | type) == "array") then (.data | length) else 0 end' 2>/dev/null)
+    if [ -n "$count" ] && [ "$count" -gt 0 ] 2>/dev/null; then
+        echo "Models endpoint: reachable ($models_url, HTTP $http_code, $count models)"
+    else
+        echo "Models endpoint: reachable but returned no usable models ($models_url, HTTP $http_code)"
+    fi
+}
+
+_coda_fallback_cliproxyapi_models() {
+    cat <<'EOF'
+{
+  "gpt-4o": {
+    "name": "gpt-4o"
+  },
+  "gpt-4.1": {
+    "name": "gpt-4.1"
+  },
+  "claude-opus-4-6": {
+    "name": "claude-opus-4-6"
+  },
+  "claude-haiku-4-5-20251001": {
+    "name": "claude-haiku-4-5-20251001"
+  },
+  "claude-sonnet-4-5-20250929": {
+    "name": "claude-sonnet-4-5-20250929"
+  }
+}
+EOF
+}
+
+_coda_discover_cliproxyapi_models() {
+    local base_url="$1"
+
+    if ! command -v curl &>/dev/null; then
+        return 1
+    fi
+
+    local response
+    response=$(_coda_fetch_cliproxyapi_models_response "${base_url}/models") || return 1
+
+    local http_code models_json
+    http_code=${response##*$'\n'}
+    models_json=${response%$'\n'*}
+
+    if [ "$http_code" = "000" ] || [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+        return 1
+    fi
+
+    local normalized
+    normalized=$(printf '%s' "$models_json" | jq -c '
+        if ((.data? | type) == "array") then
+            reduce .data[] as $model ({};
+                if ($model | type) == "object" and ($model.id // "") != "" then
+                    ($model.id) as $id
+                    | . + { ($id): { name: ($model.name // $id) } }
+                elif ($model | type) == "string" and $model != "" then
+                    . + { ($model): { name: ($model) } }
+                else
+                    .
+                end
+            )
+        else
+            {}
+        end
+    ' 2>/dev/null) || return 1
+
+    if [ "$normalized" = "{}" ]; then
+        return 1
+    fi
+
+    echo "$normalized"
+}
+
+_coda_merge_cliproxyapi_provider() {
+    local config_path="$1"
+    local base_url="$2"
+    local models_json="$3"
+    local api_key="${CLIPROXYAPI_API_KEY:-}"
+    local config_dir
+    config_dir=$(dirname "$config_path")
+
+    local input_json='{}'
+    if [ -f "$config_path" ]; then
+        if ! jq -e 'type == "object"' "$config_path" >/dev/null 2>&1; then
+            echo "Existing OpenCode config is not valid JSON object: $config_path"
+            return 1
+        fi
+        input_json=$(jq -c '.' "$config_path") || return 1
+    fi
+
+    local tmp_file
+    tmp_file=$(mktemp "$config_dir/opencode.json.XXXXXX") || return 1
+
+    if ! printf '%s' "$input_json" | jq --arg base_url "$base_url" --arg api_key "$api_key" --argjson models "$models_json" '
+        .provider = (if (.provider | type) == "object" then .provider else {} end)
+        | .provider.cliproxyapi = {
+            npm: "@ai-sdk/openai-compatible",
+            name: "CLIProxyAPI",
+            options: ({
+                baseURL: $base_url
+            } + if $api_key != "" then {
+                apiKey: $api_key
+            } else {} end),
+            models: $models
+        }
+    ' > "$tmp_file"; then
+        rm -f "$tmp_file"
+        echo "Failed to merge CLIProxyAPI provider config."
+        return 1
+    fi
+
+    mv "$tmp_file" "$config_path"
+}
+
+_coda_fetch_cliproxyapi_models_response() {
+    local models_url="$1"
+
+    if [ -n "$CLIPROXYAPI_API_KEY" ]; then
+        curl --silent --show-error --max-time 5 \
+            -H "Authorization: Bearer $CLIPROXYAPI_API_KEY" \
+            --write-out '\n%{http_code}' "$models_url" 2>/dev/null
+    else
+        curl --silent --show-error --max-time 5 \
+            --write-out '\n%{http_code}' "$models_url" 2>/dev/null
+    fi
 }
 
 _coda_load_layout() {

--- a/shell-functions.sh
+++ b/shell-functions.sh
@@ -42,7 +42,7 @@ CODA_PROFILES_DIR="${CODA_PROFILES_DIR:-$HOME/.config/coda/profiles}"
 CODA_LAYOUTS_DIR="${CODA_LAYOUTS_DIR:-$HOME/.config/coda/layouts}"
 CODA_PROVIDER_MODE="${CODA_PROVIDER_MODE:-claude-auth}"
 CLIPROXYAPI_BASE_URL="${CLIPROXYAPI_BASE_URL:-http://localhost:8317/v1}"
-CLIPROXYAPI_HEALTH_URL="${CLIPROXYAPI_HEALTH_URL:-http://localhost:8317/healthz}"
+CLIPROXYAPI_HEALTH_URL="${CLIPROXYAPI_HEALTH_URL:-}"
 CLIPROXYAPI_API_KEY="${CLIPROXYAPI_API_KEY:-}"
 
 # ===========================================================================
@@ -289,6 +289,8 @@ _coda_auth_cliproxyapi() {
         return 1
     fi
 
+    _coda_validate_api_key "$CLIPROXYAPI_API_KEY" || return 1
+
     local base_url
     base_url=$(_coda_normalize_url "$CLIPROXYAPI_BASE_URL") || {
         echo "Invalid CLIPROXYAPI_BASE_URL: $CLIPROXYAPI_BASE_URL"
@@ -354,7 +356,11 @@ _coda_provider_status() {
     fi
 
     if command -v jq &>/dev/null && [ -f "$config_path" ]; then
-        if jq -e '.provider.cliproxyapi != null' "$config_path" >/dev/null 2>&1; then
+        if ! jq -e 'type == "object"' "$config_path" >/dev/null 2>&1; then
+            echo "cliproxyapi provider block: config is not a valid JSON object ($config_path)"
+        elif ! jq -e '(.provider | type) == "object"' "$config_path" >/dev/null 2>&1; then
+            provider_block_present="no"
+        elif jq -e '.provider.cliproxyapi != null' "$config_path" >/dev/null 2>&1; then
             provider_block_present="yes"
             if jq -e '.provider.cliproxyapi.options.apiKey? != null and .provider.cliproxyapi.options.apiKey != ""' "$config_path" >/dev/null 2>&1; then
                 provider_auth_present="yes"
@@ -371,6 +377,8 @@ _coda_provider_status() {
     fi
 
     if [ "$mode" = "cliproxyapi" ]; then
+        _coda_validate_api_key "$CLIPROXYAPI_API_KEY" || return 1
+
         local base_url health_url models_url
 
         base_url=$(_coda_normalize_url "$CLIPROXYAPI_BASE_URL") || {
@@ -378,12 +386,16 @@ _coda_provider_status() {
             return 1
         }
 
-        health_url=$(_coda_normalize_url "$CLIPROXYAPI_HEALTH_URL") || {
-            echo "Health URL: invalid ($CLIPROXYAPI_HEALTH_URL)"
-            return 1
-        }
-
         models_url="${base_url}/models"
+
+        if [ -n "$CLIPROXYAPI_HEALTH_URL" ]; then
+            health_url=$(_coda_normalize_url "$CLIPROXYAPI_HEALTH_URL") || {
+                echo "Health URL: invalid ($CLIPROXYAPI_HEALTH_URL)"
+                return 1
+            }
+        else
+            health_url=""
+        fi
 
         if [ "$provider_block_present" = "yes" ]; then
             if [ -n "$CLIPROXYAPI_API_KEY" ] && [ "$provider_auth_present" = "no" ]; then
@@ -408,7 +420,11 @@ _coda_provider_status() {
         fi
 
         _coda_print_url_status "Base URL" "$base_url"
-        _coda_print_url_status "Health URL" "$health_url"
+        if [ -n "$health_url" ]; then
+            _coda_print_url_status "Health URL" "$health_url"
+        else
+            echo "Health URL: skipped (CLIPROXYAPI_HEALTH_URL not set)"
+        fi
         _coda_print_models_status "$models_url"
         echo "Readiness note: config and HTTP probes are not end-to-end runtime proof."
     fi
@@ -1420,6 +1436,19 @@ if [ -n "${CODA_OPENCODE_CONFIG_PATH:-}" ]; then
     export OPENCODE_CONFIG="$(_coda_resolve_opencode_config_path)"
 fi
 
+_coda_validate_api_key() {
+    local key="$1"
+    if [ -z "$key" ]; then
+        return 0
+    fi
+    case "$key" in
+        *$'\r'*|*$'\n'*)
+            echo "CLIPROXYAPI_API_KEY contains CR/LF characters; rejected to prevent header injection." >&2
+            return 1
+            ;;
+    esac
+}
+
 _coda_normalize_url() {
     local url="${1:-}"
     url="${url%/}"
@@ -1631,9 +1660,15 @@ _coda_fetch_cliproxyapi_models_response() {
     local models_url="$1"
 
     if [ -n "$CLIPROXYAPI_API_KEY" ]; then
+        local header_file
+        header_file=$(mktemp) || return 1
+        printf 'Authorization: Bearer %s' "$CLIPROXYAPI_API_KEY" > "$header_file"
         curl --silent --show-error --max-time 5 \
-            -H "Authorization: Bearer $CLIPROXYAPI_API_KEY" \
+            -H @"$header_file" \
             --write-out '\n%{http_code}' "$models_url" 2>/dev/null
+        local rc=$?
+        rm -f "$header_file"
+        return $rc
     else
         curl --silent --show-error --max-time 5 \
             --write-out '\n%{http_code}' "$models_url" 2>/dev/null


### PR DESCRIPTION
## Summary

- **`coda auth`** is now provider-aware: routes to the existing Claude OAuth flow (`claude-auth`, default) or a new CLIProxyAPI path (`cliproxyapi`) based on `CODA_PROVIDER_MODE`
- **`coda provider status`** shows diagnostics for the active mode — config path, managed provider block presence, proxy auth, and HTTP probes against the base URL, health endpoint, and models endpoint
- CLIProxyAPI mode auto-discovers models from `/v1/models`, merges a managed provider block into `opencode.json` (preserving existing config), and optionally writes proxy auth from `CLIPROXYAPI_API_KEY`

## Changes

- `shell-functions.sh`: new `_coda_auth_cliproxyapi`, `_coda_provider`, `_coda_provider_status`, model discovery, config merge, URL probe helpers
- `.env.example`: new env vars (`CODA_PROVIDER_MODE`, `CLIPROXYAPI_BASE_URL`, `CLIPROXYAPI_API_KEY`, `CLIPROXYAPI_HEALTH_URL`, `CODA_OPENCODE_CONFIG_PATH`)
- `completions/coda.bash`, `completions/coda.zsh`: `provider status` completions
- `man/coda.1`, `README.md`, `install.sh`: updated docs and post-install instructions
- `CLIPROXYAPI-OPENCODE-CODA-DESIGN.md`: design doc for the integration