### PR TITLE
fix: coda feature start/done not respecting explicit project name

### DIFF
--- a/shell-functions.sh
+++ b/shell-functions.sh
@@ -839,19 +839,25 @@ _coda_feature_start() {
     fi
 
     local project_root
-    project_root=$(_coda_find_project_root)
-    if [ -z "$project_root" ]; then
-        echo "Not inside a coda project directory."
-        echo "cd into a project first, or run: coda project start --repo <url>"
-        return 1
+    if [ -n "$project_name" ]; then
+        project_root="$PROJECTS_DIR/$project_name"
+        if [ ! -d "$project_root/.bare" ]; then
+            echo "Not a coda project: $project_name"
+            echo "Add it first: coda project start --repo <repo-url>"
+            return 1
+        fi
+    else
+        project_root=$(_coda_find_project_root)
+        if [ -z "$project_root" ]; then
+            echo "Not inside a coda project directory."
+            echo "cd into a project first, or run: coda project start --repo <url>"
+            return 1
+        fi
+        project_name=$(basename "$project_root")
     fi
 
     if [ -z "$base" ]; then
         base=$(_coda_detect_default_branch "$project_root")
-    fi
-
-    if [ -z "$project_name" ]; then
-        project_name=$(basename "$project_root")
     fi
 
     local worktree_dir="$project_root/$branch"
@@ -880,13 +886,19 @@ _coda_feature_done() {
     fi
 
     local project_root
-    project_root=$(_coda_find_project_root)
-    if [ -z "$project_root" ]; then
-        echo "Not inside a coda project directory."
-        return 1
-    fi
-
-    if [ -z "$project_name" ]; then
+    if [ -n "$project_name" ]; then
+        project_root="$PROJECTS_DIR/$project_name"
+        if [ ! -d "$project_root/.bare" ]; then
+            echo "Not a coda project: $project_name"
+            echo "Add it first: coda project start --repo <repo-url>"
+            return 1
+        fi
+    else
+        project_root=$(_coda_find_project_root)
+        if [ -z "$project_root" ]; then
+            echo "Not inside a coda project directory."
+            return 1
+        fi
         project_name=$(basename "$project_root")
     fi
 


### PR DESCRIPTION
## Summary

- `coda feature start <branch> [base] [project]` and `coda feature done <branch> [project]` ignored the `[project]` argument when determining where to create/remove worktrees — they always walked up from `$PWD` via `_coda_find_project_root()`
- Now when a project name is explicitly provided, the project root is resolved as `$PROJECTS_DIR/$project_name` instead
- This means `coda feature start my-feature main coda` from inside `~/projects/ideas` correctly targets `~/projects/coda`

## Testing

- Verified from `~/projects/ideas/main`: `coda feature start test main coda` creates the worktree in `~/projects/coda/test` (not `~/projects/ideas/test`)
- Verified unchanged behavior: `coda feature start test main` (no project arg) still uses `$PWD` to find the project root
- Verified error handling: invalid project name returns error with exit code 1
- Verified `coda feature done test coda` from ideas dir removes from the correct project