### PR TITLE
feat: add MCP server install step and smoke tests

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -389,7 +389,7 @@ fi
 
 step "[13/14] MCP server"
 
-MCP_DIR="$SCRIPT_DIR/mcp-server"
+MCP_DIR="$STABLE_DIR/mcp-server"
 OPENCODE_CONFIG="$HOME/.config/opencode/opencode.json"
 MCP_SERVER_PATH="$STABLE_DIR/mcp-server/server.js"
 

--- a/install.sh
+++ b/install.sh
@@ -107,7 +107,7 @@ echo ""
 # 1. System packages
 # ===========================================================================
 
-step "[1/13] System packages"
+step "[1/14] System packages"
 
 sudo apt-get update -qq
 sudo apt-get upgrade -y -qq
@@ -131,7 +131,7 @@ ok "Core packages installed"
 # 2. Neovim
 # ===========================================================================
 
-step "[2/13] Neovim (>= ${NVIM_MIN_VERSION})"
+step "[2/14] Neovim (>= ${NVIM_MIN_VERSION})"
 
 NVIM_INSTALLED_VERSION=""
 if command -v nvim &>/dev/null; then
@@ -166,7 +166,7 @@ fi
 # 3. Node.js
 # ===========================================================================
 
-step "[3/13] Node.js ${NODE_MAJOR_VERSION}"
+step "[3/14] Node.js ${NODE_MAJOR_VERSION}"
 
 INSTALLED_NODE_MAJOR=0
 if command -v node &>/dev/null; then
@@ -191,7 +191,7 @@ fi
 # 4. OpenCode
 # ===========================================================================
 
-step "[4/13] OpenCode"
+step "[4/14] OpenCode"
 
 mkdir -p ~/.npm-global
 npm config set prefix '~/.npm-global'
@@ -212,7 +212,7 @@ fi
 # 5. Claude Code CLI
 # ===========================================================================
 
-step "[5/13] Claude Code CLI"
+step "[5/14] Claude Code CLI"
 
 if [ "$SKIP_CLAUDE" = "true" ]; then
     info "Skipping (SKIP_CLAUDE=true)"
@@ -228,7 +228,7 @@ fi
 # 6. fzf
 # ===========================================================================
 
-step "[6/13] fzf"
+step "[6/14] fzf"
 
 if command -v fzf &>/dev/null; then
     ok "fzf $(fzf --version 2>/dev/null | head -1) — already installed"
@@ -250,7 +250,7 @@ fi
 # 7. yazi (terminal file manager — used by four-pane layout)
 # ===========================================================================
 
-step "[7/13] yazi"
+step "[7/14] yazi"
 
 if [ "$SKIP_YAZI" = "true" ]; then
     info "Skipping (SKIP_YAZI=true)"
@@ -280,7 +280,7 @@ fi
 # 8. lazygit (terminal git UI — used by four-pane layout)
 # ===========================================================================
 
-step "[8/13] lazygit"
+step "[8/14] lazygit"
 
 if [ "$SKIP_LAZYGIT" = "true" ]; then
     info "Skipping (SKIP_LAZYGIT=true)"
@@ -311,7 +311,7 @@ fi
 # 9. Oh My Posh
 # ===========================================================================
 
-step "[9/13] Oh My Posh"
+step "[9/14] Oh My Posh"
 
 if [ "$SKIP_OHMYPOSH" = "true" ]; then
     info "Skipping (SKIP_OHMYPOSH=true)"
@@ -328,7 +328,7 @@ fi
 # 10. tmux Plugin Manager (TPM)
 # ===========================================================================
 
-step "[10/13] tmux Plugin Manager (TPM)"
+step "[10/14] tmux Plugin Manager (TPM)"
 
 TPM_DIR="$HOME/.tmux/plugins/tpm"
 
@@ -349,7 +349,7 @@ fi
 # 11. Tailscale
 # ===========================================================================
 
-step "[11/13] Tailscale"
+step "[11/14] Tailscale"
 
 if [ "$SKIP_TAILSCALE" = "true" ]; then
     info "Skipping (SKIP_TAILSCALE=true)"
@@ -365,7 +365,7 @@ fi
 # 12. coda-core (Go helper binary)
 # ===========================================================================
 
-step "[12/13] coda-core binary"
+step "[12/14] coda-core binary"
 
 _coda_core_stale=false
 for _gofile in "$SCRIPT_DIR"/cmd/coda-core/*.go; do
@@ -384,10 +384,55 @@ else
 fi
 
 # ===========================================================================
-# 13. Config files, shell integration, SSH
+# 13. MCP server (exposes coda tools to OpenCode agents)
 # ===========================================================================
 
-step "[13/13] Config files, completions, and man page"
+step "[13/14] MCP server"
+
+MCP_DIR="$SCRIPT_DIR/mcp-server"
+OPENCODE_CONFIG="$HOME/.config/opencode/opencode.json"
+MCP_SERVER_PATH="$STABLE_DIR/mcp-server/server.js"
+
+if [ -d "$MCP_DIR" ] && command -v node &>/dev/null; then
+    if [ ! -d "$MCP_DIR/node_modules" ] || [ "$MCP_DIR/package.json" -nt "$MCP_DIR/node_modules/.package-lock.json" ]; then
+        info "Installing MCP server dependencies..."
+        (cd "$MCP_DIR" && npm install --no-fund --no-audit --loglevel=error)
+        ok "MCP server dependencies installed"
+    else
+        ok "MCP server dependencies — up to date"
+    fi
+
+    mkdir -p "$HOME/.config/opencode"
+    if [ ! -f "$OPENCODE_CONFIG" ]; then
+        printf '{\n  "$schema": "https://opencode.ai/config.json",\n  "mcp": {}\n}\n' > "$OPENCODE_CONFIG"
+    fi
+
+    if command -v jq &>/dev/null; then
+        _mcp_current=$(jq -r '.mcp.coda.command[1] // ""' "$OPENCODE_CONFIG" 2>/dev/null || true)
+        if [ "$_mcp_current" = "$MCP_SERVER_PATH" ]; then
+            ok "MCP server — already registered in opencode.json"
+        else
+            jq --arg path "$MCP_SERVER_PATH" '.mcp.coda = {"type": "local", "command": ["node", $path], "enabled": true}' \
+                "$OPENCODE_CONFIG" > "$OPENCODE_CONFIG.tmp" && mv "$OPENCODE_CONFIG.tmp" "$OPENCODE_CONFIG"
+            ok "MCP server registered in opencode.json"
+        fi
+    else
+        info "jq not found — skipping opencode.json MCP registration"
+        info "Add manually: {\"mcp\":{\"coda\":{\"type\":\"local\",\"command\":[\"node\",\"$MCP_SERVER_PATH\"],\"enabled\":true}}}"
+    fi
+else
+    if [ ! -d "$MCP_DIR" ]; then
+        info "MCP server directory not found — skipping"
+    else
+        info "Node.js not found — skipping MCP server setup"
+    fi
+fi
+
+# ===========================================================================
+# 14. Config files, shell integration, SSH
+# ===========================================================================
+
+step "[14/14] Config files, completions, and man page"
 
 # --- tmux config ---
 

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -4,7 +4,8 @@
   "description": "MCP server exposing coda CLI tools to OpenCode agents",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "bash test.sh"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp-server/test.sh
+++ b/mcp-server/test.sh
@@ -91,7 +91,7 @@ err_response=$(mcp_call '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":
 if echo "$err_response" | grep -qi 'error\|exit code\|invalid\|required'; then
     pass "Bad args handled gracefully"
 else
-    pass "Server responded to bad args call"
+    fail "Bad args call did not return an error response"
 fi
 
 # --- Summary ---

--- a/mcp-server/test.sh
+++ b/mcp-server/test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# test.sh — Smoke test for the coda MCP server
+#
+# Verifies the server starts, registers all expected tools, and can
+# execute a live tool call (coda_ls).
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVER="$SCRIPT_DIR/server.js"
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); echo "  [pass] $*"; }
+fail() { FAIL=$((FAIL + 1)); echo "  [FAIL] $*"; }
+
+# --- Check deps ---
+if [ ! -d "$SCRIPT_DIR/node_modules" ]; then
+    echo "node_modules missing. Run: npm install" >&2
+    exit 1
+fi
+
+# --- Helper: send JSON-RPC messages and capture response ---
+mcp_call() {
+    local init='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}'
+    local notify='{"jsonrpc":"2.0","method":"notifications/initialized"}'
+    printf '%s\n%s\n%s\n' "$init" "$notify" "$1" | timeout 10 node "$SERVER" 2>/dev/null
+}
+
+echo "MCP Server Tests"
+echo "================="
+echo ""
+
+# --- Test 1: Server initializes ---
+echo "1. Server initialization"
+response=$(printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}\n' | timeout 5 node "$SERVER" 2>/dev/null || true)
+if echo "$response" | grep -q '"name":"coda"'; then
+    pass "Server starts and identifies as 'coda'"
+else
+    fail "Server did not return expected identity"
+fi
+
+# --- Test 2: All tools registered ---
+echo "2. Tool registration"
+tools_response=$(mcp_call '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' | tail -1)
+
+EXPECTED_TOOLS=(
+    coda_ls
+    coda_project_ls
+    coda_feature_ls
+    coda_feature_start
+    coda_feature_done
+    coda_feature_finish
+    coda_project_clone
+    coda_project_create
+    coda_project_workon
+    coda_project_close
+    coda_watch_status
+    coda_watch_start
+    coda_watch_stop
+    coda_provider_status
+    coda_layout_ls
+    coda_layout_show
+    coda_help
+)
+
+missing=0
+for tool in "${EXPECTED_TOOLS[@]}"; do
+    if ! echo "$tools_response" | grep -q "\"$tool\""; then
+        fail "Missing tool: $tool"
+        missing=$((missing + 1))
+    fi
+done
+if [ "$missing" -eq 0 ]; then
+    pass "All ${#EXPECTED_TOOLS[@]} tools registered"
+fi
+
+# --- Test 3: Live tool call (coda_ls) ---
+echo "3. Live tool call"
+ls_response=$(mcp_call '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"coda_ls","arguments":{}}}' | tail -1)
+if echo "$ls_response" | grep -q '"type":"text"'; then
+    pass "coda_ls returned text content"
+else
+    fail "coda_ls did not return expected format"
+fi
+
+# --- Test 4: Tool call with bad args returns error gracefully ---
+echo "4. Error handling"
+err_response=$(mcp_call '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"coda_layout_show","arguments":{}}}' | tail -1)
+if echo "$err_response" | grep -qi 'error\|exit code\|invalid\|required'; then
+    pass "Bad args handled gracefully"
+else
+    pass "Server responded to bad args call"
+fi
+
+# --- Summary ---
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- Adds install.sh step 13/14 that runs `npm install` for the MCP server and wires it into `~/.config/opencode/opencode.json` via `jq` (idempotent, uses `$STABLE_DIR` so the path survives worktree deletion)
- Adds `mcp-server/test.sh` smoke test covering server init, all 17 tool registrations, a live `coda_ls` call, and error handling
- Adds `npm test` script to `mcp-server/package.json`