### PR TITLE
feat: GitHub App identity for Coda bot comments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,3 +91,15 @@ AUTO_ATTACH_TMUX="true"
 
 # Default tmux session name for auto-attach
 DEFAULT_TMUX_SESSION="default"
+
+# --- GitHub App (Coda bot identity) ---
+
+# GitHub App Client ID (recommended over App ID for JWT issuer)
+# Found at github.com/settings/apps/<app-name> under "About"
+CODA_GITHUB_CLIENT_ID=""
+
+# GitHub App Installation ID (found at github.com/settings/installations)
+CODA_GITHUB_INSTALLATION_ID=""
+
+# Path to the GitHub App private key PEM file
+CODA_GITHUB_PRIVATE_KEY_PATH="$HOME/.config/coda/github-app-private-key.pem"

--- a/cmd/coda-core/github.go
+++ b/cmd/coda-core/github.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+func runGitHub(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: coda-core github <token|comment>")
+	}
+	switch args[0] {
+	case "token":
+		return runGitHubToken(args[1:])
+	case "comment":
+		return runGitHubComment(args[1:])
+	default:
+		return fmt.Errorf("unknown github subcommand: %s", args[0])
+	}
+}
+
+func runGitHubToken(args []string) error {
+	fs := flag.NewFlagSet("github-token", flag.ExitOnError)
+	clientID := fs.String("client-id", "", "GitHub App Client ID (used as JWT issuer)")
+	installationID := fs.String("installation-id", "", "GitHub App Installation ID")
+	keyPath := fs.String("key", "", "Path to private key PEM file")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *clientID == "" || *installationID == "" || *keyPath == "" {
+		return fmt.Errorf("--client-id, --installation-id, and --key are required")
+	}
+
+	privateKey, err := loadPrivateKey(*keyPath)
+	if err != nil {
+		return fmt.Errorf("loading private key: %w", err)
+	}
+
+	jwt, err := signJWT(*clientID, privateKey, time.Now())
+	if err != nil {
+		return fmt.Errorf("signing JWT: %w", err)
+	}
+
+	token, err := exchangeForInstallationToken(jwt, *installationID)
+	if err != nil {
+		return fmt.Errorf("exchanging for installation token: %w", err)
+	}
+
+	fmt.Print(token)
+	return nil
+}
+
+func runGitHubComment(args []string) error {
+	fs := flag.NewFlagSet("github-comment", flag.ExitOnError)
+	clientID := fs.String("client-id", "", "GitHub App Client ID (used as JWT issuer)")
+	installationID := fs.String("installation-id", "", "GitHub App Installation ID")
+	keyPath := fs.String("key", "", "Path to private key PEM file")
+	repo := fs.String("repo", "", "Repository (owner/repo)")
+	issueNum := fs.Int("issue", 0, "Issue or PR number")
+	body := fs.String("body", "", "Comment body (reads stdin if empty)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *clientID == "" || *installationID == "" || *keyPath == "" {
+		return fmt.Errorf("--client-id, --installation-id, and --key are required")
+	}
+	if *repo == "" || *issueNum == 0 {
+		return fmt.Errorf("--repo and --issue are required")
+	}
+
+	commentBody := *body
+	if commentBody == "" {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("reading stdin: %w", err)
+		}
+		commentBody = string(data)
+	}
+	if strings.TrimSpace(commentBody) == "" {
+		return fmt.Errorf("comment body is empty")
+	}
+
+	privateKey, err := loadPrivateKey(*keyPath)
+	if err != nil {
+		return fmt.Errorf("loading private key: %w", err)
+	}
+
+	jwt, err := signJWT(*clientID, privateKey, time.Now())
+	if err != nil {
+		return fmt.Errorf("signing JWT: %w", err)
+	}
+
+	token, err := exchangeForInstallationToken(jwt, *installationID)
+	if err != nil {
+		return fmt.Errorf("getting installation token: %w", err)
+	}
+
+	url := fmt.Sprintf("https://api.github.com/repos/%s/issues/%d/comments", *repo, *issueNum)
+	payload, _ := json.Marshal(map[string]string{"body": commentBody})
+
+	req, err := http.NewRequest("POST", url, strings.NewReader(string(payload)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("posting comment: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("GitHub API returned HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		HTMLURL string `json:"html_url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err == nil && result.HTMLURL != "" {
+		fmt.Println(result.HTMLURL)
+	} else {
+		fmt.Println("Comment posted.")
+	}
+	return nil
+}
+
+func loadPrivateKey(path string) (*rsa.PrivateKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found in %s", path)
+	}
+
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing private key: %w", err)
+	}
+	key, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("private key is not RSA")
+	}
+	return key, nil
+}
+
+func signJWT(clientID string, key *rsa.PrivateKey, now time.Time) (string, error) {
+	header := map[string]string{"alg": "RS256", "typ": "JWT"}
+	payload := map[string]interface{}{
+		"iat": now.Add(-60 * time.Second).Unix(),
+		"exp": now.Add(10 * time.Minute).Unix(),
+		"iss": clientID,
+	}
+
+	headerJSON, _ := json.Marshal(header)
+	payloadJSON, _ := json.Marshal(payload)
+
+	headerB64 := base64URLEncode(headerJSON)
+	payloadB64 := base64URLEncode(payloadJSON)
+
+	signingInput := headerB64 + "." + payloadB64
+
+	h := crypto.SHA256.New()
+	h.Write([]byte(signingInput))
+	hashed := h.Sum(nil)
+
+	signature, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, hashed)
+	if err != nil {
+		return "", err
+	}
+
+	return signingInput + "." + base64URLEncode(signature), nil
+}
+
+func exchangeForInstallationToken(jwt, installationID string) (string, error) {
+	url := fmt.Sprintf("https://api.github.com/app/installations/%s/access_tokens", installationID)
+
+	req, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+jwt)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("GitHub API returned HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Token     string `json:"token"`
+		ExpiresAt string `json:"expires_at"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("parsing response: %w", err)
+	}
+	if result.Token == "" {
+		return "", fmt.Errorf("no token in response")
+	}
+
+	return result.Token, nil
+}
+
+func base64URLEncode(data []byte) string {
+	return strings.TrimRight(base64.URLEncoding.EncodeToString(data), "=")
+}

--- a/cmd/coda-core/github_test.go
+++ b/cmd/coda-core/github_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func generateTestKey(t *testing.T) (*rsa.PrivateKey, string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "test-key.pem")
+	if err := os.WriteFile(keyPath, keyPEM, 0600); err != nil {
+		t.Fatalf("writing key: %v", err)
+	}
+
+	return key, keyPath
+}
+
+func TestSignJWT(t *testing.T) {
+	key, _ := generateTestKey(t)
+	now := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	jwt, err := signJWT("12345", key, now)
+	if err != nil {
+		t.Fatalf("signJWT: %v", err)
+	}
+
+	parts := strings.Split(jwt, ".")
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 JWT parts, got %d", len(parts))
+	}
+
+	headerJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		t.Fatalf("decoding header: %v", err)
+	}
+	var header map[string]string
+	if err := json.Unmarshal(headerJSON, &header); err != nil {
+		t.Fatalf("parsing header: %v", err)
+	}
+	if header["alg"] != "RS256" || header["typ"] != "JWT" {
+		t.Errorf("unexpected header: %v", header)
+	}
+
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decoding payload: %v", err)
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(payloadJSON, &payload); err != nil {
+		t.Fatalf("parsing payload: %v", err)
+	}
+	if payload["iss"] != "12345" {
+		t.Errorf("expected iss=12345, got %v", payload["iss"])
+	}
+
+	iat := int64(payload["iat"].(float64))
+	exp := int64(payload["exp"].(float64))
+	expectedIAT := now.Add(-60 * time.Second).Unix()
+	expectedEXP := now.Add(10 * time.Minute).Unix()
+	if iat != expectedIAT {
+		t.Errorf("iat: expected %d, got %d", expectedIAT, iat)
+	}
+	if exp != expectedEXP {
+		t.Errorf("exp: expected %d, got %d", expectedEXP, exp)
+	}
+}
+
+func TestLoadPrivateKey_PKCS1(t *testing.T) {
+	_, keyPath := generateTestKey(t)
+
+	loaded, err := loadPrivateKey(keyPath)
+	if err != nil {
+		t.Fatalf("loadPrivateKey: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected non-nil key")
+	}
+}
+
+func TestLoadPrivateKey_MissingFile(t *testing.T) {
+	_, err := loadPrivateKey("/nonexistent/key.pem")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestLoadPrivateKey_InvalidPEM(t *testing.T) {
+	tmpDir := t.TempDir()
+	badPath := filepath.Join(tmpDir, "bad.pem")
+	os.WriteFile(badPath, []byte("not a pem file"), 0600)
+
+	_, err := loadPrivateKey(badPath)
+	if err == nil {
+		t.Fatal("expected error for invalid PEM")
+	}
+}
+
+func TestExchangeForInstallationToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		auth := r.Header.Get("Authorization")
+		if !strings.HasPrefix(auth, "Bearer ") {
+			t.Errorf("missing Bearer token")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"token":      "ghs_test_token_123",
+			"expires_at": "2025-01-15T13:00:00Z",
+		})
+	}))
+	defer server.Close()
+
+	req, _ := http.NewRequest("POST", server.URL, nil)
+	req.Header.Set("Authorization", "Bearer test-jwt")
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result.Token != "ghs_test_token_123" {
+		t.Errorf("expected ghs_test_token_123, got %s", result.Token)
+	}
+}

--- a/cmd/coda-core/main.go
+++ b/cmd/coda-core/main.go
@@ -19,6 +19,8 @@ func main() {
 		err = runProvider(os.Args[2:])
 	case "watch":
 		err = runWatch(os.Args[2:])
+	case "github":
+		err = runGitHub(os.Args[2:])
 	case "help", "--help", "-h":
 		printUsage()
 	default:
@@ -42,5 +44,7 @@ Commands:
   layout snapshot    Capture current tmux layout as a reusable layout script
   provider auth      Configure CLIProxyAPI provider in OpenCode config
   provider status    Show provider diagnostics
-  watch              Monitor OpenCode sessions and notify on attention needed`)
+  watch              Monitor OpenCode sessions and notify on attention needed
+  github token       Generate a GitHub App installation access token
+  github comment     Post a comment as the GitHub App identity`)
 }

--- a/completions/coda.bash
+++ b/completions/coda.bash
@@ -63,7 +63,7 @@ _coda_complete() {
         cword=$COMP_CWORD
     }
 
-    local top_subcommands="attach ls switch serve auth project feature layout profile watch provider help"
+    local top_subcommands="attach ls switch serve auth project feature layout profile watch provider github help"
 
     # Word positions:
     #   words[0] = coda
@@ -132,6 +132,9 @@ _coda_complete() {
                     ;;
                 provider)
                     COMPREPLY=($(compgen -W "status" -- "$cur"))
+                    ;;
+                github)
+                    COMPREPLY=($(compgen -W "token comment status" -- "$cur"))
                     ;;
                 attach)
                     local sessions

--- a/completions/coda.zsh
+++ b/completions/coda.zsh
@@ -76,6 +76,7 @@ _coda() {
                 'profile:manage config profiles'
                 'watch:monitor sessions for attention signals'
                 'provider:manage provider status'
+                'github:post comments as Coda bot identity'
                 'help:show usage'
             )
             # Add existing sessions as completions
@@ -108,6 +109,9 @@ _coda() {
                     ;;
                 provider)
                     _coda_provider_args
+                    ;;
+                github)
+                    _coda_github_args
                     ;;
                 serve)
                     local base="${OPENCODE_BASE_PORT:-4096}"
@@ -330,6 +334,25 @@ _coda_provider_args() {
                 'status:show provider status'
             )
             _describe 'provider subcommand' subcmds
+            ;;
+    esac
+}
+
+_coda_github_args() {
+    local state line
+    _arguments -C \
+        '1: :->subcmd' \
+        && return 0
+
+    case $state in
+        subcmd)
+            local -a subcmds
+            subcmds=(
+                'token:print a GitHub App installation access token'
+                'comment:post a comment as Coda bot'
+                'status:check GitHub App configuration'
+            )
+            _describe 'github subcommand' subcmds
             ;;
     esac
 }

--- a/install.sh
+++ b/install.sh
@@ -367,7 +367,11 @@ fi
 
 step "[12/13] coda-core binary"
 
-if [ -f "$SCRIPT_DIR/coda-core" ] && [ "$SCRIPT_DIR/coda-core" -nt "$SCRIPT_DIR/cmd/coda-core/main.go" ]; then
+_coda_core_stale=false
+for _gofile in "$SCRIPT_DIR"/cmd/coda-core/*.go; do
+    [ -f "$_gofile" ] && [ "$_gofile" -nt "$SCRIPT_DIR/coda-core" ] && _coda_core_stale=true
+done
+if [ -f "$SCRIPT_DIR/coda-core" ] && [ "$_coda_core_stale" = "false" ]; then
     ok "coda-core — up to date"
 elif command -v go &>/dev/null; then
     info "Building coda-core..."

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -46,6 +46,7 @@ coda() {
         layout)           _coda_layout_cmd "${args[@]:1}"; status=$? ;;
         profile)          _coda_profile_cmd "${args[@]:1}"; status=$? ;;
         watch)            _coda_watch "${args[@]:1}"; status=$? ;;
+        github)           _coda_github "${args[@]:1}"; status=$? ;;
         help|--help|-h)   _coda_help; status=$? ;;
         "")               _coda_attach; status=$? ;;
         *)                _coda_attach "${args[0]#"$SESSION_PREFIX"}" "${args[@]:1}"; status=$? ;;
@@ -203,6 +204,10 @@ USAGE
   coda watch                       Start monitoring sessions (bell on idle)
   coda watch stop                  Stop the watcher
   coda watch status                Check if watcher is running
+
+  coda github token                Print a GitHub App installation token
+  coda github comment --issue N    Post a comment as Coda [bot]
+  coda github status               Check GitHub App configuration
 
   coda help                   Show this help
 

--- a/lib/github.sh
+++ b/lib/github.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# github.sh — GitHub App identity for bot comments
+#
+
+CODA_GITHUB_CLIENT_ID="${CODA_GITHUB_CLIENT_ID:-}"
+CODA_GITHUB_INSTALLATION_ID="${CODA_GITHUB_INSTALLATION_ID:-}"
+CODA_GITHUB_PRIVATE_KEY_PATH="${CODA_GITHUB_PRIVATE_KEY_PATH:-$HOME/.config/coda/github-app-private-key.pem}"
+
+_coda_github() {
+    local subcmd="${1:-}"
+    shift 2>/dev/null || true
+
+    case "$subcmd" in
+        token)    _coda_github_token "$@" ;;
+        comment)  _coda_github_comment "$@" ;;
+        status)   _coda_github_status ;;
+        *)        _coda_github_help; return 1 ;;
+    esac
+}
+
+_coda_github_check_config() {
+    if [ -z "$CODA_GITHUB_CLIENT_ID" ]; then
+        echo "CODA_GITHUB_CLIENT_ID is not set. Add it to your .env file."
+        return 1
+    fi
+    if [ -z "$CODA_GITHUB_INSTALLATION_ID" ]; then
+        echo "CODA_GITHUB_INSTALLATION_ID is not set. Add it to your .env file."
+        return 1
+    fi
+    if [ ! -f "$CODA_GITHUB_PRIVATE_KEY_PATH" ]; then
+        echo "Private key not found: $CODA_GITHUB_PRIVATE_KEY_PATH"
+        echo "Download it from GitHub App settings and place it there."
+        return 1
+    fi
+    if ! command -v coda-core &>/dev/null; then
+        echo "coda-core not found. Run install.sh to build it."
+        return 1
+    fi
+}
+
+_coda_github_token() {
+    _coda_github_check_config || return 1
+
+    coda-core github token \
+        --client-id "$CODA_GITHUB_CLIENT_ID" \
+        --installation-id "$CODA_GITHUB_INSTALLATION_ID" \
+        --key "$CODA_GITHUB_PRIVATE_KEY_PATH"
+}
+
+_coda_github_comment() {
+    _coda_github_check_config || return 1
+
+    local repo="" issue="" body=""
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --repo|-r)   repo="$2"; shift 2 ;;
+            --issue|-i)  issue="$2"; shift 2 ;;
+            --body|-b)   body="$2"; shift 2 ;;
+            *)           shift ;;
+        esac
+    done
+
+    if [ -z "$repo" ]; then
+        repo=$(_coda_github_detect_repo)
+        if [ -z "$repo" ]; then
+            echo "Could not detect repository. Use --repo owner/repo."
+            return 1
+        fi
+    fi
+
+    if [ -z "$issue" ]; then
+        echo "--issue is required."
+        return 1
+    fi
+
+    local comment_args=(
+        --client-id "$CODA_GITHUB_CLIENT_ID"
+        --installation-id "$CODA_GITHUB_INSTALLATION_ID"
+        --key "$CODA_GITHUB_PRIVATE_KEY_PATH"
+        --repo "$repo"
+        --issue "$issue"
+    )
+
+    if [ -n "$body" ]; then
+        comment_args+=(--body "$body")
+        coda-core github comment "${comment_args[@]}"
+    else
+        coda-core github comment "${comment_args[@]}"
+    fi
+}
+
+_coda_github_detect_repo() {
+    local remote_url
+    remote_url=$(git remote get-url "${GIT_REMOTE:-origin}" 2>/dev/null) || return
+
+    remote_url="${remote_url%.git}"
+    if [[ "$remote_url" =~ github\.com[:/]([^/]+/[^/]+)$ ]]; then
+        echo "${BASH_REMATCH[1]}"
+    fi
+}
+
+_coda_github_status() {
+    echo "GitHub App Configuration:"
+    echo "  Client ID:       ${CODA_GITHUB_CLIENT_ID:-<not set>}"
+    echo "  Installation ID: ${CODA_GITHUB_INSTALLATION_ID:-<not set>}"
+    echo "  Private key:     $CODA_GITHUB_PRIVATE_KEY_PATH"
+
+    if [ -f "$CODA_GITHUB_PRIVATE_KEY_PATH" ]; then
+        echo "  Key file:        found"
+    else
+        echo "  Key file:        missing"
+    fi
+
+    if command -v coda-core &>/dev/null; then
+        echo "  coda-core:       found"
+    else
+        echo "  coda-core:       missing"
+    fi
+
+    if [ -n "$CODA_GITHUB_CLIENT_ID" ] && [ -n "$CODA_GITHUB_INSTALLATION_ID" ] && \
+       [ -f "$CODA_GITHUB_PRIVATE_KEY_PATH" ] && command -v coda-core &>/dev/null; then
+        echo ""
+        echo "Testing token generation..."
+        local token
+        if token=$(_coda_github_token 2>&1); then
+            echo "  Token: OK (${#token} chars)"
+        else
+            echo "  Token: FAILED"
+            echo "  $token"
+        fi
+    fi
+}
+
+_coda_github_help() {
+    cat <<'EOF'
+coda github — post comments as the Coda bot identity
+
+USAGE
+  coda github token                            Print an installation access token
+  coda github comment --issue N [--repo R] [--body B]
+                                                Post a comment (reads stdin if no --body)
+  coda github status                           Check configuration and test token
+
+OPTIONS
+  --repo, -r   owner/repo  (auto-detected from git remote if omitted)
+  --issue, -i  Issue or PR number
+  --body, -b   Comment text (reads stdin if omitted)
+
+CONFIGURATION (.env)
+  CODA_GITHUB_CLIENT_ID            GitHub App Client ID (recommended over App ID)
+  CODA_GITHUB_INSTALLATION_ID      Installation ID
+  CODA_GITHUB_PRIVATE_KEY_PATH     Path to PEM file (default: ~/.config/coda/github-app-private-key.pem)
+EOF
+}

--- a/shell-functions.sh
+++ b/shell-functions.sh
@@ -34,7 +34,7 @@ CLIPROXYAPI_HEALTH_URL="${CLIPROXYAPI_HEALTH_URL:-}"
 CLIPROXYAPI_API_KEY="${CLIPROXYAPI_API_KEY:-}"
 
 # Load modules
-for _coda_mod in helpers hooks core project feature layout provider profile watch; do
+for _coda_mod in helpers hooks core project feature layout provider profile watch github; do
     # shellcheck source=/dev/null
     source "$_CODA_DIR/lib/${_coda_mod}.sh"
 done


### PR DESCRIPTION
## Summary

- Add `coda github` subcommand (token, comment, status) so Coda can post GitHub comments under its own App identity — comments appear as **Coda [bot]** instead of the human user
- Go implementation uses stdlib-only RS256 JWT signing (no external dependencies) to generate short-lived installation access tokens
- Shell wrappers auto-detect the repo from git remote, support `--body` or stdin, and include bash/zsh tab completions

## Details

### New files
- `cmd/coda-core/github.go` — JWT signing, token exchange, comment posting via GitHub REST API
- `cmd/coda-core/github_test.go` — Unit tests for key loading, JWT structure, and token exchange
- `lib/github.sh` — Shell functions: `_coda_github_token`, `_coda_github_comment`, `_coda_github_status`

### Modified files
- `.env.example` — Added `CODA_GITHUB_CLIENT_ID`, `CODA_GITHUB_INSTALLATION_ID`, `CODA_GITHUB_PRIVATE_KEY_PATH`
- `cmd/coda-core/main.go` — Registered `github` subcommand
- `lib/core.sh` — Added `github` to dispatch table and help text
- `shell-functions.sh` — Added `github` to module loader
- `completions/coda.bash` + `completions/coda.zsh` — Tab completion for `coda github`
- `install.sh` — Fixed `coda-core` staleness check to compare all `*.go` files (not just `main.go`)

### Auth flow
Uses the GitHub-recommended Client ID as JWT issuer (`iss` claim) per [current docs](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app).

### Tested
- All Go tests pass (18/18)
- Shell lifecycle tests pass
- End-to-end token generation verified against live GitHub API