### PR TITLE
feat: declarative YAML layout configuration DSL

### DIFF
--- a/cmd/coda-core/layout.go
+++ b/cmd/coda-core/layout.go
@@ -12,11 +12,13 @@ import (
 
 func runLayout(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: coda-core layout snapshot --name <name> --output <file>")
+		return fmt.Errorf("usage: coda-core layout <snapshot|render> [args]")
 	}
 	switch args[0] {
 	case "snapshot":
 		return runLayoutSnapshot(args[1:])
+	case "render":
+		return runLayoutRender(args[1:])
 	default:
 		return fmt.Errorf("unknown layout subcommand: %s", args[0])
 	}
@@ -26,6 +28,7 @@ func runLayoutSnapshot(args []string) error {
 	fs := flag.NewFlagSet("layout-snapshot", flag.ExitOnError)
 	name := fs.String("name", "", "Layout name")
 	output := fs.String("output", "", "Output file path")
+	format := fs.String("format", "sh", "Output format: sh or yaml")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -38,9 +41,18 @@ func runLayoutSnapshot(args []string) error {
 		return err
 	}
 
-	script := generateLayoutScript(*name, snap)
-	if err := os.WriteFile(*output, []byte(script), 0755); err != nil {
-		return fmt.Errorf("writing layout file: %w", err)
+	switch *format {
+	case "yaml", "yml":
+		if err := writeLayoutYAML(snap, *output); err != nil {
+			return err
+		}
+	case "sh", "":
+		script := generateLayoutScript(*name, snap)
+		if err := os.WriteFile(*output, []byte(script), 0755); err != nil {
+			return fmt.Errorf("writing layout file: %w", err)
+		}
+	default:
+		return fmt.Errorf("unknown format %q (use 'sh' or 'yaml')", *format)
 	}
 
 	fmt.Printf("Snapshot saved: %s\n", *output)

--- a/cmd/coda-core/layout_config.go
+++ b/cmd/coda-core/layout_config.go
@@ -36,13 +36,6 @@ func (p *PaneConfig) IsLeaf() bool {
 	return len(p.Panes) == 0
 }
 
-func (p *PaneConfig) ResolvedCommand() string {
-	if p.Command != "" {
-		return p.Command
-	}
-	return ""
-}
-
 func parseLayoutConfig(path string) (*LayoutConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/cmd/coda-core/layout_config.go
+++ b/cmd/coda-core/layout_config.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type LayoutConfig struct {
+	Direction string        `yaml:"direction"`
+	Panes     []PaneConfig  `yaml:"panes"`
+	Border    *BorderConfig `yaml:"border,omitempty"`
+}
+
+type PaneConfig struct {
+	Command   string            `yaml:"command,omitempty"`
+	Prefer    []string          `yaml:"prefer,omitempty"`
+	Title     string            `yaml:"title,omitempty"`
+	Env       map[string]string `yaml:"env,omitempty"`
+	Direction string            `yaml:"direction,omitempty"`
+	Panes     []PaneConfig      `yaml:"panes,omitempty"`
+	Size      string            `yaml:"size,omitempty"`
+}
+
+type BorderConfig struct {
+	Status      string `yaml:"status,omitempty"`
+	Lines       string `yaml:"lines,omitempty"`
+	Style       string `yaml:"style,omitempty"`
+	ActiveStyle string `yaml:"active_style,omitempty"`
+	Format      string `yaml:"format,omitempty"`
+}
+
+func (p *PaneConfig) IsLeaf() bool {
+	return len(p.Panes) == 0
+}
+
+func (p *PaneConfig) ResolvedCommand() string {
+	if p.Command != "" {
+		return p.Command
+	}
+	return ""
+}
+
+func parseLayoutConfig(path string) (*LayoutConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading layout config: %w", err)
+	}
+	return parseLayoutConfigBytes(data)
+}
+
+func parseLayoutConfigBytes(data []byte) (*LayoutConfig, error) {
+	var cfg LayoutConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing layout YAML: %w", err)
+	}
+
+	if err := validateLayoutConfig(&cfg); err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
+}
+
+func validateLayoutConfig(cfg *LayoutConfig) error {
+	if len(cfg.Panes) == 0 {
+		return fmt.Errorf("layout must have at least one pane")
+	}
+
+	dir := normalizeDirection(cfg.Direction)
+	if dir == "" {
+		return fmt.Errorf("layout direction must be 'horizontal' or 'vertical' (got %q)", cfg.Direction)
+	}
+	cfg.Direction = dir
+
+	for i := range cfg.Panes {
+		if err := validatePaneConfig(&cfg.Panes[i], fmt.Sprintf("panes[%d]", i)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validatePaneConfig(p *PaneConfig, path string) error {
+	if p.IsLeaf() {
+		if p.Command != "" && len(p.Prefer) > 0 {
+			return fmt.Errorf("%s: cannot specify both 'command' and 'prefer'", path)
+		}
+	} else {
+		if p.Command != "" || len(p.Prefer) > 0 {
+			return fmt.Errorf("%s: split pane cannot have 'command' or 'prefer'", path)
+		}
+		dir := normalizeDirection(p.Direction)
+		if dir == "" {
+			return fmt.Errorf("%s: split direction must be 'horizontal' or 'vertical' (got %q)", path, p.Direction)
+		}
+		p.Direction = dir
+
+		for i := range p.Panes {
+			if err := validatePaneConfig(&p.Panes[i], fmt.Sprintf("%s.panes[%d]", path, i)); err != nil {
+				return err
+			}
+		}
+	}
+
+	if p.Size != "" {
+		if err := validateSize(p.Size); err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+	}
+
+	return nil
+}
+
+func normalizeDirection(d string) string {
+	switch strings.ToLower(d) {
+	case "horizontal", "h":
+		return "horizontal"
+	case "vertical", "v":
+		return "vertical"
+	case "":
+		return ""
+	default:
+		return ""
+	}
+}
+
+func validateSize(s string) error {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	if strings.HasSuffix(s, "%") {
+		numStr := strings.TrimSuffix(s, "%")
+		var pct int
+		if _, err := fmt.Sscanf(numStr, "%d", &pct); err != nil {
+			return fmt.Errorf("invalid percentage size %q", s)
+		}
+		if pct < 1 || pct > 99 {
+			return fmt.Errorf("percentage size must be between 1%% and 99%% (got %q)", s)
+		}
+		return nil
+	}
+	var cells int
+	if _, err := fmt.Sscanf(s, "%d", &cells); err != nil {
+		return fmt.Errorf("invalid size %q (use percentage like '80%%' or cell count like '20')", s)
+	}
+	if cells < 1 {
+		return fmt.Errorf("cell size must be positive (got %q)", s)
+	}
+	return nil
+}

--- a/cmd/coda-core/layout_config.go
+++ b/cmd/coda-core/layout_config.go
@@ -3,10 +3,14 @@ package main
 import (
 	"fmt"
 	"os"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 )
+
+var envKeyRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 type LayoutConfig struct {
 	Direction string        `yaml:"direction"`
@@ -82,6 +86,9 @@ func validatePaneConfig(p *PaneConfig, path string) error {
 		if p.Command != "" && len(p.Prefer) > 0 {
 			return fmt.Errorf("%s: cannot specify both 'command' and 'prefer'", path)
 		}
+		if p.Direction != "" {
+			return fmt.Errorf("%s: leaf pane cannot have 'direction' without 'panes'", path)
+		}
 	} else {
 		if p.Command != "" || len(p.Prefer) > 0 {
 			return fmt.Errorf("%s: split pane cannot have 'command' or 'prefer'", path)
@@ -100,8 +107,16 @@ func validatePaneConfig(p *PaneConfig, path string) error {
 	}
 
 	if p.Size != "" {
-		if err := validateSize(p.Size); err != nil {
+		normalized, err := validateSize(p.Size)
+		if err != nil {
 			return fmt.Errorf("%s: %w", path, err)
+		}
+		p.Size = normalized
+	}
+
+	for k := range p.Env {
+		if !envKeyRe.MatchString(k) {
+			return fmt.Errorf("%s: invalid env key %q (must match [A-Za-z_][A-Za-z0-9_]*)", path, k)
 		}
 	}
 
@@ -121,28 +136,28 @@ func normalizeDirection(d string) string {
 	}
 }
 
-func validateSize(s string) error {
+func validateSize(s string) (string, error) {
 	s = strings.TrimSpace(s)
 	if s == "" {
-		return nil
+		return s, nil
 	}
 	if strings.HasSuffix(s, "%") {
 		numStr := strings.TrimSuffix(s, "%")
-		var pct int
-		if _, err := fmt.Sscanf(numStr, "%d", &pct); err != nil {
-			return fmt.Errorf("invalid percentage size %q", s)
+		pct, err := strconv.Atoi(numStr)
+		if err != nil {
+			return "", fmt.Errorf("invalid percentage size %q", s)
 		}
 		if pct < 1 || pct > 99 {
-			return fmt.Errorf("percentage size must be between 1%% and 99%% (got %q)", s)
+			return "", fmt.Errorf("percentage size must be between 1%% and 99%% (got %q)", s)
 		}
-		return nil
+		return fmt.Sprintf("%d%%", pct), nil
 	}
-	var cells int
-	if _, err := fmt.Sscanf(s, "%d", &cells); err != nil {
-		return fmt.Errorf("invalid size %q (use percentage like '80%%' or cell count like '20')", s)
+	cells, err := strconv.Atoi(s)
+	if err != nil {
+		return "", fmt.Errorf("invalid size %q (use percentage like '80%%' or cell count like '20')", s)
 	}
 	if cells < 1 {
-		return fmt.Errorf("cell size must be positive (got %q)", s)
+		return "", fmt.Errorf("cell size must be positive (got %q)", s)
 	}
-	return nil
+	return strconv.Itoa(cells), nil
 }

--- a/cmd/coda-core/layout_config_test.go
+++ b/cmd/coda-core/layout_config_test.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParseLayoutConfig_SinglePane(t *testing.T) {
+	yaml := `
+direction: horizontal
+panes:
+  - command: opencode
+`
+	cfg, err := parseLayoutConfigBytes([]byte(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Direction != "horizontal" {
+		t.Errorf("expected horizontal, got %s", cfg.Direction)
+	}
+	if len(cfg.Panes) != 1 {
+		t.Fatalf("expected 1 pane, got %d", len(cfg.Panes))
+	}
+	if cfg.Panes[0].Command != "opencode" {
+		t.Errorf("expected opencode command, got %s", cfg.Panes[0].Command)
+	}
+}
+
+func TestParseLayoutConfig_TwoPanes(t *testing.T) {
+	yaml := `
+direction: vertical
+panes:
+  - command: opencode
+    title: OpenCode
+    size: "80%"
+  - command: "$SHELL"
+    size: "20%"
+`
+	cfg, err := parseLayoutConfigBytes([]byte(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Panes) != 2 {
+		t.Fatalf("expected 2 panes, got %d", len(cfg.Panes))
+	}
+	if cfg.Panes[0].Title != "OpenCode" {
+		t.Errorf("expected title OpenCode, got %s", cfg.Panes[0].Title)
+	}
+	if cfg.Panes[0].Size != "80%" {
+		t.Errorf("expected 80%%, got %s", cfg.Panes[0].Size)
+	}
+}
+
+func TestParseLayoutConfig_NestedSplits(t *testing.T) {
+	yaml := `
+direction: vertical
+panes:
+  - direction: horizontal
+    size: "65%"
+    panes:
+      - command: opencode
+        title: OpenCode
+        size: "50%"
+      - command: "nvim ."
+        title: Editor
+        size: "50%"
+  - command: "$SHELL"
+    title: Shell
+    size: "35%"
+`
+	cfg, err := parseLayoutConfigBytes([]byte(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Panes) != 2 {
+		t.Fatalf("expected 2 top-level panes, got %d", len(cfg.Panes))
+	}
+	if !cfg.Panes[0].IsLeaf() {
+		t.Log("first pane is a split (expected)")
+	} else {
+		t.Error("first pane should be a split, not a leaf")
+	}
+	if cfg.Panes[0].Direction != "horizontal" {
+		t.Errorf("expected nested horizontal, got %s", cfg.Panes[0].Direction)
+	}
+	if len(cfg.Panes[0].Panes) != 2 {
+		t.Fatalf("expected 2 nested panes, got %d", len(cfg.Panes[0].Panes))
+	}
+}
+
+func TestParseLayoutConfig_Prefer(t *testing.T) {
+	yaml := `
+direction: horizontal
+panes:
+  - prefer:
+      - yazi
+      - nnn
+      - lf
+    title: Explorer
+`
+	cfg, err := parseLayoutConfigBytes([]byte(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Panes[0].Prefer) != 3 {
+		t.Errorf("expected 3 prefer entries, got %d", len(cfg.Panes[0].Prefer))
+	}
+}
+
+func TestParseLayoutConfig_WithBorder(t *testing.T) {
+	yaml := `
+direction: horizontal
+panes:
+  - command: opencode
+    title: OpenCode
+border:
+  status: top
+  lines: heavy
+  style: "fg=colour245"
+`
+	cfg, err := parseLayoutConfigBytes([]byte(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Border == nil {
+		t.Fatal("expected border config")
+	}
+	if cfg.Border.Status != "top" {
+		t.Errorf("expected top, got %s", cfg.Border.Status)
+	}
+}
+
+func TestParseLayoutConfig_Validation_NoPanes(t *testing.T) {
+	yaml := `
+direction: horizontal
+panes: []
+`
+	_, err := parseLayoutConfigBytes([]byte(yaml))
+	if err == nil {
+		t.Fatal("expected error for empty panes")
+	}
+}
+
+func TestParseLayoutConfig_Validation_BadDirection(t *testing.T) {
+	yaml := `
+direction: diagonal
+panes:
+  - command: opencode
+`
+	_, err := parseLayoutConfigBytes([]byte(yaml))
+	if err == nil {
+		t.Fatal("expected error for bad direction")
+	}
+}
+
+func TestParseLayoutConfig_Validation_CommandAndPrefer(t *testing.T) {
+	yaml := `
+direction: horizontal
+panes:
+  - command: opencode
+    prefer:
+      - yazi
+`
+	_, err := parseLayoutConfigBytes([]byte(yaml))
+	if err == nil {
+		t.Fatal("expected error for both command and prefer")
+	}
+}
+
+func TestParseLayoutConfig_Validation_BadSize(t *testing.T) {
+	yaml := `
+direction: horizontal
+panes:
+  - command: opencode
+    size: "150%"
+`
+	_, err := parseLayoutConfigBytes([]byte(yaml))
+	if err == nil {
+		t.Fatal("expected error for size > 99%")
+	}
+}
+
+func TestParseLayoutConfig_Validation_SplitWithCommand(t *testing.T) {
+	yaml := `
+direction: horizontal
+panes:
+  - command: opencode
+    direction: vertical
+    panes:
+      - command: "$SHELL"
+`
+	_, err := parseLayoutConfigBytes([]byte(yaml))
+	if err == nil {
+		t.Fatal("expected error for split with command")
+	}
+}
+
+func TestParseLayoutConfig_ShorthandDirection(t *testing.T) {
+	yaml := `
+direction: h
+panes:
+  - command: opencode
+`
+	cfg, err := parseLayoutConfigBytes([]byte(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Direction != "horizontal" {
+		t.Errorf("expected horizontal from 'h', got %s", cfg.Direction)
+	}
+}
+
+func TestParseLayoutConfig_EnvVars(t *testing.T) {
+	yaml := `
+direction: horizontal
+panes:
+  - command: "nvim ."
+    env:
+      NVIM_APPNAME: nvim-custom
+`
+	cfg, err := parseLayoutConfigBytes([]byte(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Panes[0].Env["NVIM_APPNAME"] != "nvim-custom" {
+		t.Errorf("expected nvim-custom, got %s", cfg.Panes[0].Env["NVIM_APPNAME"])
+	}
+}
+
+func TestParseLayoutConfig_BarePaneDefaultsToShell(t *testing.T) {
+	yaml := `
+direction: horizontal
+panes:
+  - title: Shell
+`
+	cfg, err := parseLayoutConfigBytes([]byte(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.Panes[0].IsLeaf() {
+		t.Error("bare pane should be a leaf")
+	}
+	if cfg.Panes[0].Command != "" {
+		t.Errorf("bare pane should have empty command, got %s", cfg.Panes[0].Command)
+	}
+}

--- a/cmd/coda-core/layout_render.go
+++ b/cmd/coda-core/layout_render.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 )
 
@@ -100,9 +101,10 @@ func (rc *renderCtx) paneCmd(p flatPane) string {
 	if p.command != "" {
 		cmd := p.command
 		if len(p.env) > 0 {
+			keys := sortedKeys(p.env)
 			var parts []string
-			for k, v := range p.env {
-				parts = append(parts, fmt.Sprintf("%s=%s", k, v))
+			for _, k := range keys {
+				parts = append(parts, fmt.Sprintf("%s=%s", k, p.env[k]))
 			}
 			cmd = strings.Join(parts, " ") + " " + cmd
 		}
@@ -113,6 +115,18 @@ func (rc *renderCtx) paneCmd(p flatPane) string {
 		return fmt.Sprintf("$(_prefer_%d)", rc.preferIndex[key])
 	}
 	return ""
+}
+
+func shellEscapeDouble(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	s = strings.ReplaceAll(s, `$`, `\$`)
+	s = strings.ReplaceAll(s, "`", "\\`")
+	return s
+}
+
+func shellEscapeSingle(s string) string {
+	return strings.ReplaceAll(s, `'`, `'\''`)
 }
 
 func shellFirstWord(cmd string) string {
@@ -130,7 +144,7 @@ func (rc *renderCtx) writePreferBlock(b *strings.Builder, indent string) {
 			if cmd == "$SHELL" || cmd == "\"$SHELL\"" {
 				b.WriteString(fmt.Sprintf("%s    printf '%%s' \"%s\"\n", indent, cmd))
 			} else {
-				b.WriteString(fmt.Sprintf("%s    command -v %s &>/dev/null && { printf '%%s' '%s'; return; }\n", indent, shellFirstWord(cmd), cmd))
+				b.WriteString(fmt.Sprintf("%s    command -v %s &>/dev/null && { printf '%%s' '%s'; return; }\n", indent, shellFirstWord(cmd), shellEscapeSingle(cmd)))
 			}
 		}
 		b.WriteString(fmt.Sprintf("%s    printf '%%s' \"$SHELL\"\n", indent))
@@ -157,7 +171,7 @@ func (rc *renderCtx) writeInitFunc(b *strings.Builder) {
 		b.WriteString("    tmux new-session -d -s \"$session\" -x \"$cols\" -y \"$rows\" -c \"$dir\"\n")
 	}
 	if rc.flat[0].title != "" {
-		b.WriteString(fmt.Sprintf("    tmux select-pane -t \"$session\" -T \"%s\"\n", rc.flat[0].title))
+		b.WriteString(fmt.Sprintf("    tmux select-pane -t \"$session\" -T \"%s\"\n", shellEscapeDouble(rc.flat[0].title)))
 	}
 	writeEnvVars(b, rc.flat[0].env, "    ", "\"$session\"")
 
@@ -191,7 +205,7 @@ func (rc *renderCtx) writeSpawnFunc(b *strings.Builder) {
 	rc.writePreferBlock(b, "")
 
 	if rc.flat[0].title != "" {
-		b.WriteString(fmt.Sprintf("tmux select-pane -T \"%s\"\n", rc.flat[0].title))
+		b.WriteString(fmt.Sprintf("tmux select-pane -T \"%s\"\n", shellEscapeDouble(rc.flat[0].title)))
 	}
 	writeEnvVars(b, rc.flat[0].env, "", "")
 
@@ -255,9 +269,9 @@ func (rc *renderCtx) emitSplits(b *strings.Builder, direction string, panes []Pa
 			}
 			if fp.title != "" {
 				if isInit {
-					b.WriteString(fmt.Sprintf("%stmux select-pane -t \"$session\" -T \"%s\"\n", indent, fp.title))
+					b.WriteString(fmt.Sprintf("%stmux select-pane -t \"$session\" -T \"%s\"\n", indent, shellEscapeDouble(fp.title)))
 				} else {
-					b.WriteString(fmt.Sprintf("%stmux select-pane -T \"%s\"\n", indent, fp.title))
+					b.WriteString(fmt.Sprintf("%stmux select-pane -T \"%s\"\n", indent, shellEscapeDouble(fp.title)))
 				}
 			}
 			*leafIdx++
@@ -275,9 +289,9 @@ func (rc *renderCtx) emitSplits(b *strings.Builder, direction string, panes []Pa
 				}
 				if fp.title != "" {
 					if isInit {
-						b.WriteString(fmt.Sprintf("%stmux select-pane -t \"$session\" -T \"%s\"\n", indent, fp.title))
+						b.WriteString(fmt.Sprintf("%stmux select-pane -t \"$session\" -T \"%s\"\n", indent, shellEscapeDouble(fp.title)))
 					} else {
-						b.WriteString(fmt.Sprintf("%stmux select-pane -T \"%s\"\n", indent, fp.title))
+						b.WriteString(fmt.Sprintf("%stmux select-pane -T \"%s\"\n", indent, shellEscapeDouble(fp.title)))
 					}
 				}
 			}
@@ -296,6 +310,15 @@ func (rc *renderCtx) firstLeafIndex(panes []PaneConfig) int {
 	return -1
 }
 
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
 func sizeFlag(size string) string {
 	if size == "" {
 		return ""
@@ -307,11 +330,13 @@ func sizeFlag(size string) string {
 }
 
 func writeEnvVars(b *strings.Builder, env map[string]string, indent, target string) {
-	for k, v := range env {
+	keys := sortedKeys(env)
+	for _, k := range keys {
+		v := env[k]
 		if target != "" {
-			b.WriteString(fmt.Sprintf("%stmux set-environment -t %s %s \"%s\"\n", indent, target, k, v))
+			b.WriteString(fmt.Sprintf("%stmux set-environment -t %s %s \"%s\"\n", indent, target, k, shellEscapeDouble(v)))
 		} else {
-			b.WriteString(fmt.Sprintf("%stmux set-environment %s \"%s\"\n", indent, k, v))
+			b.WriteString(fmt.Sprintf("%stmux set-environment %s \"%s\"\n", indent, k, shellEscapeDouble(v)))
 		}
 	}
 }
@@ -348,7 +373,7 @@ func writeBorderSetup(b *strings.Builder, border *BorderConfig, indent, target s
 
 	b.WriteString(fmt.Sprintf("%stmux set-option%s pane-border-status %s\n", indent, targetArg, status))
 	b.WriteString(fmt.Sprintf("%stmux set-option%s pane-border-lines %s\n", indent, targetArg, lines))
-	b.WriteString(fmt.Sprintf("%stmux set-option%s pane-border-style '%s'\n", indent, targetArg, style))
-	b.WriteString(fmt.Sprintf("%stmux set-option%s pane-active-border-style '%s'\n", indent, targetArg, activeStyle))
-	b.WriteString(fmt.Sprintf("%stmux set-option%s pane-border-format '%s'\n", indent, targetArg, borderFormat))
+	b.WriteString(fmt.Sprintf("%stmux set-option%s pane-border-style '%s'\n", indent, targetArg, shellEscapeSingle(style)))
+	b.WriteString(fmt.Sprintf("%stmux set-option%s pane-active-border-style '%s'\n", indent, targetArg, shellEscapeSingle(activeStyle)))
+	b.WriteString(fmt.Sprintf("%stmux set-option%s pane-border-format '%s'\n", indent, targetArg, shellEscapeSingle(borderFormat)))
 }

--- a/cmd/coda-core/layout_render.go
+++ b/cmd/coda-core/layout_render.go
@@ -1,0 +1,354 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+func runLayoutRender(args []string) error {
+	fs := flag.NewFlagSet("layout-render", flag.ExitOnError)
+	configPath := fs.String("config", "", "Path to YAML layout config file")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *configPath == "" {
+		return fmt.Errorf("--config is required")
+	}
+
+	cfg, err := parseLayoutConfig(*configPath)
+	if err != nil {
+		return err
+	}
+
+	return renderLayoutBash(os.Stdout, cfg)
+}
+
+type flatPane struct {
+	command string
+	prefer  []string
+	title   string
+	env     map[string]string
+}
+
+type renderCtx struct {
+	cfg         *LayoutConfig
+	flat        []flatPane
+	hasTitles   bool
+	preferFuncs []preferFunc
+	preferIndex map[string]int
+}
+
+type preferFunc struct {
+	cmds []string
+}
+
+func newRenderCtx(cfg *LayoutConfig) *renderCtx {
+	flat := flattenPanes(cfg.Panes)
+	rc := &renderCtx{
+		cfg:         cfg,
+		flat:        flat,
+		preferIndex: make(map[string]int),
+	}
+	for _, p := range flat {
+		if p.title != "" {
+			rc.hasTitles = true
+		}
+		if len(p.prefer) > 0 {
+			key := strings.Join(p.prefer, "|")
+			if _, ok := rc.preferIndex[key]; !ok {
+				rc.preferIndex[key] = len(rc.preferFuncs)
+				rc.preferFuncs = append(rc.preferFuncs, preferFunc{cmds: p.prefer})
+			}
+		}
+	}
+	return rc
+}
+
+func renderLayoutBash(w io.Writer, cfg *LayoutConfig) error {
+	rc := newRenderCtx(cfg)
+
+	var b strings.Builder
+	rc.writeInitFunc(&b)
+	b.WriteString("\n")
+	rc.writeSpawnFunc(&b)
+
+	_, err := fmt.Fprint(w, b.String())
+	return err
+}
+
+func flattenPanes(panes []PaneConfig) []flatPane {
+	var result []flatPane
+	for _, p := range panes {
+		if p.IsLeaf() {
+			result = append(result, flatPane{
+				command: p.Command,
+				prefer:  p.Prefer,
+				title:   p.Title,
+				env:     p.Env,
+			})
+		} else {
+			result = append(result, flattenPanes(p.Panes)...)
+		}
+	}
+	return result
+}
+
+func (rc *renderCtx) paneCmd(p flatPane) string {
+	if p.command != "" {
+		cmd := p.command
+		if len(p.env) > 0 {
+			var parts []string
+			for k, v := range p.env {
+				parts = append(parts, fmt.Sprintf("%s=%s", k, v))
+			}
+			cmd = strings.Join(parts, " ") + " " + cmd
+		}
+		return cmd
+	}
+	if len(p.prefer) > 0 {
+		key := strings.Join(p.prefer, "|")
+		return fmt.Sprintf("$(_prefer_%d)", rc.preferIndex[key])
+	}
+	return ""
+}
+
+func shellFirstWord(cmd string) string {
+	parts := strings.Fields(cmd)
+	if len(parts) > 0 {
+		return parts[0]
+	}
+	return cmd
+}
+
+func (rc *renderCtx) writePreferBlock(b *strings.Builder, indent string) {
+	for i, pf := range rc.preferFuncs {
+		b.WriteString(fmt.Sprintf("%s_prefer_%d() {\n", indent, i))
+		for _, cmd := range pf.cmds {
+			if cmd == "$SHELL" || cmd == "\"$SHELL\"" {
+				b.WriteString(fmt.Sprintf("%s    printf '%%s' \"%s\"\n", indent, cmd))
+			} else {
+				b.WriteString(fmt.Sprintf("%s    command -v %s &>/dev/null && { printf '%%s' '%s'; return; }\n", indent, shellFirstWord(cmd), cmd))
+			}
+		}
+		b.WriteString(fmt.Sprintf("%s    printf '%%s' \"$SHELL\"\n", indent))
+		b.WriteString(fmt.Sprintf("%s}\n", indent))
+	}
+	if len(rc.preferFuncs) > 0 {
+		b.WriteString("\n")
+	}
+}
+
+func (rc *renderCtx) writeInitFunc(b *strings.Builder) {
+	b.WriteString("_layout_init() {\n")
+	b.WriteString("    local session=\"$1\" dir=\"$2\" nvim_appname=\"${3:-nvim}\"\n")
+	b.WriteString("    local cols=\"${COLUMNS:-200}\" rows=\"${LINES:-50}\"\n")
+	b.WriteString("\n")
+
+	rc.writePreferBlock(b, "    ")
+
+	firstCmd := rc.paneCmd(rc.flat[0])
+	if firstCmd != "" {
+		b.WriteString(fmt.Sprintf("    tmux new-session -d -s \"$session\" -x \"$cols\" -y \"$rows\" -c \"$dir\" \\" + "\n"))
+		b.WriteString(fmt.Sprintf("        \"%s; exec \\$SHELL\"\n", firstCmd))
+	} else {
+		b.WriteString("    tmux new-session -d -s \"$session\" -x \"$cols\" -y \"$rows\" -c \"$dir\"\n")
+	}
+	if rc.flat[0].title != "" {
+		b.WriteString(fmt.Sprintf("    tmux select-pane -t \"$session\" -T \"%s\"\n", rc.flat[0].title))
+	}
+	writeEnvVars(b, rc.flat[0].env, "    ", "\"$session\"")
+
+	if len(rc.flat) > 1 {
+		b.WriteString("\n")
+		leafIdx := 0
+		rc.emitSplits(b, rc.cfg.Direction, rc.cfg.Panes, "    ", true, &leafIdx, true)
+	}
+
+	if rc.hasTitles {
+		b.WriteString("\n")
+		writeBorderSetup(b, rc.cfg.Border, "    ", "\"$session\"")
+	}
+
+	b.WriteString("    tmux select-pane -t \"$session\" -t 0\n")
+	b.WriteString("}\n")
+}
+
+func (rc *renderCtx) writeSpawnFunc(b *strings.Builder) {
+	b.WriteString("_layout_spawn() {\n")
+	b.WriteString("    local session=\"$1\" dir=\"$2\" nvim_appname=\"${3:-nvim}\"\n")
+	b.WriteString("\n")
+	b.WriteString("    local script\n")
+	b.WriteString("    script=$(mktemp \"${TMPDIR:-/tmp}/coda-layout.XXXXXX\")\n")
+	b.WriteString("    cat > \"$script\" <<'SETUP'\n")
+	b.WriteString("#!/usr/bin/env bash\n")
+	b.WriteString("rm -f \"$0\"\n")
+	b.WriteString("dir=\"$1\"\n")
+	b.WriteString("\n")
+
+	rc.writePreferBlock(b, "")
+
+	if rc.flat[0].title != "" {
+		b.WriteString(fmt.Sprintf("tmux select-pane -T \"%s\"\n", rc.flat[0].title))
+	}
+	writeEnvVars(b, rc.flat[0].env, "", "")
+
+	if len(rc.flat) > 1 {
+		leafIdx := 0
+		rc.emitSplits(b, rc.cfg.Direction, rc.cfg.Panes, "", false, &leafIdx, true)
+	}
+
+	if rc.hasTitles {
+		b.WriteString("\n")
+		writeBorderSetup(b, rc.cfg.Border, "", "")
+	}
+
+	b.WriteString("\n")
+	b.WriteString("tmux select-pane -t 0\n")
+	firstCmd := rc.paneCmd(rc.flat[0])
+	if firstCmd != "" {
+		b.WriteString(fmt.Sprintf("%s; exec \"$SHELL\"\n", firstCmd))
+	}
+
+	b.WriteString("SETUP\n")
+	b.WriteString("    chmod +x \"$script\"\n")
+	b.WriteString("    tmux new-window -t \"$session\" -c \"$dir\" \"$script\" \"$dir\"\n")
+	b.WriteString("}\n")
+}
+
+func (rc *renderCtx) emitSplits(b *strings.Builder, direction string, panes []PaneConfig, indent string, isInit bool, leafIdx *int, isRoot bool) {
+	var splitFlag string
+	if direction == "vertical" {
+		splitFlag = "-v"
+	} else {
+		splitFlag = "-h"
+	}
+
+	for i, p := range panes {
+		if i == 0 && isRoot {
+			if p.IsLeaf() {
+				*leafIdx++
+			} else {
+				rc.emitSplits(b, p.Direction, p.Panes, indent, isInit, leafIdx, true)
+			}
+			continue
+		}
+
+		var targetArg string
+		if isInit {
+			targetArg = " -t \"$session\""
+		}
+
+		sizeArg := sizeFlag(p.Size)
+
+		if p.IsLeaf() {
+			fp := rc.flat[*leafIdx]
+			cmd := rc.paneCmd(fp)
+			if cmd != "" {
+				b.WriteString(fmt.Sprintf("%stmux split-window %s%s%s -c \"$dir\" \"%s; exec \\$SHELL\"\n",
+					indent, splitFlag, targetArg, sizeArg, cmd))
+			} else {
+				b.WriteString(fmt.Sprintf("%stmux split-window %s%s%s -c \"$dir\"\n",
+					indent, splitFlag, targetArg, sizeArg))
+			}
+			if fp.title != "" {
+				if isInit {
+					b.WriteString(fmt.Sprintf("%stmux select-pane -t \"$session\" -T \"%s\"\n", indent, fp.title))
+				} else {
+					b.WriteString(fmt.Sprintf("%stmux select-pane -T \"%s\"\n", indent, fp.title))
+				}
+			}
+			*leafIdx++
+		} else {
+			firstLeafIdx := rc.firstLeafIndex(p.Panes)
+			if firstLeafIdx >= 0 {
+				fp := rc.flat[*leafIdx+firstLeafIdx]
+				cmd := rc.paneCmd(fp)
+				if cmd != "" {
+					b.WriteString(fmt.Sprintf("%stmux split-window %s%s%s -c \"$dir\" \"%s; exec \\$SHELL\"\n",
+						indent, splitFlag, targetArg, sizeArg, cmd))
+				} else {
+					b.WriteString(fmt.Sprintf("%stmux split-window %s%s%s -c \"$dir\"\n",
+						indent, splitFlag, targetArg, sizeArg))
+				}
+				if fp.title != "" {
+					if isInit {
+						b.WriteString(fmt.Sprintf("%stmux select-pane -t \"$session\" -T \"%s\"\n", indent, fp.title))
+					} else {
+						b.WriteString(fmt.Sprintf("%stmux select-pane -T \"%s\"\n", indent, fp.title))
+					}
+				}
+			}
+			rc.emitSplits(b, p.Direction, p.Panes, indent, isInit, leafIdx, true)
+		}
+	}
+}
+
+func (rc *renderCtx) firstLeafIndex(panes []PaneConfig) int {
+	for _, p := range panes {
+		if p.IsLeaf() {
+			return 0
+		}
+		return rc.firstLeafIndex(p.Panes)
+	}
+	return -1
+}
+
+func sizeFlag(size string) string {
+	if size == "" {
+		return ""
+	}
+	if strings.HasSuffix(size, "%") {
+		return fmt.Sprintf(" -p %s", strings.TrimSuffix(size, "%"))
+	}
+	return fmt.Sprintf(" -l %s", size)
+}
+
+func writeEnvVars(b *strings.Builder, env map[string]string, indent, target string) {
+	for k, v := range env {
+		if target != "" {
+			b.WriteString(fmt.Sprintf("%stmux set-environment -t %s %s \"%s\"\n", indent, target, k, v))
+		} else {
+			b.WriteString(fmt.Sprintf("%stmux set-environment %s \"%s\"\n", indent, k, v))
+		}
+	}
+}
+
+func writeBorderSetup(b *strings.Builder, border *BorderConfig, indent, target string) {
+	status := "top"
+	lines := "heavy"
+	style := "fg=colour245"
+	activeStyle := "fg=green,bold"
+	borderFormat := " #{?pane_active,\u25b8 ,  }#{pane_title} "
+
+	if border != nil {
+		if border.Status != "" {
+			status = border.Status
+		}
+		if border.Lines != "" {
+			lines = border.Lines
+		}
+		if border.Style != "" {
+			style = border.Style
+		}
+		if border.ActiveStyle != "" {
+			activeStyle = border.ActiveStyle
+		}
+		if border.Format != "" {
+			borderFormat = border.Format
+		}
+	}
+
+	var targetArg string
+	if target != "" {
+		targetArg = fmt.Sprintf(" -t %s", target)
+	}
+
+	b.WriteString(fmt.Sprintf("%stmux set-option%s pane-border-status %s\n", indent, targetArg, status))
+	b.WriteString(fmt.Sprintf("%stmux set-option%s pane-border-lines %s\n", indent, targetArg, lines))
+	b.WriteString(fmt.Sprintf("%stmux set-option%s pane-border-style '%s'\n", indent, targetArg, style))
+	b.WriteString(fmt.Sprintf("%stmux set-option%s pane-active-border-style '%s'\n", indent, targetArg, activeStyle))
+	b.WriteString(fmt.Sprintf("%stmux set-option%s pane-border-format '%s'\n", indent, targetArg, borderFormat))
+}

--- a/cmd/coda-core/layout_render.go
+++ b/cmd/coda-core/layout_render.go
@@ -144,7 +144,7 @@ func (rc *renderCtx) writePreferBlock(b *strings.Builder, indent string) {
 			if cmd == "$SHELL" || cmd == "\"$SHELL\"" {
 				b.WriteString(fmt.Sprintf("%s    printf '%%s' \"%s\"\n", indent, cmd))
 			} else {
-				b.WriteString(fmt.Sprintf("%s    command -v %s &>/dev/null && { printf '%%s' '%s'; return; }\n", indent, shellFirstWord(cmd), shellEscapeSingle(cmd)))
+				b.WriteString(fmt.Sprintf("%s    command -v -- '%s' &>/dev/null && { printf '%%s' '%s'; return; }\n", indent, shellEscapeSingle(shellFirstWord(cmd)), shellEscapeSingle(cmd)))
 			}
 		}
 		b.WriteString(fmt.Sprintf("%s    printf '%%s' \"$SHELL\"\n", indent))
@@ -186,7 +186,7 @@ func (rc *renderCtx) writeInitFunc(b *strings.Builder) {
 		writeBorderSetup(b, rc.cfg.Border, "    ", "\"$session\"")
 	}
 
-	b.WriteString("    tmux select-pane -t \"$session\" -t 0\n")
+	b.WriteString("    tmux select-pane -t \"$session\":0\n")
 	b.WriteString("}\n")
 }
 
@@ -371,8 +371,8 @@ func writeBorderSetup(b *strings.Builder, border *BorderConfig, indent, target s
 		targetArg = fmt.Sprintf(" -t %s", target)
 	}
 
-	b.WriteString(fmt.Sprintf("%stmux set-option%s pane-border-status %s\n", indent, targetArg, status))
-	b.WriteString(fmt.Sprintf("%stmux set-option%s pane-border-lines %s\n", indent, targetArg, lines))
+	b.WriteString(fmt.Sprintf("%stmux set-option%s pane-border-status '%s'\n", indent, targetArg, shellEscapeSingle(status)))
+	b.WriteString(fmt.Sprintf("%stmux set-option%s pane-border-lines '%s'\n", indent, targetArg, shellEscapeSingle(lines)))
 	b.WriteString(fmt.Sprintf("%stmux set-option%s pane-border-style '%s'\n", indent, targetArg, shellEscapeSingle(style)))
 	b.WriteString(fmt.Sprintf("%stmux set-option%s pane-active-border-style '%s'\n", indent, targetArg, shellEscapeSingle(activeStyle)))
 	b.WriteString(fmt.Sprintf("%stmux set-option%s pane-border-format '%s'\n", indent, targetArg, shellEscapeSingle(borderFormat)))

--- a/cmd/coda-core/layout_render_test.go
+++ b/cmd/coda-core/layout_render_test.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRenderLayoutBash_SinglePane(t *testing.T) {
+	cfg := &LayoutConfig{
+		Direction: "horizontal",
+		Panes:     []PaneConfig{{Command: "opencode"}},
+	}
+
+	var buf bytes.Buffer
+	if err := renderLayoutBash(&buf, cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "_layout_init()") {
+		t.Error("missing _layout_init")
+	}
+	if !strings.Contains(out, "_layout_spawn()") {
+		t.Error("missing _layout_spawn")
+	}
+	if !strings.Contains(out, "opencode") {
+		t.Error("missing opencode command")
+	}
+	if strings.Contains(out, "split-window") {
+		t.Error("single pane should not have split-window")
+	}
+}
+
+func TestRenderLayoutBash_TwoPanes(t *testing.T) {
+	cfg := &LayoutConfig{
+		Direction: "vertical",
+		Panes: []PaneConfig{
+			{Command: "opencode", Title: "OpenCode", Size: "80%"},
+			{Title: "Shell", Size: "20%"},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := renderLayoutBash(&buf, cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "split-window -v") {
+		t.Error("expected vertical split")
+	}
+	if !strings.Contains(out, "-p 20") {
+		t.Error("expected percentage size flag")
+	}
+	if !strings.Contains(out, "pane-border-status") {
+		t.Error("expected border setup (titles present)")
+	}
+	if !strings.Contains(out, `"OpenCode"`) {
+		t.Error("expected OpenCode title")
+	}
+	if !strings.Contains(out, `"Shell"`) {
+		t.Error("expected Shell title")
+	}
+}
+
+func TestRenderLayoutBash_HorizontalSplit(t *testing.T) {
+	cfg := &LayoutConfig{
+		Direction: "horizontal",
+		Panes: []PaneConfig{
+			{Command: "opencode", Size: "50%"},
+			{Command: "nvim .", Size: "50%"},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := renderLayoutBash(&buf, cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "split-window -h") {
+		t.Error("expected horizontal split")
+	}
+}
+
+func TestRenderLayoutBash_NestedLayout(t *testing.T) {
+	cfg := &LayoutConfig{
+		Direction: "vertical",
+		Panes: []PaneConfig{
+			{
+				Direction: "horizontal",
+				Size:      "65%",
+				Panes: []PaneConfig{
+					{Command: "opencode", Title: "OpenCode", Size: "50%"},
+					{Command: "nvim .", Title: "Editor", Size: "50%"},
+				},
+			},
+			{Title: "Shell", Size: "35%"},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := renderLayoutBash(&buf, cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "split-window -v") {
+		t.Error("expected vertical split for bottom pane")
+	}
+	if !strings.Contains(out, "split-window -h") {
+		t.Error("expected horizontal split for top nested panes")
+	}
+	if !strings.Contains(out, "opencode") {
+		t.Error("missing opencode")
+	}
+	if !strings.Contains(out, "nvim") {
+		t.Error("missing nvim")
+	}
+}
+
+func TestRenderLayoutBash_PreferCommands(t *testing.T) {
+	cfg := &LayoutConfig{
+		Direction: "horizontal",
+		Panes: []PaneConfig{
+			{
+				Prefer: []string{"yazi", "nnn", "lf"},
+				Title:  "Explorer",
+			},
+			{Command: "opencode"},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := renderLayoutBash(&buf, cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "_prefer_0()") {
+		t.Error("missing prefer function")
+	}
+	if !strings.Contains(out, "command -v yazi") {
+		t.Error("missing yazi check")
+	}
+	if !strings.Contains(out, "command -v nnn") {
+		t.Error("missing nnn check")
+	}
+	if !strings.Contains(out, "command -v lf") {
+		t.Error("missing lf check")
+	}
+}
+
+func TestRenderLayoutBash_EnvVars(t *testing.T) {
+	cfg := &LayoutConfig{
+		Direction: "horizontal",
+		Panes: []PaneConfig{
+			{
+				Command: "nvim .",
+				Env:     map[string]string{"NVIM_APPNAME": "$nvim_appname"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := renderLayoutBash(&buf, cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "NVIM_APPNAME=$nvim_appname") {
+		t.Errorf("expected env var in command, got:\n%s", out)
+	}
+}
+
+func TestRenderLayoutBash_NoBordersWithoutTitles(t *testing.T) {
+	cfg := &LayoutConfig{
+		Direction: "horizontal",
+		Panes: []PaneConfig{
+			{Command: "opencode"},
+			{Command: "nvim ."},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := renderLayoutBash(&buf, cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "pane-border-status") {
+		t.Error("should not have border setup without titles")
+	}
+}
+
+func TestRenderLayoutBash_SpawnFuncHasHeredoc(t *testing.T) {
+	cfg := &LayoutConfig{
+		Direction: "horizontal",
+		Panes: []PaneConfig{
+			{Command: "opencode"},
+			{Command: "nvim ."},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := renderLayoutBash(&buf, cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "<<'SETUP'") {
+		t.Error("spawn func should use heredoc")
+	}
+	if !strings.Contains(out, "SETUP") {
+		t.Error("spawn func should have SETUP delimiter")
+	}
+	if !strings.Contains(out, "mktemp") {
+		t.Error("spawn func should use mktemp")
+	}
+}
+
+func TestRenderLayoutBash_FixedSize(t *testing.T) {
+	cfg := &LayoutConfig{
+		Direction: "vertical",
+		Panes: []PaneConfig{
+			{Command: "opencode"},
+			{Size: "10"},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := renderLayoutBash(&buf, cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "-l 10") {
+		t.Error("expected fixed size flag -l")
+	}
+}
+
+func TestFlattenPanes(t *testing.T) {
+	panes := []PaneConfig{
+		{Command: "a"},
+		{
+			Direction: "horizontal",
+			Panes: []PaneConfig{
+				{Command: "b"},
+				{Command: "c"},
+			},
+		},
+		{Command: "d"},
+	}
+
+	flat := flattenPanes(panes)
+	if len(flat) != 4 {
+		t.Fatalf("expected 4 flat panes, got %d", len(flat))
+	}
+	expected := []string{"a", "b", "c", "d"}
+	for i, e := range expected {
+		if flat[i].command != e {
+			t.Errorf("flat[%d].command = %q, want %q", i, flat[i].command, e)
+		}
+	}
+}

--- a/cmd/coda-core/layout_render_test.go
+++ b/cmd/coda-core/layout_render_test.go
@@ -141,13 +141,13 @@ func TestRenderLayoutBash_PreferCommands(t *testing.T) {
 	if !strings.Contains(out, "_prefer_0()") {
 		t.Error("missing prefer function")
 	}
-	if !strings.Contains(out, "command -v yazi") {
+	if !strings.Contains(out, "command -v -- 'yazi'") {
 		t.Error("missing yazi check")
 	}
-	if !strings.Contains(out, "command -v nnn") {
+	if !strings.Contains(out, "command -v -- 'nnn'") {
 		t.Error("missing nnn check")
 	}
-	if !strings.Contains(out, "command -v lf") {
+	if !strings.Contains(out, "command -v -- 'lf'") {
 		t.Error("missing lf check")
 	}
 }

--- a/cmd/coda-core/layout_snapshot_yaml.go
+++ b/cmd/coda-core/layout_snapshot_yaml.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+func generateLayoutYAML(snap *snapshot) ([]byte, error) {
+	cfg := snapshotToConfig(snap)
+	return yaml.Marshal(cfg)
+}
+
+func snapshotToConfig(snap *snapshot) *LayoutConfig {
+	tree := parseLayoutTree(snap.LayoutStr)
+	paneMap := make(map[string]paneInfo)
+	for _, p := range snap.Panes {
+		paneMap[p.ID] = p
+	}
+
+	hasTitles := false
+	for _, p := range snap.Panes {
+		if resolveTitle(p.Title) != "" {
+			hasTitles = true
+			break
+		}
+	}
+
+	cfg := &LayoutConfig{
+		Direction: tree.direction,
+		Panes:     treeNodeToConfig(tree, paneMap, snap),
+	}
+
+	if hasTitles {
+		cfg.Border = &BorderConfig{
+			Status: "top",
+			Lines:  "heavy",
+		}
+	}
+
+	return cfg
+}
+
+type layoutNode struct {
+	direction string
+	children  []layoutChild
+}
+
+type layoutChild struct {
+	width, height int
+	paneID        string
+	subNode       *layoutNode
+}
+
+func treeNodeToConfig(node *layoutNode, paneMap map[string]paneInfo, snap *snapshot) []PaneConfig {
+	var panes []PaneConfig
+	totalSize := 0
+	for _, c := range node.children {
+		if node.direction == "horizontal" {
+			totalSize += c.width
+		} else {
+			totalSize += c.height
+		}
+	}
+
+	for _, c := range node.children {
+		var pct int
+		if node.direction == "horizontal" && totalSize > 0 {
+			pct = (c.width * 100) / totalSize
+		} else if totalSize > 0 {
+			pct = (c.height * 100) / totalSize
+		}
+		size := fmt.Sprintf("%d%%", pct)
+
+		if c.subNode != nil {
+			subPanes := treeNodeToConfig(c.subNode, paneMap, snap)
+			panes = append(panes, PaneConfig{
+				Direction: c.subNode.direction,
+				Panes:     subPanes,
+				Size:      size,
+			})
+		} else {
+			pi := paneMap[c.paneID]
+			cmd := resolveCmd(pi.Start, pi.Cmd)
+			title := resolveTitle(pi.Title)
+			pc := PaneConfig{Size: size}
+			if cmd != "" {
+				pc.Command = cmd
+			}
+			if title != "" {
+				pc.Title = title
+			}
+			panes = append(panes, pc)
+		}
+	}
+
+	return panes
+}
+
+// parseLayoutTree parses a tmux layout string into a tree structure.
+// Layout strings look like: "checksum,WxH,X,Y{...}" or "checksum,WxH,X,Y[...]" or "checksum,WxH,X,Y,ID"
+// { } = horizontal split, [ ] = vertical split
+func parseLayoutTree(layout string) *layoutNode {
+	idx := strings.Index(layout, ",")
+	if idx < 0 {
+		return &layoutNode{direction: "horizontal"}
+	}
+	body := layout[idx+1:]
+
+	node, _ := parseLayoutBody(body, 0)
+	if node == nil {
+		return &layoutNode{direction: "horizontal"}
+	}
+	return node
+}
+
+func parseLayoutBody(s string, pos int) (*layoutNode, int) {
+	w, h, newPos := parseDimensions(s, pos)
+	if newPos < 0 {
+		return nil, pos
+	}
+	pos = newPos
+
+	if pos >= len(s) {
+		return &layoutNode{
+			direction: "horizontal",
+			children:  []layoutChild{{width: w, height: h}},
+		}, pos
+	}
+
+	switch s[pos] {
+	case '{':
+		children, end := parseChildren(s, pos+1, '}')
+		return &layoutNode{direction: "horizontal", children: setDimensions(children, w, h)}, end
+	case '[':
+		children, end := parseChildren(s, pos+1, ']')
+		return &layoutNode{direction: "vertical", children: setDimensions(children, w, h)}, end
+	case ',':
+		id, end := parseID(s, pos+1)
+		return &layoutNode{
+			direction: "horizontal",
+			children:  []layoutChild{{width: w, height: h, paneID: id}},
+		}, end
+	default:
+		return nil, pos
+	}
+}
+
+func parseDimensions(s string, pos int) (w, h, newPos int) {
+	var num int
+	start := pos
+	for pos < len(s) && s[pos] >= '0' && s[pos] <= '9' {
+		num = num*10 + int(s[pos]-'0')
+		pos++
+	}
+	if pos == start || pos >= len(s) || s[pos] != 'x' {
+		return 0, 0, -1
+	}
+	w = num
+	pos++
+
+	num = 0
+	start = pos
+	for pos < len(s) && s[pos] >= '0' && s[pos] <= '9' {
+		num = num*10 + int(s[pos]-'0')
+		pos++
+	}
+	if pos == start {
+		return 0, 0, -1
+	}
+	h = num
+
+	if pos >= len(s) || s[pos] != ',' {
+		return 0, 0, -1
+	}
+	pos++
+
+	for pos < len(s) && s[pos] >= '0' && s[pos] <= '9' {
+		pos++
+	}
+	if pos >= len(s) || s[pos] != ',' {
+		return 0, 0, -1
+	}
+	pos++
+
+	for pos < len(s) && s[pos] >= '0' && s[pos] <= '9' {
+		pos++
+	}
+
+	return w, h, pos
+}
+
+func parseChildren(s string, pos int, closer byte) ([]layoutChild, int) {
+	var children []layoutChild
+	for pos < len(s) && s[pos] != closer {
+		if s[pos] == ',' {
+			pos++
+			continue
+		}
+		node, end := parseLayoutBody(s, pos)
+		if node == nil || end == pos {
+			break
+		}
+		if len(node.children) == 1 && node.children[0].subNode == nil {
+			c := node.children[0]
+			children = append(children, layoutChild{
+				width:  c.width,
+				height: c.height,
+				paneID: c.paneID,
+			})
+		} else {
+			w, h := node.children[0].width, node.children[0].height
+			for _, c := range node.children {
+				if c.width > w {
+					w = c.width
+				}
+				if c.height > h {
+					h = c.height
+				}
+			}
+			children = append(children, layoutChild{
+				width:   w,
+				height:  h,
+				subNode: node,
+			})
+		}
+		pos = end
+	}
+	if pos < len(s) && s[pos] == closer {
+		pos++
+	}
+	return children, pos
+}
+
+func parseID(s string, pos int) (string, int) {
+	start := pos
+	for pos < len(s) && s[pos] >= '0' && s[pos] <= '9' {
+		pos++
+	}
+	return s[start:pos], pos
+}
+
+func setDimensions(children []layoutChild, w, h int) []layoutChild {
+	if len(children) == 0 {
+		return children
+	}
+	for i := range children {
+		if children[i].width == 0 {
+			children[i].width = w
+		}
+		if children[i].height == 0 {
+			children[i].height = h
+		}
+	}
+	return children
+}
+
+func writeLayoutYAML(snap *snapshot, outputPath string) error {
+	data, err := generateLayoutYAML(snap)
+	if err != nil {
+		return fmt.Errorf("generating YAML: %w", err)
+	}
+	if err := os.WriteFile(outputPath, data, 0644); err != nil {
+		return fmt.Errorf("writing YAML file: %w", err)
+	}
+	return nil
+}

--- a/cmd/coda-core/layout_snapshot_yaml.go
+++ b/cmd/coda-core/layout_snapshot_yaml.go
@@ -30,7 +30,7 @@ func snapshotToConfig(snap *snapshot) *LayoutConfig {
 
 	cfg := &LayoutConfig{
 		Direction: tree.direction,
-		Panes:     treeNodeToConfig(tree, paneMap, snap),
+		Panes:     treeNodeToConfig(tree, paneMap),
 	}
 
 	if hasTitles {
@@ -54,7 +54,7 @@ type layoutChild struct {
 	subNode       *layoutNode
 }
 
-func treeNodeToConfig(node *layoutNode, paneMap map[string]paneInfo, snap *snapshot) []PaneConfig {
+func treeNodeToConfig(node *layoutNode, paneMap map[string]paneInfo) []PaneConfig {
 	var panes []PaneConfig
 	totalSize := 0
 	for _, c := range node.children {
@@ -72,10 +72,13 @@ func treeNodeToConfig(node *layoutNode, paneMap map[string]paneInfo, snap *snaps
 		} else if totalSize > 0 {
 			pct = (c.height * 100) / totalSize
 		}
+		if pct < 1 && totalSize > 0 {
+			pct = 1
+		}
 		size := fmt.Sprintf("%d%%", pct)
 
 		if c.subNode != nil {
-			subPanes := treeNodeToConfig(c.subNode, paneMap, snap)
+			subPanes := treeNodeToConfig(c.subNode, paneMap)
 			panes = append(panes, PaneConfig{
 				Direction: c.subNode.direction,
 				Panes:     subPanes,

--- a/cmd/coda-core/layout_snapshot_yaml_test.go
+++ b/cmd/coda-core/layout_snapshot_yaml_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestParseLayoutTree_TwoPanes(t *testing.T) {
+	layout := "a1b2,200x50,0,0{100x50,0,0,0,99x50,101,0,1}"
+	node := parseLayoutTree(layout)
+
+	if node.direction != "horizontal" {
+		t.Errorf("expected horizontal, got %s", node.direction)
+	}
+	if len(node.children) != 2 {
+		t.Fatalf("expected 2 children, got %d", len(node.children))
+	}
+	if node.children[0].paneID != "0" {
+		t.Errorf("first child paneID = %q, want 0", node.children[0].paneID)
+	}
+	if node.children[1].paneID != "1" {
+		t.Errorf("second child paneID = %q, want 1", node.children[1].paneID)
+	}
+}
+
+func TestParseLayoutTree_ThreePaneNested(t *testing.T) {
+	layout := "c3d4,160x40,0,0[160x30,0,0{80x30,0,0,5,79x30,81,0,6},160x9,0,31,7]"
+	node := parseLayoutTree(layout)
+
+	if node.direction != "vertical" {
+		t.Errorf("expected vertical, got %s", node.direction)
+	}
+	if len(node.children) != 2 {
+		t.Fatalf("expected 2 children, got %d", len(node.children))
+	}
+	if node.children[0].subNode == nil {
+		t.Fatal("first child should be a sub-node")
+	}
+	if node.children[0].subNode.direction != "horizontal" {
+		t.Errorf("sub-node direction = %s, want horizontal", node.children[0].subNode.direction)
+	}
+	if node.children[1].paneID != "7" {
+		t.Errorf("bottom pane ID = %q, want 7", node.children[1].paneID)
+	}
+}
+
+func TestSnapshotToConfig_TwoPanes(t *testing.T) {
+	snap := &snapshot{
+		WinW:      200,
+		WinH:      50,
+		LayoutStr: "a1b2,200x50,0,0{100x50,0,0,0,99x50,101,0,1}",
+		PaneCount: 2,
+		Panes: []paneInfo{
+			{ID: "0", Cmd: "opencode", Title: "OpenCode"},
+			{ID: "1", Cmd: "nvim", Title: "Editor"},
+		},
+		LayoutTmpl: "200x50,0,0{100x50,0,0,__P0__,99x50,101,0,__P1__}",
+		LeafIDs:    []string{"0", "1"},
+	}
+
+	cfg := snapshotToConfig(snap)
+	if cfg.Direction != "horizontal" {
+		t.Errorf("expected horizontal, got %s", cfg.Direction)
+	}
+	if len(cfg.Panes) != 2 {
+		t.Fatalf("expected 2 panes, got %d", len(cfg.Panes))
+	}
+	if cfg.Panes[0].Command != "opencode" {
+		t.Errorf("first pane command = %q, want opencode", cfg.Panes[0].Command)
+	}
+	if cfg.Panes[0].Title != "OpenCode" {
+		t.Errorf("first pane title = %q, want OpenCode", cfg.Panes[0].Title)
+	}
+}
+
+func TestGenerateLayoutYAML_RoundTrip(t *testing.T) {
+	snap := &snapshot{
+		WinW:      200,
+		WinH:      50,
+		LayoutStr: "a1b2,200x50,0,0{100x50,0,0,0,99x50,101,0,1}",
+		PaneCount: 2,
+		Panes: []paneInfo{
+			{ID: "0", Cmd: "opencode", Title: "OpenCode"},
+			{ID: "1", Cmd: "nvim", Title: "Editor"},
+		},
+		LayoutTmpl: "200x50,0,0{100x50,0,0,__P0__,99x50,101,0,__P1__}",
+		LeafIDs:    []string{"0", "1"},
+	}
+
+	yamlData, err := generateLayoutYAML(snap)
+	if err != nil {
+		t.Fatalf("generateLayoutYAML failed: %v", err)
+	}
+
+	var cfg LayoutConfig
+	if err := yaml.Unmarshal(yamlData, &cfg); err != nil {
+		t.Fatalf("round-trip parse failed: %v", err)
+	}
+
+	if cfg.Direction != "horizontal" {
+		t.Errorf("round-trip direction = %s, want horizontal", cfg.Direction)
+	}
+	if len(cfg.Panes) != 2 {
+		t.Fatalf("round-trip pane count = %d, want 2", len(cfg.Panes))
+	}
+}
+
+func TestGenerateLayoutYAML_ContainsExpectedFields(t *testing.T) {
+	snap := &snapshot{
+		WinW:      200,
+		WinH:      50,
+		LayoutStr: "a1b2,200x50,0,0{100x50,0,0,0,99x50,101,0,1}",
+		PaneCount: 2,
+		Panes: []paneInfo{
+			{ID: "0", Cmd: "opencode", Title: "OpenCode"},
+			{ID: "1", Cmd: "bash", Title: ""},
+		},
+		LayoutTmpl: "200x50,0,0{100x50,0,0,__P0__,99x50,101,0,__P1__}",
+		LeafIDs:    []string{"0", "1"},
+	}
+
+	yamlData, err := generateLayoutYAML(snap)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	str := string(yamlData)
+	if !strings.Contains(str, "direction:") {
+		t.Error("YAML missing direction field")
+	}
+	if !strings.Contains(str, "command: opencode") {
+		t.Error("YAML missing opencode command")
+	}
+	if !strings.Contains(str, "title: OpenCode") {
+		t.Error("YAML missing OpenCode title")
+	}
+}

--- a/cmd/coda-core/main.go
+++ b/cmd/coda-core/main.go
@@ -42,6 +42,7 @@ Usage: coda-core <command> [args...]
 
 Commands:
   layout snapshot    Capture current tmux layout as a reusable layout script
+  layout render      Render a YAML layout config as bash functions
   provider auth      Configure CLIProxyAPI provider in OpenCode config
   provider status    Show provider diagnostics
   watch              Monitor OpenCode sessions and notify on attention needed

--- a/cmd/coda-core/main.go
+++ b/cmd/coda-core/main.go
@@ -41,7 +41,7 @@ func printUsage() {
 Usage: coda-core <command> [args...]
 
 Commands:
-  layout snapshot    Capture current tmux layout as a reusable layout script
+  layout snapshot    Capture current tmux layout as a script or YAML config
   layout render      Render a YAML layout config as bash functions
   provider auth      Configure CLIProxyAPI provider in OpenCode config
   provider status    Show provider diagnostics

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/evanstern/coda
 
 go 1.22.2
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/evanstern/coda
 
 go 1.22.2
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/layouts/examples/default.yaml
+++ b/layouts/examples/default.yaml
@@ -1,0 +1,3 @@
+direction: horizontal
+panes:
+  - command: opencode

--- a/layouts/examples/four-pane.yaml
+++ b/layouts/examples/four-pane.yaml
@@ -1,0 +1,26 @@
+direction: vertical
+border:
+  status: top
+  lines: heavy
+panes:
+  - direction: horizontal
+    size: "80%"
+    panes:
+      - prefer:
+          - lazygit
+          - gitui
+          - tig
+        title: Git
+        size: "20%"
+      - prefer:
+          - yazi
+          - nnn
+          - lf
+          - ranger
+        title: Explorer
+        size: "40%"
+      - command: opencode
+        title: OpenCode
+        size: "40%"
+  - title: Shell
+    size: "20%"

--- a/layouts/examples/three-pane.yaml
+++ b/layouts/examples/three-pane.yaml
@@ -1,0 +1,12 @@
+direction: vertical
+panes:
+  - direction: horizontal
+    size: "65%"
+    panes:
+      - command: opencode
+        size: "50%"
+      - command: "nvim ."
+        env:
+          NVIM_APPNAME: "$nvim_appname"
+        size: "50%"
+  - size: "35%"

--- a/layouts/examples/wide-twopane.yaml
+++ b/layouts/examples/wide-twopane.yaml
@@ -1,0 +1,8 @@
+direction: horizontal
+panes:
+  - command: opencode
+    size: "50%"
+  - command: "nvim ."
+    env:
+      NVIM_APPNAME: "$nvim_appname"
+    size: "50%"

--- a/lib/layout.sh
+++ b/lib/layout.sh
@@ -18,7 +18,9 @@ Usage: coda layout <apply|ls|show|create|name>
   coda layout ls               List available layouts
   coda layout show <name>      Show layout file contents
   coda layout create <name>    Create a new layout from template
+  coda layout create <name> --yaml      Create a YAML layout template
   coda layout create <name> --snapshot  Capture current window layout
+  coda layout create <name> --snapshot --yaml  Capture as YAML config
 EOF
         ;;
         *)      _coda_layout_apply "$subcmd" "$@" ;;
@@ -68,18 +70,24 @@ _coda_layout_apply() {
 
 _coda_layout_ls() {
     echo "Available layouts:"
-    local seen="" name source
-    for f in "$CODA_LAYOUTS_DIR"/*.sh "$_CODA_DIR/layouts"/*.sh; do
+    local seen="" name source fmt_tag
+    for f in "$CODA_LAYOUTS_DIR"/*.sh "$CODA_LAYOUTS_DIR"/*.yaml "$_CODA_DIR/layouts"/*.sh "$_CODA_DIR/layouts"/*.yaml; do
         [ -f "$f" ] || continue
-        name=$(basename "${f%.sh}")
+        local base
+        base=$(basename "$f")
+        name="${base%.*}"
         case "$seen" in *"|$name|"*) continue ;; esac
         seen="$seen|$name|"
-        if [ -f "$CODA_LAYOUTS_DIR/${name}.sh" ]; then
+        if [ -f "$CODA_LAYOUTS_DIR/${name}.sh" ] || [ -f "$CODA_LAYOUTS_DIR/${name}.yaml" ]; then
             source="user"
         else
             source="builtin"
         fi
-        echo "  $name  ($source)"
+        case "$base" in
+            *.yaml) fmt_tag="yaml" ;;
+            *)      fmt_tag="sh" ;;
+        esac
+        echo "  $name  ($source, $fmt_tag)"
     done
     echo ""
     echo "Default: $DEFAULT_LAYOUT"
@@ -98,8 +106,12 @@ _coda_layout_show() {
     local layout_file=""
     if [ -f "$CODA_LAYOUTS_DIR/${name}.sh" ]; then
         layout_file="$CODA_LAYOUTS_DIR/${name}.sh"
+    elif [ -f "$CODA_LAYOUTS_DIR/${name}.yaml" ]; then
+        layout_file="$CODA_LAYOUTS_DIR/${name}.yaml"
     elif [ -f "$_CODA_DIR/layouts/${name}.sh" ]; then
         layout_file="$_CODA_DIR/layouts/${name}.sh"
+    elif [ -f "$_CODA_DIR/layouts/${name}.yaml" ]; then
+        layout_file="$_CODA_DIR/layouts/${name}.yaml"
     fi
 
     if [ -z "$layout_file" ]; then
@@ -115,33 +127,47 @@ _coda_layout_show() {
 }
 
 _coda_layout_create() {
-    local name="" snapshot=false
+    local name="" snapshot=false use_yaml=false
     while [ $# -gt 0 ]; do
         case "$1" in
             --snapshot) snapshot=true; shift ;;
+            --yaml)     use_yaml=true; shift ;;
             *) if [ -z "$name" ]; then name="$1"; fi; shift ;;
         esac
     done
 
     if [ -z "$name" ]; then
-        echo "Usage: coda layout create <name> [--snapshot]"
+        echo "Usage: coda layout create <name> [--snapshot] [--yaml]"
         return 1
     fi
 
     mkdir -p "$CODA_LAYOUTS_DIR"
-    local layout_file="$CODA_LAYOUTS_DIR/${name}.sh"
 
-    if [ -f "$layout_file" ]; then
-        echo "Layout already exists: $layout_file"
+    local ext="sh"
+    if [ "$use_yaml" = true ]; then
+        ext="yaml"
+    fi
+    local layout_file="$CODA_LAYOUTS_DIR/${name}.${ext}"
+
+    if [ -f "$CODA_LAYOUTS_DIR/${name}.sh" ] || [ -f "$CODA_LAYOUTS_DIR/${name}.yaml" ]; then
+        echo "Layout already exists: $(ls "$CODA_LAYOUTS_DIR"/${name}.* 2>/dev/null)"
         return 1
     fi
 
     if [ "$snapshot" = true ]; then
-        _coda_layout_snapshot "$name" "$layout_file"
+        if [ "$use_yaml" = true ]; then
+            _coda_layout_snapshot_yaml "$name" "$layout_file"
+        else
+            _coda_layout_snapshot "$name" "$layout_file"
+        fi
         return $?
     fi
 
-    _coda_layout_create_template "$name" "$layout_file"
+    if [ "$use_yaml" = true ]; then
+        _coda_layout_create_yaml_template "$name" "$layout_file"
+    else
+        _coda_layout_create_template "$name" "$layout_file"
+    fi
 }
 
 _coda_layout_create_template() {
@@ -194,14 +220,54 @@ _coda_layout_snapshot() {
     _coda_layout_create_template "$name" "$layout_file"
 }
 
+_coda_layout_snapshot_yaml() {
+    local name="$1" layout_file="$2"
+
+    if [ -z "${TMUX:-}" ]; then
+        echo "--snapshot requires being inside a tmux session."
+        return 1
+    fi
+
+    if command -v coda-core &>/dev/null; then
+        coda-core layout snapshot --name "$name" --output "$layout_file" --format yaml
+        return $?
+    fi
+
+    echo "coda-core not found. Install it to use --snapshot --yaml."
+    echo "Falling back to blank YAML template."
+    _coda_layout_create_yaml_template "$name" "$layout_file"
+}
+
+_coda_layout_create_yaml_template() {
+    local name="$1" layout_file="$2"
+
+    cat > "$layout_file" <<TMPL
+direction: horizontal
+panes:
+  - command: "opencode"
+    title: OpenCode
+    size: "50%"
+  - size: "50%"
+TMPL
+
+    echo "Created: $layout_file"
+    echo "Edit it, then apply: coda layout $name"
+}
+
 _coda_load_layout() {
     local name="$1"
-    local layout_file=""
+    local layout_file="" layout_type="sh"
 
     if [ -f "$CODA_LAYOUTS_DIR/${name}.sh" ]; then
         layout_file="$CODA_LAYOUTS_DIR/${name}.sh"
     elif [ -f "$_CODA_DIR/layouts/${name}.sh" ]; then
         layout_file="$_CODA_DIR/layouts/${name}.sh"
+    elif [ -f "$CODA_LAYOUTS_DIR/${name}.yaml" ]; then
+        layout_file="$CODA_LAYOUTS_DIR/${name}.yaml"
+        layout_type="yaml"
+    elif [ -f "$_CODA_DIR/layouts/${name}.yaml" ]; then
+        layout_file="$_CODA_DIR/layouts/${name}.yaml"
+        layout_type="yaml"
     fi
 
     if [ -z "$layout_file" ]; then
@@ -213,19 +279,27 @@ _coda_load_layout() {
 
     unset -f _layout_init _layout_spawn _layout_apply 2>/dev/null
 
-    # shellcheck source=/dev/null
-    source "$layout_file"
+    if [ "$layout_type" = "yaml" ]; then
+        if ! command -v coda-core &>/dev/null; then
+            echo "YAML layouts require coda-core. Install it first."
+            return 1
+        fi
+        local rendered
+        rendered=$(coda-core layout render --config "$layout_file" 2>&1)
+        if [ $? -ne 0 ]; then
+            echo "Failed to render YAML layout '$name': $rendered"
+            return 1
+        fi
+        eval "$rendered"
+    else
+        # shellcheck source=/dev/null
+        source "$layout_file"
+    fi
 
-    # Validate: _layout_init is required
     if ! declare -f _layout_init &>/dev/null && ! declare -f _layout_apply &>/dev/null; then
         echo "Layout '$name' is invalid: must define _layout_init() (or legacy _layout_apply())."
         echo "File: $layout_file"
         return 1
-    fi
-
-    # Warn if _layout_spawn is missing (not fatal)
-    if ! declare -f _layout_spawn &>/dev/null; then
-        :
     fi
 
     return 0
@@ -233,9 +307,10 @@ _coda_load_layout() {
 
 _coda_list_layouts() {
     local seen="" name
-    for f in "$CODA_LAYOUTS_DIR"/*.sh "$_CODA_DIR/layouts"/*.sh; do
+    for f in "$CODA_LAYOUTS_DIR"/*.sh "$CODA_LAYOUTS_DIR"/*.yaml "$_CODA_DIR/layouts"/*.sh "$_CODA_DIR/layouts"/*.yaml; do
         [ -f "$f" ] || continue
-        name=$(basename "${f%.sh}")
+        name=$(basename "$f")
+        name="${name%.*}"
         case "$seen" in *"|$name|"*) continue ;; esac
         seen="$seen|$name|"
         echo "$name"

--- a/lib/layout.sh
+++ b/lib/layout.sh
@@ -149,8 +149,11 @@ _coda_layout_create() {
     fi
     local layout_file="$CODA_LAYOUTS_DIR/${name}.${ext}"
 
-    if [ -f "$CODA_LAYOUTS_DIR/${name}.sh" ] || [ -f "$CODA_LAYOUTS_DIR/${name}.yaml" ]; then
-        echo "Layout already exists: $(ls "$CODA_LAYOUTS_DIR"/${name}.* 2>/dev/null)"
+    local existing=""
+    [ -f "$CODA_LAYOUTS_DIR/${name}.sh" ] && existing="$CODA_LAYOUTS_DIR/${name}.sh"
+    [ -f "$CODA_LAYOUTS_DIR/${name}.yaml" ] && existing="${existing:+$existing }$CODA_LAYOUTS_DIR/${name}.yaml"
+    if [ -n "$existing" ]; then
+        echo "Layout already exists: $existing"
         return 1
     fi
 
@@ -260,11 +263,11 @@ _coda_load_layout() {
 
     if [ -f "$CODA_LAYOUTS_DIR/${name}.sh" ]; then
         layout_file="$CODA_LAYOUTS_DIR/${name}.sh"
-    elif [ -f "$_CODA_DIR/layouts/${name}.sh" ]; then
-        layout_file="$_CODA_DIR/layouts/${name}.sh"
     elif [ -f "$CODA_LAYOUTS_DIR/${name}.yaml" ]; then
         layout_file="$CODA_LAYOUTS_DIR/${name}.yaml"
         layout_type="yaml"
+    elif [ -f "$_CODA_DIR/layouts/${name}.sh" ]; then
+        layout_file="$_CODA_DIR/layouts/${name}.sh"
     elif [ -f "$_CODA_DIR/layouts/${name}.yaml" ]; then
         layout_file="$_CODA_DIR/layouts/${name}.yaml"
         layout_type="yaml"
@@ -284,13 +287,25 @@ _coda_load_layout() {
             echo "YAML layouts require coda-core. Install it first."
             return 1
         fi
-        local rendered
-        rendered=$(coda-core layout render --config "$layout_file" 2>&1)
-        if [ $? -ne 0 ]; then
-            echo "Failed to render YAML layout '$name': $rendered"
+        local rendered_file render_error
+        rendered_file=$(mktemp "${TMPDIR:-/tmp}/coda-layout-render.XXXXXX") || {
+            echo "Failed to create temporary file for rendered layout."
+            return 1
+        }
+        if ! coda-core layout render --config "$layout_file" >"$rendered_file" 2>&1; then
+            render_error=$(cat "$rendered_file")
+            rm -f "$rendered_file"
+            echo "Failed to render YAML layout '$name': $render_error"
             return 1
         fi
-        eval "$rendered"
+        if ! bash -n "$rendered_file" >/dev/null 2>&1; then
+            rm -f "$rendered_file"
+            echo "Rendered YAML layout '$name' produced invalid shell."
+            return 1
+        fi
+        # shellcheck source=/dev/null
+        source "$rendered_file"
+        rm -f "$rendered_file"
     else
         # shellcheck source=/dev/null
         source "$layout_file"


### PR DESCRIPTION
## Summary

- Adds a declarative YAML format for defining tmux layouts, supplementing the existing bash script approach
- `coda-core layout render --config <file>` converts YAML configs into `_layout_init()`/`_layout_spawn()` bash functions
- `lib/layout.sh` discovers `.yaml` layouts alongside `.sh` (shell scripts take precedence), using `coda-core` to render at load time
- Snapshot export supports `--format yaml` to capture live tmux sessions as YAML configs
- `coda layout create <name> --yaml` scaffolds a YAML layout template; `--snapshot --yaml` captures live
- Fully backwards compatible — all existing `.sh` layouts work unchanged

## YAML Schema

```yaml
direction: vertical
border:
  status: top
  lines: heavy
panes:
  - direction: horizontal
    size: "80%"
    panes:
      - prefer: [lazygit, gitui, tig]
        title: Git
        size: "20%"
      - command: opencode
        title: OpenCode
        size: "80%"
  - title: Shell
    size: "20%"
```

Supports: nested splits, `prefer` (first-available command), `env` vars, `border` customization, percentage and fixed sizing.

## Testing

- 25 new Go tests covering YAML parsing, validation, bash rendering, tree parsing, snapshot round-trip
- All 53 Go tests pass, all 126 bats shell tests pass (1 pre-existing failure unrelated to this change)

## Files

| File | Change |
|---|---|
| `cmd/coda-core/layout_config.go` | YAML schema types, parser, validator |
| `cmd/coda-core/layout_render.go` | YAML→bash renderer |
| `cmd/coda-core/layout_snapshot_yaml.go` | tmux layout string→tree parser, snapshot→YAML export |
| `cmd/coda-core/layout.go` | `render` subcommand, `--format yaml` on snapshot |
| `lib/layout.sh` | YAML discovery, `--yaml` flag, snapshot/create support |
| `layouts/examples/*.yaml` | 4 example YAML layouts |
| `*_test.go` | 25 new tests |