### PR TITLE
fix: bot snark deficiency and install.sh staleness detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -368,10 +368,21 @@ fi
 step "[12/13] coda-core binary"
 
 _coda_core_stale=false
-for _gofile in "$SCRIPT_DIR"/cmd/coda-core/*.go; do
-    [ -f "$_gofile" ] && [ "$_gofile" -nt "$SCRIPT_DIR/coda-core" ] && _coda_core_stale=true
-done
-if [ -f "$SCRIPT_DIR/coda-core" ] && [ "$_coda_core_stale" = "false" ]; then
+_coda_core_installed="$HOME/.local/bin/coda-core"
+if [ ! -f "$_coda_core_installed" ]; then
+    # No installed binary at all
+    _coda_core_stale=true
+elif [ ! -f "$SCRIPT_DIR/coda-core" ]; then
+    # No local build artifact — need to rebuild
+    _coda_core_stale=true
+else
+    for _gofile in "$SCRIPT_DIR"/cmd/coda-core/*.go; do
+        [ -f "$_gofile" ] && [ "$_gofile" -nt "$SCRIPT_DIR/coda-core" ] && _coda_core_stale=true
+    done
+    # Also stale if local build is newer than installed copy
+    [ "$SCRIPT_DIR/coda-core" -nt "$_coda_core_installed" ] && _coda_core_stale=true
+fi
+if [ "$_coda_core_stale" = "false" ]; then
     ok "coda-core — up to date"
 elif command -v go &>/dev/null; then
     info "Building coda-core..."

--- a/install.sh
+++ b/install.sh
@@ -369,18 +369,18 @@ step "[12/13] coda-core binary"
 
 _coda_core_stale=false
 _coda_core_installed="$HOME/.local/bin/coda-core"
+mkdir -p "$(dirname "$_coda_core_installed")"
 if [ ! -f "$_coda_core_installed" ]; then
-    # No installed binary at all
     _coda_core_stale=true
-elif [ ! -f "$SCRIPT_DIR/coda-core" ]; then
-    # No local build artifact — need to rebuild
-    _coda_core_stale=true
-else
+elif [ -f "$SCRIPT_DIR/coda-core" ]; then
     for _gofile in "$SCRIPT_DIR"/cmd/coda-core/*.go; do
         [ -f "$_gofile" ] && [ "$_gofile" -nt "$SCRIPT_DIR/coda-core" ] && _coda_core_stale=true
     done
-    # Also stale if local build is newer than installed copy
     [ "$SCRIPT_DIR/coda-core" -nt "$_coda_core_installed" ] && _coda_core_stale=true
+else
+    for _gofile in "$SCRIPT_DIR"/cmd/coda-core/*.go; do
+        [ -f "$_gofile" ] && [ "$_gofile" -nt "$_coda_core_installed" ] && _coda_core_stale=true
+    done
 fi
 if [ "$_coda_core_stale" = "false" ]; then
     ok "coda-core — up to date"


### PR DESCRIPTION
## Summary

- **Fix install.sh coda-core staleness detection** u2014 the previous logic only compared `.go` file timestamps against the local build artifact, missing three failure modes: installed binary absent, local build artifact absent (fresh clone/checkout), and local build newer than installed copy
- **Rewrite copilot-review-watcher skill tone instructions** (local opencode-skills change, not in this diff) u2014 restructured SKILL.md so personality is established first, encoded snark requirements into every action step, added explicit anti-pattern examples ("Good catch!" = bad), and removed the escape hatch that let agents default to polite

## Testing

Trigger a Copilot review on this PR, then invoke the copilot-review-watcher skill to validate the new tone instructions produce actually snarky replies.

## Context

Focus item 17. The bot replies on PR #29 were too polite ("Good catch", "Fair point") despite the skill already having snark instructions. Root cause: tone section was buried after procedural framing, agents deprioritized it as optional style guidance.