### PR TITLE
feat: plugin system with versioning, slimmed installer, dynamic MCP tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,7 +76,7 @@ CODA_WATCH_COOLDOWN=60
 
 # Default tmux layout when creating sessions (see: coda layout ls)
 # Options: default, wide-twopane, classic, three-pane, four-pane
-DEFAULT_LAYOUT="four-pane"
+DEFAULT_LAYOUT="default"
 
 # Default Neovim config name (maps to ~/.config/<name>/)
 # Use NVIM_APPNAME to run different nvim configs side-by-side
@@ -90,6 +90,9 @@ CODA_PROFILES_DIR="$HOME/.config/coda/profiles"
 
 # Where user hook scripts live (override built-ins of the same name)
 CODA_HOOKS_DIR="$HOME/.config/coda/hooks"
+
+# Where plugins are installed
+CODA_PLUGINS_DIR="$HOME/.config/coda/plugins"
 
 # Where user provider plugins live (override built-ins of the same name)
 CODA_PROVIDERS_DIR="$HOME/.config/coda/providers"

--- a/completions/coda.bash
+++ b/completions/coda.bash
@@ -71,7 +71,7 @@ _coda_complete() {
         cword=$COMP_CWORD
     }
 
-    local top_subcommands="attach ls switch serve auth project feature layout profile hooks watch provider github help"
+    local top_subcommands="attach ls switch serve auth project feature layout profile hooks watch provider github plugin help"
 
     # Word positions:
     #   words[0] = coda
@@ -146,6 +146,9 @@ _coda_complete() {
                     ;;
                 github)
                     COMPREPLY=($(compgen -W "token comment status" -- "$cur"))
+                    ;;
+                plugin)
+                    COMPREPLY=($(compgen -W "install remove update ls" -- "$cur"))
                     ;;
                 attach)
                     local sessions

--- a/completions/coda.zsh
+++ b/completions/coda.zsh
@@ -78,6 +78,7 @@ _coda() {
                 'hooks:manage lifecycle hooks'
                 'provider:manage provider plugins'
                 'github:post comments as Coda bot identity'
+                'plugin:manage plugins'
                 'help:show usage'
             )
             # Add existing sessions as completions
@@ -116,6 +117,9 @@ _coda() {
                     ;;
                 github)
                     _coda_github_args
+                    ;;
+                plugin)
+                    _coda_plugin_args
                     ;;
                 serve)
                     local base="${OPENCODE_BASE_PORT:-4096}"
@@ -392,6 +396,26 @@ _coda_github_args() {
                 'status:check GitHub App configuration'
             )
             _describe 'github subcommand' subcmds
+            ;;
+    esac
+}
+
+_coda_plugin_args() {
+    local state line
+    _arguments -C \
+        '1: :->subcmd' \
+        && return 0
+
+    case $state in
+        subcmd)
+            local -a subcmds
+            subcmds=(
+                'install:install a plugin from a git repo'
+                'remove:remove an installed plugin'
+                'update:update plugin(s) via git pull'
+                'ls:list installed plugins'
+            )
+            _describe 'plugin subcommand' subcmds
             ;;
     esac
 }

--- a/docs/plugin-contracts/hooks.md
+++ b/docs/plugin-contracts/hooks.md
@@ -38,6 +38,22 @@ echo "Session $CODA_SESSION_NAME created in $CODA_SESSION_DIR"
 
 Make it executable: `chmod +x hooks/post-session-create/10-notify`
 
+## Plugin Hooks
+
+Plugins can provide hooks via the `provides.hooks` field in `plugin.json`:
+
+```json
+{
+  "provides": {
+    "hooks": {
+      "post-project-create": ["hooks/post-project-create/*"]
+    }
+  }
+}
+```
+
+Plugin hooks run after user and builtin hooks. Glob patterns are resolved relative to the plugin directory. See [plugins.md](plugins.md).
+
 ## Guarantees
 
 - Hooks receive context via exported environment variables, not positional arguments

--- a/docs/plugin-contracts/layouts.md
+++ b/docs/plugin-contracts/layouts.md
@@ -59,3 +59,5 @@ coda layout create my-layout --snapshot # capture current window
 ```
 
 Templates include both `_layout_init` and `_layout_spawn` stubs.
+
+Note: Layouts are not currently providable via plugins. Plugins can provide commands, hooks, providers, and notifications. See [plugins.md](plugins.md).

--- a/docs/plugin-contracts/notifications.md
+++ b/docs/plugin-contracts/notifications.md
@@ -1,0 +1,37 @@
+# Notification Plugin Contract
+
+Notifications are executable scripts that fire when the watcher detects an agent transition from processing to idle.
+
+## Directory Resolution
+
+Notifications are discovered from multiple sources:
+
+1. `$_CODA_DIR/notifications/` (builtin)
+2. `$CODA_NOTIFICATIONS_DIR/` (user, default: `~/.config/coda/notifications/`)
+3. Plugin notification directories (from `provides.notifications` globs in `plugin.json`)
+
+## Writing a Notification Script
+
+A notification script is any executable file in a notifications directory. The watcher runs each script when a session becomes idle.
+
+```bash
+#!/usr/bin/env bash
+# Send a terminal bell
+printf '\a'
+```
+
+The built-in `bell.sh` sends a terminal bell to all connected tmux clients.
+
+## Plugin Notifications
+
+Plugins can provide notification scripts via the `provides.notifications` field in `plugin.json`:
+
+```json
+{
+  "provides": {
+    "notifications": ["notifications/*"]
+  }
+}
+```
+
+Glob patterns are resolved relative to the plugin directory.

--- a/docs/plugin-contracts/plugins.md
+++ b/docs/plugin-contracts/plugins.md
@@ -1,0 +1,173 @@
+# Plugin System
+
+Plugins are git repos that extend coda with commands, hooks, providers, and notifications.
+
+## Plugin Storage
+
+Plugins are cloned to `$CODA_PLUGINS_DIR/<name>/` (default: `~/.config/coda/plugins/`).
+
+## User Config (`~/.config/coda/config.json`)
+
+```json
+{
+  "plugins": {
+    "git@github.com:user/coda-github.git": {
+      "enabled": true,
+      "options": {
+        "CODA_GITHUB_CLIENT_ID": "Iv23abc"
+      }
+    }
+  }
+}
+```
+
+Plugin options are exported as environment variables before the plugin's handlers are sourced.
+
+## Plugin Manifest (`plugin.json`)
+
+Each plugin repo has a `plugin.json` at the root:
+
+```json
+{
+  "name": "coda-github",
+  "version": "1.0.0",
+  "coda": "^0.1.0",
+  "description": "GitHub App bot identity for coda",
+  "provides": {
+    "commands": {
+      "github": {
+        "description": "Post comments as Coda bot identity",
+        "handler": "lib/github.sh",
+        "function": "_coda_github"
+      }
+    },
+    "hooks": {
+      "post-project-create": ["hooks/post-project-create/*"]
+    },
+    "providers": {
+      "claude-auth": "providers/claude-auth/"
+    },
+    "notifications": ["notifications/*"]
+  },
+  "dependencies": {
+    "system": ["lazygit"],
+    "npm": ["opencode-claude-auth"],
+    "go": "cmd/coda-github/"
+  },
+  "install": "install.sh"
+}
+```
+
+All fields under `provides` are optional.
+
+### `provides.commands`
+
+Maps subcommand names to shell files and functions. When the user runs `coda <cmd>`, core sources the handler and calls the function.
+
+| Field | Description |
+|-------|-------------|
+| `handler` | Relative path to the shell script |
+| `function` | Function name to call after sourcing |
+| `description` | Human-readable description |
+
+### `provides.hooks`
+
+Maps event names to glob patterns of executable hook scripts within the plugin directory. See [hooks.md](hooks.md) for events.
+
+### `provides.providers`
+
+Maps provider names to directories containing `auth.sh` and `status.sh`. See [providers.md](providers.md) for the provider contract.
+
+### `provides.notifications`
+
+Glob patterns of notification scripts. See [notifications.md](notifications.md).
+
+### `provides.mcp_tools`
+
+Registers tools with the coda MCP server so OpenCode agents can call plugin
+functionality. Each entry maps a tool name to its definition:
+
+```json
+"mcp_tools": {
+  "coda_watch_status": {
+    "description": "Check if the session watcher is running",
+    "command": ["watch", "status"]
+  },
+  "coda_github_comment": {
+    "description": "Post a comment as Coda bot",
+    "command": ["github", "comment"],
+    "params": {
+      "issue": { "type": "string", "description": "Issue or PR number" },
+      "body": { "type": "string", "description": "Comment body" },
+      "repo": { "type": "string", "description": "owner/repo", "optional": true }
+    }
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `command` | Array of coda subcommand args (e.g. `["watch", "status"]`) |
+| `description` | Human-readable description shown to agents |
+| `params` | Optional parameter definitions |
+
+Param types: `"string"`, `"boolean"`, `"cwd"` (used as working directory, not
+appended to args). String params become `--name value` flags. Boolean params
+become `--name` flags when true.
+
+### `coda` (version constraint)
+
+Specifies which versions of coda this plugin is compatible with, using
+standard semver range syntax:
+
+```json
+"coda": "^0.1.0"
+```
+
+| Syntax | Meaning |
+|--------|--------|
+| `^0.1.0` | `>=0.1.0 <1.0.0` (compatible with 0.x) |
+| `^1.2.0` | `>=1.2.0 <2.0.0` (same major) |
+| `~1.2.0` | `>=1.2.0 <1.3.0` (same minor) |
+| `>= 1.0.0 < 2.0.0` | Explicit range |
+| `1.0.0` | Exact version |
+
+At plugin load time, if the constraint doesn't match `CODA_VERSION`, the
+plugin is skipped with a warning. During `coda plugin install`, a mismatch
+prompts for confirmation.
+
+If the `coda` field is absent, the plugin is treated as compatible with any
+version.
+
+### `dependencies`
+
+| Field | Description |
+|-------|-------------|
+| `system` | Binary names that must be in PATH |
+| `npm` | npm packages to install globally |
+| `go` | Go module directory to build (installed to `~/.local/bin/`) |
+
+### `install`
+
+Optional custom install script to run after cloning and dependency installation.
+
+## CLI Commands
+
+```bash
+coda plugin install <git-url>   # Clone and install a plugin
+coda plugin remove <name>       # Remove an installed plugin
+coda plugin update [name]       # Update plugin(s) via git pull
+coda plugin ls                  # List installed plugins
+```
+
+## Plugin Lifecycle
+
+1. **Install**: `coda plugin install` clones the repo, reads `plugin.json`, installs deps, runs install script.
+2. **Load**: On shell startup, `_coda_plugin_load_all` reads `config.json`, discovers installed plugins, registers commands/hooks/providers/notifications.
+3. **Auto-detect**: When `coda` runs and config.json references uninstalled plugins, prompts to install.
+4. **Update**: `coda plugin update` does `git pull`, re-checks deps.
+5. **Remove**: `coda plugin remove` deletes the plugin directory and config entry.
+
+## Requirements
+
+`jq` is required for plugin management. If jq is not available, the plugin system is silently skipped (coda works normally without plugins).

--- a/docs/plugin-contracts/plugins.md
+++ b/docs/plugin-contracts/plugins.md
@@ -126,7 +126,7 @@ standard semver range syntax:
 
 | Syntax | Meaning |
 |--------|--------|
-| `^0.1.0` | `>=0.1.0 <1.0.0` (compatible with 0.x) |
+| `^0.1.0` | `>=0.1.0 <0.2.0` (same minor for 0.x) |
 | `^1.2.0` | `>=1.2.0 <2.0.0` (same major) |
 | `~1.2.0` | `>=1.2.0 <1.3.0` (same minor) |
 | `>= 1.0.0 < 2.0.0` | Explicit range |

--- a/docs/plugin-contracts/providers.md
+++ b/docs/plugin-contracts/providers.md
@@ -44,3 +44,19 @@ mkdir -p ~/.config/coda/providers/my-provider
 ```
 
 Set `CODA_PROVIDER_MODE=my-provider` in `.env` to activate it.
+
+## Plugin Providers
+
+Plugins can provide providers via the `provides.providers` field in `plugin.json`:
+
+```json
+{
+  "provides": {
+    "providers": {
+      "my-provider": "providers/my-provider/"
+    }
+  }
+}
+```
+
+Plugin providers follow the same contract (auth.sh + status.sh) and are checked after user and builtin directories. See [plugins.md](plugins.md).

--- a/install.sh
+++ b/install.sh
@@ -1,33 +1,8 @@
 #!/usr/bin/env bash
-#
-# install.sh - Bootstrap an Ubuntu Server VM for AI-assisted development
-#
-# Idempotent: safe to run multiple times. Each step checks whether it has
-# already been done and skips or updates as appropriate.
-#
-# Usage:
-#   chmod +x install.sh
-#   ./install.sh
-#
-# Overrides (environment variables or .env):
-#   SKIP_TAILSCALE=true      Skip Tailscale installation
-#   SKIP_OPENCODE=true       Skip OpenCode installation
-#   SKIP_CLAUDE=true         Skip Claude Code CLI installation
-#   SKIP_OHMYPOSH=true       Skip Oh My Posh installation
-#   SKIP_YAZI=true           Skip yazi file manager installation
-#   SKIP_LAZYGIT=true        Skip lazygit installation
-#   NODE_MAJOR_VERSION=20    Node.js major version (default: 20)
-#   NVIM_MIN_VERSION=0.11.0  Minimum acceptable Neovim version
-#   PROJECTS_DIR=~/projects  Where git repos live
-
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Resolve a stable path for lines written to shell RC files.
-# In a bare-repo + worktree layout, SCRIPT_DIR may point to an ephemeral
-# feature worktree that gets deleted by "coda feature done".  We detect this
-# and pin to the permanent "main" worktree instead.
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 if [ -d "$PROJECT_ROOT/.bare" ] && [ -d "$PROJECT_ROOT/main" ]; then
     STABLE_DIR="$PROJECT_ROOT/main"
@@ -35,9 +10,40 @@ else
     STABLE_DIR="$SCRIPT_DIR"
 fi
 
-# ---------------------------------------------------------------------------
-# Load config — create .env from template if it doesn't exist yet
-# ---------------------------------------------------------------------------
+# --- Parse CLI options (override .env and defaults) ---
+
+usage() {
+    cat <<'EOF'
+Usage: install.sh [options]
+
+Install coda core: shell functions, completions, man page, and Go helper.
+
+Options:
+  --projects-dir DIR     Where projects live (default: ~/projects)
+  --skip-go              Don't build the coda-core Go binary
+  --skip-mcp             Don't set up the MCP server
+  --skip-man             Don't install the man page
+  --help                 Show this help
+
+All options can also be set via .env or environment variables:
+  PROJECTS_DIR, SKIP_GO, SKIP_MCP, SKIP_MAN
+EOF
+    exit 0
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --projects-dir)  PROJECTS_DIR="$2"; shift 2 ;;
+        --projects-dir=*) PROJECTS_DIR="${1#*=}"; shift ;;
+        --skip-go)       SKIP_GO=true; shift ;;
+        --skip-mcp)      SKIP_MCP=true; shift ;;
+        --skip-man)      SKIP_MAN=true; shift ;;
+        --help|-h)       usage ;;
+        *) echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+# --- Load .env (CLI options above take precedence) ---
 
 if [ ! -f "$SCRIPT_DIR/.env" ] && [ -f "$SCRIPT_DIR/.env.example" ]; then
     cp "$SCRIPT_DIR/.env.example" "$SCRIPT_DIR/.env"
@@ -46,371 +52,121 @@ if [ ! -f "$SCRIPT_DIR/.env" ] && [ -f "$SCRIPT_DIR/.env.example" ]; then
 fi
 
 if [ -f "$SCRIPT_DIR/.env" ]; then
-    # shellcheck source=/dev/null
     set -a; source "$SCRIPT_DIR/.env"; set +a
 fi
 
-# Defaults (environment or .env take precedence over these)
-NODE_MAJOR_VERSION="${NODE_MAJOR_VERSION:-20}"
-NVIM_MIN_VERSION="${NVIM_MIN_VERSION:-0.11.0}"
 PROJECTS_DIR="${PROJECTS_DIR:-$HOME/projects}"
-SKIP_TAILSCALE="${SKIP_TAILSCALE:-false}"
-SKIP_OPENCODE="${SKIP_OPENCODE:-false}"
-SKIP_CLAUDE="${SKIP_CLAUDE:-false}"
-SKIP_OHMYPOSH="${SKIP_OHMYPOSH:-false}"
-SKIP_YAZI="${SKIP_YAZI:-false}"
-SKIP_LAZYGIT="${SKIP_LAZYGIT:-false}"
+SKIP_GO="${SKIP_GO:-false}"
+SKIP_MCP="${SKIP_MCP:-false}"
+SKIP_MAN="${SKIP_MAN:-false}"
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+# --- Helpers ---
 
-step() { echo ""; echo "==> $*"; }
-ok()   { echo "    [ok] $*"; }
-info() { echo "    $*"; }
+step()  { echo ""; echo "==> $*"; }
+ok()    { echo "    [ok] $*"; }
+info()  { echo "    $*"; }
+warn()  { echo "    [warn] $*"; }
 
-version_ge() {
-    # Returns 0 (true) if version $1 >= $2
-    [ "$(printf '%s\n' "$1" "$2" | sort -V | head -1)" = "$2" ]
-}
+# --- Check core dependencies ---
 
-# Detect architecture for Neovim download
-case "$(uname -m)" in
-    x86_64)  NVIM_ARCH="nvim-linux-x86_64" ;;
-    aarch64) NVIM_ARCH="nvim-linux-arm64"  ;;
-    *)
-        echo "Unsupported architecture: $(uname -m)"
-        exit 1
-        ;;
-esac
+step "Checking core dependencies"
 
-# ---------------------------------------------------------------------------
-# Banner
-# ---------------------------------------------------------------------------
+_missing=0
+for dep in bash git tmux; do
+    if command -v "$dep" &>/dev/null; then
+        ok "$dep"
+    else
+        warn "$dep is REQUIRED but not found"
+        _missing=1
+    fi
+done
 
+if [ "$_missing" -eq 1 ]; then
+    echo ""
+    echo "ERROR: Missing required dependencies. Install them and re-run."
+    exit 1
+fi
+
+_optional_missing=()
+for dep in jq fzf curl; do
+    if command -v "$dep" &>/dev/null; then
+        ok "$dep"
+    else
+        _optional_missing+=("$dep")
+    fi
+done
+
+if ! command -v go &>/dev/null; then
+    _optional_missing+=("go")
+fi
+if ! command -v node &>/dev/null; then
+    _optional_missing+=("node")
+fi
+
+if [ ${#_optional_missing[@]} -gt 0 ]; then
+    info "Optional (some features disabled without these): ${_optional_missing[*]}"
+fi
+
+# --- Banner ---
+
+echo ""
 echo "===================================================="
-echo "  Coda — Install"
+echo "  coda v$(grep -oP 'CODA_VERSION="\K[^"]+' "$SCRIPT_DIR/shell-functions.sh" 2>/dev/null || echo '?') — Install"
 echo "===================================================="
 echo ""
-echo "  Node.js version : v${NODE_MAJOR_VERSION}"
-echo "  Neovim minimum  : >= ${NVIM_MIN_VERSION}"
-echo "  Projects dir    : ${PROJECTS_DIR}"
-echo "  Tailscale       : $([ "$SKIP_TAILSCALE" = "true" ] && echo "skip" || echo "install")"
-echo "  OpenCode        : $([ "$SKIP_OPENCODE"  = "true" ] && echo "skip" || echo "install")"
-echo "  Claude CLI      : $([ "$SKIP_CLAUDE"    = "true" ] && echo "skip" || echo "install")"
-echo "  Oh My Posh      : $([ "$SKIP_OHMYPOSH" = "true" ] && echo "skip" || echo "install")"
-echo "  yazi            : $([ "$SKIP_YAZI"     = "true" ] && echo "skip" || echo "install")"
-echo "  lazygit         : $([ "$SKIP_LAZYGIT"  = "true" ] && echo "skip" || echo "install")"
-echo ""
 
 # ===========================================================================
-# 1. System packages
+# 1. coda-core Go binary (layout snapshot helper)
 # ===========================================================================
 
-step "[1/14] System packages"
+step "[1/5] coda-core binary"
 
-sudo apt-get update -qq
-sudo apt-get upgrade -y -qq
-sudo apt-get install -y -qq \
-    git \
-    tmux \
-    mosh \
-    curl \
-    wget \
-    build-essential \
-    htop \
-    jq \
-    lsof \
-    unzip \
-    ca-certificates \
-    gnupg
-
-ok "Core packages installed"
-
-# ===========================================================================
-# 2. Neovim
-# ===========================================================================
-
-step "[2/14] Neovim (>= ${NVIM_MIN_VERSION})"
-
-NVIM_INSTALLED_VERSION=""
-if command -v nvim &>/dev/null; then
-    NVIM_INSTALLED_VERSION="$(nvim --version 2>/dev/null | head -1 | sed 's/NVIM v//')"
-fi
-
-if [ -n "$NVIM_INSTALLED_VERSION" ] && version_ge "$NVIM_INSTALLED_VERSION" "$NVIM_MIN_VERSION"; then
-    ok "Neovim ${NVIM_INSTALLED_VERSION} — up to date"
-else
-    if [ -n "$NVIM_INSTALLED_VERSION" ]; then
-        info "Upgrading from ${NVIM_INSTALLED_VERSION} (need >= ${NVIM_MIN_VERSION})..."
-    else
-        info "Installing Neovim..."
-    fi
-
-    NVIM_ARCHIVE="${NVIM_ARCH}.tar.gz"
-    NVIM_URL="https://github.com/neovim/neovim/releases/latest/download/${NVIM_ARCHIVE}"
-    NVIM_INSTALL_DIR="/opt/nvim"
-    TMP_DIR="$(mktemp -d)"
-
-    curl -fsSL "$NVIM_URL" -o "$TMP_DIR/${NVIM_ARCHIVE}"
-    sudo rm -rf "$NVIM_INSTALL_DIR"
-    sudo mkdir -p "$NVIM_INSTALL_DIR"
-    sudo tar -C "$NVIM_INSTALL_DIR" --strip-components=1 -xzf "$TMP_DIR/${NVIM_ARCHIVE}"
-    rm -rf "$TMP_DIR"
-    sudo ln -sf "$NVIM_INSTALL_DIR/bin/nvim" /usr/local/bin/nvim
-
-    ok "Neovim $(nvim --version | head -1) installed to $NVIM_INSTALL_DIR"
-fi
-
-# ===========================================================================
-# 3. Node.js
-# ===========================================================================
-
-step "[3/14] Node.js ${NODE_MAJOR_VERSION}"
-
-INSTALLED_NODE_MAJOR=0
-if command -v node &>/dev/null; then
-    INSTALLED_NODE_MAJOR="$(node --version 2>/dev/null | sed 's/v//' | cut -d. -f1)"
-fi
-
-if [ "${INSTALLED_NODE_MAJOR}" -ge "${NODE_MAJOR_VERSION}" ] 2>/dev/null; then
-    ok "Node.js $(node --version) — up to date (major >= ${NODE_MAJOR_VERSION})"
-else
-    info "Installing Node.js ${NODE_MAJOR_VERSION} via NodeSource..."
-    sudo mkdir -p /etc/apt/keyrings
-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
-        | sudo gpg --yes --dearmor -o /etc/apt/keyrings/nodesource.gpg
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR_VERSION}.x nodistro main" \
-        | sudo tee /etc/apt/sources.list.d/nodesource.list >/dev/null
-    sudo apt-get update -qq
-    sudo apt-get install -y -qq nodejs
-    ok "Node.js $(node --version) installed"
-fi
-
-# ===========================================================================
-# 4. OpenCode
-# ===========================================================================
-
-step "[4/14] OpenCode"
-
-mkdir -p ~/.npm-global
-npm config set prefix '~/.npm-global'
-# Add to ~/.bashrc or ~/.zshrc:
-export PATH="$HOME/.npm-global/bin:$PATH"
-
-if [ "$SKIP_OPENCODE" = "true" ]; then
-    info "Skipping (SKIP_OPENCODE=true)"
-elif command -v opencode &>/dev/null; then
-    ok "opencode — already installed"
-else
-    info "Installing OpenCode..."
-    npm install -g opencode-ai@latest
-    ok "OpenCode installed"
-fi
-
-# ===========================================================================
-# 5. Claude Code CLI
-# ===========================================================================
-
-step "[5/14] Claude Code CLI"
-
-if [ "$SKIP_CLAUDE" = "true" ]; then
-    info "Skipping (SKIP_CLAUDE=true)"
-elif command -v claude &>/dev/null; then
-    ok "claude — already installed"
-else
-    info "Installing Claude Code CLI..."
-    npm install -g @anthropic-ai/claude-code
-    ok "Claude Code CLI installed"
-fi
-
-# ===========================================================================
-# 6. fzf
-# ===========================================================================
-
-step "[6/14] fzf"
-
-if command -v fzf &>/dev/null; then
-    ok "fzf $(fzf --version 2>/dev/null | head -1) — already installed"
-elif [ -d "$HOME/.fzf/.git" ]; then
-    info "Updating existing fzf..."
-    git -C "$HOME/.fzf" pull --quiet
-    "$HOME/.fzf/install" --bin
-    sudo ln -sf "$HOME/.fzf/bin/fzf" /usr/local/bin/fzf
-    ok "fzf updated"
-else
-    info "Installing fzf..."
-    git clone --depth 1 https://github.com/junegunn/fzf.git "$HOME/.fzf"
-    "$HOME/.fzf/install" --bin
-    sudo ln -sf "$HOME/.fzf/bin/fzf" /usr/local/bin/fzf
-    ok "fzf installed"
-fi
-
-# ===========================================================================
-# 7. yazi (terminal file manager — used by four-pane layout)
-# ===========================================================================
-
-step "[7/14] yazi"
-
-if [ "$SKIP_YAZI" = "true" ]; then
-    info "Skipping (SKIP_YAZI=true)"
-elif command -v yazi &>/dev/null; then
-    ok "yazi $(yazi --version 2>/dev/null | head -1) — already installed"
-else
-    info "Installing yazi..."
-    case "$(uname -m)" in
-        x86_64)  YAZI_ARCH="x86_64-unknown-linux-gnu" ;;
-        aarch64) YAZI_ARCH="aarch64-unknown-linux-gnu" ;;
-        *)       YAZI_ARCH="" ;;
-    esac
-    if [ -n "$YAZI_ARCH" ]; then
-        TMP_DIR="$(mktemp -d)"
-        curl -fsSL "https://github.com/sxyazi/yazi/releases/latest/download/yazi-${YAZI_ARCH}.zip" \
-            -o "$TMP_DIR/yazi.zip"
-        unzip -o "$TMP_DIR/yazi.zip" -d "$TMP_DIR" >/dev/null
-        sudo install "$TMP_DIR/yazi-${YAZI_ARCH}/yazi" /usr/local/bin/yazi
-        rm -rf "$TMP_DIR"
-        ok "yazi $(yazi --version 2>/dev/null | head -1) installed"
-    else
-        info "Unsupported architecture for yazi: $(uname -m)"
-    fi
-fi
-
-# ===========================================================================
-# 8. lazygit (terminal git UI — used by four-pane layout)
-# ===========================================================================
-
-step "[8/14] lazygit"
-
-if [ "$SKIP_LAZYGIT" = "true" ]; then
-    info "Skipping (SKIP_LAZYGIT=true)"
-elif command -v lazygit &>/dev/null; then
-    ok "lazygit $(lazygit --version 2>/dev/null | sed 's/.*version=//' | cut -d, -f1) — already installed"
-else
-    info "Installing lazygit..."
-    LAZYGIT_VERSION="$(curl -fsSL 'https://api.github.com/repos/jesseduffield/lazygit/releases/latest' | jq -r '.tag_name' | sed 's/v//')"
-    case "$(uname -m)" in
-        x86_64)  LAZYGIT_ARCH="x86_64" ;;
-        aarch64) LAZYGIT_ARCH="arm64"   ;;
-        *)       LAZYGIT_ARCH="" ;;
-    esac
-    if [ -n "$LAZYGIT_ARCH" ]; then
-        TMP_DIR="$(mktemp -d)"
-        curl -fsSL "https://github.com/jesseduffield/lazygit/releases/latest/download/lazygit_${LAZYGIT_VERSION}_Linux_${LAZYGIT_ARCH}.tar.gz" \
-            -o "$TMP_DIR/lazygit.tar.gz"
-        tar xf "$TMP_DIR/lazygit.tar.gz" -C "$TMP_DIR" lazygit
-        sudo install "$TMP_DIR/lazygit" /usr/local/bin/lazygit
-        rm -rf "$TMP_DIR"
-        ok "lazygit ${LAZYGIT_VERSION} installed"
-    else
-        info "Unsupported architecture for lazygit: $(uname -m)"
-    fi
-fi
-
-# ===========================================================================
-# 9. Oh My Posh
-# ===========================================================================
-
-step "[9/14] Oh My Posh"
-
-if [ "$SKIP_OHMYPOSH" = "true" ]; then
-    info "Skipping (SKIP_OHMYPOSH=true)"
-elif command -v oh-my-posh &>/dev/null; then
-    ok "oh-my-posh $(oh-my-posh version 2>/dev/null) — already installed"
-else
-    info "Installing Oh My Posh..."
-    mkdir -p "$HOME/.local/bin"
-    curl -fsSL https://ohmyposh.dev/install.sh | bash -s -- -d "$HOME/.local/bin"
-    ok "Oh My Posh installed to ~/.local/bin"
-fi
-
-# ===========================================================================
-# 10. tmux Plugin Manager (TPM)
-# ===========================================================================
-
-step "[10/14] tmux Plugin Manager (TPM)"
-
-TPM_DIR="$HOME/.tmux/plugins/tpm"
-
-if [ -d "$TPM_DIR/.git" ]; then
-    git -C "$TPM_DIR" pull --quiet 2>/dev/null || true
-    ok "TPM updated"
-elif [ -d "$TPM_DIR" ]; then
-    info "Incomplete TPM directory found, re-cloning..."
-    rm -rf "$TPM_DIR"
-    git clone --quiet https://github.com/tmux-plugins/tpm "$TPM_DIR"
-    ok "TPM installed"
-else
-    git clone --quiet https://github.com/tmux-plugins/tpm "$TPM_DIR"
-    ok "TPM installed to $TPM_DIR"
-fi
-
-# ===========================================================================
-# 11. Tailscale
-# ===========================================================================
-
-step "[11/14] Tailscale"
-
-if [ "$SKIP_TAILSCALE" = "true" ]; then
-    info "Skipping (SKIP_TAILSCALE=true)"
-elif command -v tailscale &>/dev/null; then
-    ok "Tailscale $(tailscale --version 2>/dev/null | head -1) — already installed"
-else
-    info "Installing Tailscale..."
-    curl -fsSL https://tailscale.com/install.sh | sh
-    ok "Tailscale installed"
-fi
-
-# ===========================================================================
-# 12. coda-core (Go helper binary)
-# ===========================================================================
-
-step "[12/14] coda-core binary"
-
-_coda_core_stale=false
-_coda_core_installed="$HOME/.local/bin/coda-core"
-mkdir -p "$(dirname "$_coda_core_installed")"
-if [ ! -f "$_coda_core_installed" ]; then
-    _coda_core_stale=true
-elif [ -f "$SCRIPT_DIR/coda-core" ]; then
-    for _gofile in "$SCRIPT_DIR"/cmd/coda-core/*.go; do
-        [ -f "$_gofile" ] && [ "$_gofile" -nt "$SCRIPT_DIR/coda-core" ] && _coda_core_stale=true
-    done
-    [ "$SCRIPT_DIR/coda-core" -nt "$_coda_core_installed" ] && _coda_core_stale=true
-else
-    for _gofile in "$SCRIPT_DIR"/cmd/coda-core/*.go; do
-        [ -f "$_gofile" ] && [ "$_gofile" -nt "$_coda_core_installed" ] && _coda_core_stale=true
-    done
-fi
-if [ "$_coda_core_stale" = "false" ]; then
-    ok "coda-core — up to date"
-elif command -v go &>/dev/null; then
-    info "Building coda-core..."
-    (cd "$SCRIPT_DIR" && go build -o coda-core ./cmd/coda-core/)
-    cp "$SCRIPT_DIR/coda-core" "$HOME/.local/bin/coda-core"
-    ok "coda-core built and installed to ~/.local/bin/"
-else
+if [ "$SKIP_GO" = "true" ]; then
+    info "Skipping (--skip-go)"
+elif ! command -v go &>/dev/null; then
     info "Go not found — skipping coda-core build"
-    info "Shell functions will use built-in fallbacks"
+    info "Layout snapshot will not be available"
+else
+    _coda_core_stale=false
+    _coda_core_installed="$HOME/.local/bin/coda-core"
+    mkdir -p "$(dirname "$_coda_core_installed")"
+    if [ ! -f "$_coda_core_installed" ]; then
+        _coda_core_stale=true
+    else
+        for _gofile in "$SCRIPT_DIR"/cmd/coda-core/*.go; do
+            [ -f "$_gofile" ] && [ "$_gofile" -nt "$_coda_core_installed" ] && _coda_core_stale=true
+        done
+    fi
+    if [ "$_coda_core_stale" = "false" ]; then
+        ok "coda-core — up to date"
+    else
+        info "Building coda-core..."
+        (cd "$SCRIPT_DIR" && go build -o "$_coda_core_installed" ./cmd/coda-core/)
+        ok "coda-core built and installed to ~/.local/bin/"
+    fi
 fi
 
 # ===========================================================================
-# 13. MCP server (exposes coda tools to OpenCode agents)
+# 2. MCP server
 # ===========================================================================
 
-step "[13/14] MCP server"
+step "[2/5] MCP server"
 
 MCP_DIR="$STABLE_DIR/mcp-server"
 OPENCODE_CONFIG="$HOME/.config/opencode/opencode.json"
 MCP_SERVER_PATH="$STABLE_DIR/mcp-server/server.js"
 
-if [ -d "$MCP_DIR" ] && command -v node &>/dev/null; then
+if [ "$SKIP_MCP" = "true" ]; then
+    info "Skipping (--skip-mcp)"
+elif [ ! -d "$MCP_DIR" ]; then
+    info "MCP server directory not found — skipping"
+elif ! command -v node &>/dev/null; then
+    info "Node.js not found — skipping MCP server"
+    info "Install Node.js to enable MCP support for OpenCode agents"
+else
     if [ ! -d "$MCP_DIR/node_modules" ] || [ "$MCP_DIR/package.json" -nt "$MCP_DIR/node_modules/.package-lock.json" ]; then
         info "Installing MCP server dependencies..."
         (cd "$MCP_DIR" && npm install --no-fund --no-audit --loglevel=error)
-        ok "MCP server dependencies installed"
-    else
-        ok "MCP server dependencies — up to date"
     fi
 
     mkdir -p "$HOME/.config/opencode"
@@ -428,61 +184,16 @@ if [ -d "$MCP_DIR" ] && command -v node &>/dev/null; then
             ok "MCP server registered in opencode.json"
         fi
     else
-        info "jq not found — skipping opencode.json MCP registration"
-        info "Add manually: {\"mcp\":{\"coda\":{\"type\":\"local\",\"command\":[\"node\",\"$MCP_SERVER_PATH\"],\"enabled\":true}}}"
-    fi
-else
-    if [ ! -d "$MCP_DIR" ]; then
-        info "MCP server directory not found — skipping"
-    else
-        info "Node.js not found — skipping MCP server setup"
+        info "jq not found — add MCP manually to opencode.json:"
+        info "  {\"mcp\":{\"coda\":{\"type\":\"local\",\"command\":[\"node\",\"$MCP_SERVER_PATH\"],\"enabled\":true}}}"
     fi
 fi
 
 # ===========================================================================
-# 14. Config files, shell integration, SSH
+# 3. Shell functions and completions
 # ===========================================================================
 
-step "[14/14] Config files, completions, and man page"
-
-# --- tmux config ---
-
-if [ -f "$HOME/.tmux.conf" ] && diff -q "$SCRIPT_DIR/tmux.conf" "$HOME/.tmux.conf" &>/dev/null; then
-    ok "~/.tmux.conf — up to date"
-else
-    if [ -f "$HOME/.tmux.conf" ]; then
-        cp "$HOME/.tmux.conf" "$HOME/.tmux.conf.backup.$(date +%Y%m%d%H%M%S)"
-    fi
-    cp "$SCRIPT_DIR/tmux.conf" "$HOME/.tmux.conf"
-    ok "~/.tmux.conf installed"
-fi
-
-# --- OpenCode TUI keybinds ---
-
-mkdir -p "$HOME/.config/opencode"
-
-if [ -f "$HOME/.config/opencode/tui.json" ] && diff -q "$SCRIPT_DIR/tui.json.example" "$HOME/.config/opencode/tui.json" &>/dev/null; then
-    ok "~/.config/opencode/tui.json — up to date"
-else
-    if [ -f "$HOME/.config/opencode/tui.json" ]; then
-        cp "$HOME/.config/opencode/tui.json" "$HOME/.config/opencode/tui.json.backup.$(date +%Y%m%d%H%M%S)"
-    fi
-    cp "$SCRIPT_DIR/tui.json.example" "$HOME/.config/opencode/tui.json"
-    ok "~/.config/opencode/tui.json installed"
-fi
-
-# --- Helper scripts (tmux pane picker, etc.) ---
-
-mkdir -p "$HOME/.local/bin"
-for script in "$SCRIPT_DIR"/scripts/*; do
-    [ -f "$script" ] || continue
-    name="$(basename "${script%.sh}")"
-    cp "$script" "$HOME/.local/bin/$name"
-    chmod +x "$HOME/.local/bin/$name"
-done
-ok "Helper scripts installed to ~/.local/bin/"
-
-# --- Shell functions and completions ---
+step "[3/5] Shell functions and completions"
 
 RC_FILES=()
 [ -f "$HOME/.bashrc" ] && RC_FILES+=("$HOME/.bashrc")
@@ -505,14 +216,9 @@ if [ "${#RC_FILES[@]}" -gt 0 ]; then
         ok "Shell functions updated in $SHELL_RC"
     done
 else
-    info "No shell RC found. Add these lines manually:"
+    info "No shell RC found. Add manually:"
     info "  $SOURCE_LINE"
-    if [ "$SCRIPT_DIR" != "$STABLE_DIR" ]; then
-        info "  [ -f \"$SCRIPT_DIR/shell-functions.sh\" ] && source \"$SCRIPT_DIR/shell-functions.sh\""
-    fi
 fi
-
-# --- Tab completion ---
 
 if [ -f "$HOME/.bashrc" ]; then
     COMPLETION_LINES=("source \"$STABLE_DIR/completions/coda.bash\"")
@@ -543,66 +249,40 @@ if [ -f "$HOME/.zshrc" ]; then
     ok "Zsh completion updated in ~/.zshrc"
 fi
 
-# --- Oh My Posh prompt ---
+# ===========================================================================
+# 4. Man page
+# ===========================================================================
 
-if [ "$SKIP_OHMYPOSH" != "true" ] && command -v oh-my-posh &>/dev/null; then
-    if [ -f "$HOME/.bashrc" ]; then
-        if grep -qF "oh-my-posh init" "$HOME/.bashrc" 2>/dev/null; then
-            ok "Oh My Posh — already initialized in ~/.bashrc"
-        else
-            printf '\n# Oh My Posh prompt\nexport PATH="$HOME/.local/bin:$PATH"\neval "$(oh-my-posh init bash)"\n' >> "$HOME/.bashrc"
-            ok "Oh My Posh initialized in ~/.bashrc"
-        fi
-    fi
+step "[4/5] Man page"
 
-    if [ -f "$HOME/.zshrc" ]; then
-        if grep -qF "oh-my-posh init" "$HOME/.zshrc" 2>/dev/null; then
-            ok "Oh My Posh — already initialized in ~/.zshrc"
-        else
-            printf '\n# Oh My Posh prompt\nexport PATH="$HOME/.local/bin:$PATH"\neval "$(oh-my-posh init zsh)"\n' >> "$HOME/.zshrc"
-            ok "Oh My Posh initialized in ~/.zshrc"
-        fi
+if [ "$SKIP_MAN" = "true" ]; then
+    info "Skipping (--skip-man)"
+else
+    MAN_DIR="/usr/local/share/man/man1"
+    if sudo mkdir -p "$MAN_DIR" 2>/dev/null; then
+        sudo cp "$SCRIPT_DIR/man/coda.1" "$MAN_DIR/coda.1"
+        sudo mandb -q 2>/dev/null || true
+        ok "Man page installed (man coda)"
+    else
+        info "Could not install man page (no sudo?)"
     fi
 fi
 
-# --- Man page ---
+# ===========================================================================
+# 5. Directories and .env
+# ===========================================================================
 
-MAN_DIR="/usr/local/share/man/man1"
-if sudo mkdir -p "$MAN_DIR" 2>/dev/null; then
-    sudo cp "$SCRIPT_DIR/man/coda.1" "$MAN_DIR/coda.1"
-    sudo mandb -q 2>/dev/null || true
-    ok "Man page installed (man coda)"
-else
-    info "Could not install man page (no sudo?). Install manually:"
-    info "  sudo cp $SCRIPT_DIR/man/coda.1 /usr/local/share/man/man1/"
-fi
-
-# --- SSH server keepalive ---
-
-if grep -q "^ClientAliveInterval" /etc/ssh/sshd_config 2>/dev/null; then
-    ok "SSH keepalive — already configured"
-else
-    printf '\nClientAliveInterval 60\nClientAliveCountMax 3\n' \
-        | sudo tee -a /etc/ssh/sshd_config >/dev/null
-    sudo systemctl restart sshd 2>/dev/null || sudo systemctl restart ssh 2>/dev/null || true
-    ok "SSH keepalive configured (60s interval, 3 retries)"
-fi
-
-# --- Directories ---
+step "[5/5] Directories"
 
 mkdir -p "$PROJECTS_DIR"
-mkdir -p "$HOME/.config/opencode"
-mkdir -p "${CODA_LAYOUTS_DIR:-$HOME/.config/coda/layouts}"
-mkdir -p "${CODA_PROFILES_DIR:-$HOME/.config/coda/profiles}"
-ok "Directories: $PROJECTS_DIR, ~/.config/opencode, ~/.config/coda/{layouts,profiles}"
-
-# --- tmux plugins (headless install via TPM batch mode) ---
-
-if [ -x "$TPM_DIR/bin/install_plugins" ] && [ -f "$HOME/.tmux.conf" ]; then
-    TMUX_PLUGIN_MANAGER_PATH="$HOME/.tmux/plugins" \
-        "$TPM_DIR/bin/install_plugins" 2>/dev/null || true
-    ok "tmux plugins installed"
-fi
+mkdir -p "$HOME/.config/coda/layouts"
+mkdir -p "$HOME/.config/coda/profiles"
+mkdir -p "$HOME/.config/coda/hooks"
+mkdir -p "$HOME/.config/coda/providers"
+mkdir -p "$HOME/.config/coda/notifications"
+mkdir -p "$HOME/.config/coda/plugins"
+mkdir -p "$HOME/.local/bin"
+ok "$PROJECTS_DIR, ~/.config/coda/{layouts,profiles,hooks,providers,notifications,plugins}"
 
 # ===========================================================================
 # Done
@@ -613,39 +293,14 @@ echo "===================================================="
 echo "  Install complete!"
 echo "===================================================="
 echo ""
-echo "Next steps:"
+echo "Reload your shell:"
+[ -f "$HOME/.bashrc" ] && echo "  source ~/.bashrc"
+[ -f "$HOME/.zshrc" ] && echo "  source ~/.zshrc"
 echo ""
-
-if [ "$SKIP_TAILSCALE" != "true" ] && command -v tailscale &>/dev/null; then
-    if ! tailscale status &>/dev/null 2>&1; then
-        echo "  1. Connect to Tailscale:"
-        echo "       sudo tailscale up"
-        echo ""
-    fi
-fi
-
-echo "  Reload your shell:"
-if [ -f "$HOME/.bashrc" ]; then
-    echo "       source ~/.bashrc"
-fi
-if [ -f "$HOME/.zshrc" ]; then
-    echo "       source ~/.zshrc"
-fi
+echo "Install plugins:"
+echo "  coda plugin install git@github.com:evanstern/coda-provider-claude-auth.git"
+echo "  coda plugin install git@github.com:evanstern/coda-watch.git"
+echo "  coda plugin install git@github.com:evanstern/coda-github.git"
 echo ""
-echo "  Provider-aware OpenCode setup:"
-echo "       # Claude path"
-echo "       claude auth login"
-echo "       coda auth"
-echo ""
-echo "       # CLIProxyAPI path"
-echo "       # edit .env: CODA_PROVIDER_MODE=cliproxyapi"
-echo "       # edit .env: CLIPROXYAPI_BASE_URL=http://localhost:8317/v1"
-echo "       coda auth"
-echo "       coda provider status"
-echo ""
-echo "  Start a tmux session:"
-echo "       tmux"
-echo ""
-echo "  Start your first project:"
-echo "       coda project start --repo <git-repo-url>"
-echo ""
+echo "Start your first project:"
+echo "  coda project start --repo <git-repo-url>"

--- a/install.sh
+++ b/install.sh
@@ -31,19 +31,7 @@ EOF
     exit 0
 }
 
-while [ $# -gt 0 ]; do
-    case "$1" in
-        --projects-dir)  PROJECTS_DIR="$2"; shift 2 ;;
-        --projects-dir=*) PROJECTS_DIR="${1#*=}"; shift ;;
-        --skip-go)       SKIP_GO=true; shift ;;
-        --skip-mcp)      SKIP_MCP=true; shift ;;
-        --skip-man)      SKIP_MAN=true; shift ;;
-        --help|-h)       usage ;;
-        *) echo "Unknown option: $1"; usage ;;
-    esac
-done
-
-# --- Load .env (CLI options above take precedence) ---
+# --- Load .env first, then CLI overrides take precedence ---
 
 if [ ! -f "$SCRIPT_DIR/.env" ] && [ -f "$SCRIPT_DIR/.env.example" ]; then
     cp "$SCRIPT_DIR/.env.example" "$SCRIPT_DIR/.env"
@@ -59,6 +47,18 @@ PROJECTS_DIR="${PROJECTS_DIR:-$HOME/projects}"
 SKIP_GO="${SKIP_GO:-false}"
 SKIP_MCP="${SKIP_MCP:-false}"
 SKIP_MAN="${SKIP_MAN:-false}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --projects-dir)  PROJECTS_DIR="$2"; shift 2 ;;
+        --projects-dir=*) PROJECTS_DIR="${1#*=}"; shift ;;
+        --skip-go)       SKIP_GO=true; shift ;;
+        --skip-mcp)      SKIP_MCP=true; shift ;;
+        --skip-man)      SKIP_MAN=true; shift ;;
+        --help|-h)       usage ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
 
 # --- Helpers ---
 

--- a/layouts/default.sh
+++ b/layouts/default.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# default.sh — tmux layout: single pane running opencode
+# default.sh u2014 tmux layout: opencode (top 80%) + shell (bottom 20%)
 #
 # Called by _coda_attach / coda layout apply with:
 #   $1 = session name
@@ -8,19 +8,25 @@
 #   $3 = NVIM_APPNAME (unused in this layout)
 #
 # Layout:
-#   ┌──────────────────────────────────────┐
-#   │                                       │
-#   │              opencode                 │
-#   │          (falls back to $SHELL)       │
-#   │                                       │
-#   └──────────────────────────────────────┘
+#   u250cu2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2510
+#   u2502                                       u2502
+#   u2502              opencode                 u2502
+#   u2502              (80%)                    u2502
+#   u2502                                       u2502
+#   u251cu2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2524
+#   u2502              shell (20%)              u2502
+#   u2514u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2518
 
 _layout_init() {
     local session="$1" dir="$2"
     tmux new-session -d -s "$session" -x "${COLUMNS:-200}" -y "${LINES:-50}" -c "$dir" "opencode; exec \$SHELL"
+    tmux split-window -t "$session" -v -l 20% -c "$dir"
+    tmux select-pane -t "$session:.0"
 }
 
 _layout_spawn() {
     local session="$1" dir="$2"
     tmux new-window -t "$session" -c "$dir" "opencode; exec \$SHELL"
+    tmux split-window -t "$session" -v -l 20% -c "$dir"
+    tmux select-pane -t "${session}:.0"
 }

--- a/layouts/default.sh
+++ b/layouts/default.sh
@@ -1,21 +1,18 @@
 #!/usr/bin/env bash
 #
-# default.sh u2014 tmux layout: opencode (top 80%) + shell (bottom 20%)
+# default.sh -- tmux layout: opencode (top 80%) + shell (bottom 20%)
 #
-# Called by _coda_attach / coda layout apply with:
 #   $1 = session name
 #   $2 = working directory
 #   $3 = NVIM_APPNAME (unused in this layout)
 #
-# Layout:
-#   u250cu2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2510
-#   u2502                                       u2502
-#   u2502              opencode                 u2502
-#   u2502              (80%)                    u2502
-#   u2502                                       u2502
-#   u251cu2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2524
-#   u2502              shell (20%)              u2502
-#   u2514u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2500u2518
+#   +--------------------------------------+
+#   |                                      |
+#   |            opencode (80%)            |
+#   |                                      |
+#   +--------------------------------------+
+#   |            shell (20%)               |
+#   +--------------------------------------+
 
 _layout_init() {
     local session="$1" dir="$2"

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -13,6 +13,11 @@ coda() {
     local args=()
     local status=0
 
+    if [ -z "${_CODA_PLUGINS_CHECKED:-}" ] && [ -t 0 ]; then
+        _CODA_PLUGINS_CHECKED=1
+        _coda_plugin_check_installed
+    fi
+
     while [ $# -gt 0 ]; do
         case "$1" in
             --profile)    _coda_profile="$2"; shift 2 ;;
@@ -48,9 +53,17 @@ coda() {
         profile)          _coda_profile_cmd "${args[@]:1}"; status=$? ;;
         watch)            _coda_watch "${args[@]:1}"; status=$? ;;
         github)           _coda_github "${args[@]:1}"; status=$? ;;
+        plugin)           _coda_plugin_cmd "${args[@]:1}"; status=$? ;;
+        version|--version|-V)  echo "coda $CODA_VERSION"; status=$? ;;
         help|--help|-h)   _coda_help; status=$? ;;
         "")               _coda_attach; status=$? ;;
-        *)                _coda_attach "${args[0]#"$SESSION_PREFIX"}" "${args[@]:1}"; status=$? ;;
+        *)  if _coda_plugin_dispatch "$subcmd" "${args[@]:1}"; then
+                status=$?
+            else
+                _coda_attach "${args[0]#"$SESSION_PREFIX"}" "${args[@]:1}"
+                status=$?
+            fi
+            ;;
     esac
 
     unset CODA_PROFILE CODA_LAYOUT
@@ -223,6 +236,11 @@ USAGE
   coda github token                Print a GitHub App installation token
   coda github comment --issue N    Post a comment as Coda [bot]
   coda github status               Check GitHub App configuration
+
+  coda plugin install <git-url>    Install a plugin from a git repo
+  coda plugin remove <name>        Remove an installed plugin
+  coda plugin update [name]        Update plugin(s) via git pull
+  coda plugin ls                   List installed plugins
 
   coda help                   Show this help
 

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -57,7 +57,8 @@ coda() {
         version|--version|-V)  echo "coda $CODA_VERSION"; status=$? ;;
         help|--help|-h)   _coda_help; status=$? ;;
         "")               _coda_attach; status=$? ;;
-        *)  if _coda_plugin_dispatch "$subcmd" "${args[@]:1}"; then
+        *)  if _coda_plugin_has_command "$subcmd"; then
+                _coda_plugin_dispatch "$subcmd" "${args[@]:1}"
                 status=$?
             else
                 _coda_attach "${args[0]#"$SESSION_PREFIX"}" "${args[@]:1}"

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -185,5 +185,24 @@ _coda_run_hooks() {
         done < <(printf '%s\n' "$dir"/* | LC_ALL=C sort)
     done
 
+    # Plugin hooks
+    local key
+    for key in "${!_CODA_PLUGIN_HOOKS[@]}"; do
+        local key_event="${key%%:*}"
+        [ "$key_event" = "$event" ] || continue
+        local glob_pattern="${_CODA_PLUGIN_HOOKS[$key]}"
+        IFS='|' read -ra patterns <<< "$glob_pattern"
+        for pattern in "${patterns[@]}"; do
+            local hook
+            for hook in $pattern; do
+                [ -f "$hook" ] && [ -x "$hook" ] || continue
+                found=1
+                if ! "$hook" "$@" 2>&1; then
+                    echo "  hook warning: $(basename "$hook") exited non-zero" >&2
+                fi
+            done
+        done
+    done
+
     return 0
 }

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -185,7 +185,7 @@ _coda_run_hooks() {
         done < <(printf '%s\n' "$dir"/* | LC_ALL=C sort)
     done
 
-    # Plugin hooks
+    local _plugin_hooks_sorted=()
     local key
     for key in "${!_CODA_PLUGIN_HOOKS[@]}"; do
         local key_event="${key%%:*}"
@@ -195,14 +195,17 @@ _coda_run_hooks() {
         for pattern in "${patterns[@]}"; do
             local hook
             for hook in $pattern; do
-                [ -f "$hook" ] && [ -x "$hook" ] || continue
-                found=1
-                if ! "$hook" "$@" 2>&1; then
-                    echo "  hook warning: $(basename "$hook") exited non-zero" >&2
-                fi
+                [ -f "$hook" ] && [ -x "$hook" ] && _plugin_hooks_sorted+=("$hook")
             done
         done
     done
+    while IFS= read -r hook; do
+        [ -z "$hook" ] && continue
+        found=1
+        if ! "$hook" "$@" 2>&1; then
+            echo "  hook warning: $(basename "$hook") exited non-zero" >&2
+        fi
+    done < <(printf '%s\n' "${_plugin_hooks_sorted[@]}" | LC_ALL=C sort)
 
     return 0
 }

--- a/lib/plugin.sh
+++ b/lib/plugin.sh
@@ -1,0 +1,568 @@
+#!/usr/bin/env bash
+#
+# plugin.sh — coda plugin system
+#
+# Plugins are git repos cloned to ~/.config/coda/plugins/<name>/.
+# Each plugin has a plugin.json manifest describing what it provides:
+# commands, hooks, providers, and notifications.
+#
+# User config lives in ~/.config/coda/config.json.
+
+CODA_PLUGINS_DIR="${CODA_PLUGINS_DIR:-$HOME/.config/coda/plugins}"
+
+# Global state for loaded plugins
+declare -gA _CODA_PLUGIN_COMMANDS 2>/dev/null || true
+declare -gA _CODA_PLUGIN_HOOKS 2>/dev/null || true
+declare -gA _CODA_PLUGIN_PROVIDERS 2>/dev/null || true
+declare -ga _CODA_PLUGIN_NOTIFICATIONS 2>/dev/null || true
+
+_coda_plugin_dir() {
+    echo "$CODA_PLUGINS_DIR"
+}
+
+_coda_semver_parse() {
+    local ver="$1"
+    local major minor patch
+    IFS='.' read -r major minor patch <<< "${ver%%-*}"
+    echo "${major:-0} ${minor:-0} ${patch:-0}"
+}
+
+_coda_semver_compare() {
+    local a_major a_minor a_patch b_major b_minor b_patch
+    read -r a_major a_minor a_patch <<< "$(_coda_semver_parse "$1")"
+    read -r b_major b_minor b_patch <<< "$(_coda_semver_parse "$2")"
+    if (( a_major != b_major )); then
+        (( a_major > b_major )) && echo 1 || echo -1
+    elif (( a_minor != b_minor )); then
+        (( a_minor > b_minor )) && echo 1 || echo -1
+    elif (( a_patch != b_patch )); then
+        (( a_patch > b_patch )) && echo 1 || echo -1
+    else
+        echo 0
+    fi
+}
+
+_coda_semver_satisfies() {
+    local version="$1" constraint="$2"
+    [ -z "$constraint" ] && return 0
+
+    local part prev_op=""
+    for part in $constraint; do
+        if [[ "$part" == ^* ]]; then
+            local base="${part#^}"
+            local base_major
+            read -r base_major _ _ <<< "$(_coda_semver_parse "$base")"
+            local next_major=$((base_major + 1)).0.0
+            [[ $(_coda_semver_compare "$version" "$base") -ge 0 ]] || return 1
+            [[ $(_coda_semver_compare "$version" "$next_major") -lt 0 ]] || return 1
+        elif [[ "$part" == ~* ]]; then
+            local base="${part#\~}"
+            local base_major base_minor
+            read -r base_major base_minor _ <<< "$(_coda_semver_parse "$base")"
+            local next_minor=${base_major}.$((base_minor + 1)).0
+            [[ $(_coda_semver_compare "$version" "$base") -ge 0 ]] || return 1
+            [[ $(_coda_semver_compare "$version" "$next_minor") -lt 0 ]] || return 1
+        elif [[ "$part" == ">=" || "$part" == "<" || "$part" == "<=" || "$part" == ">" ]]; then
+            prev_op="$part"
+            continue
+        elif [[ "$prev_op" == ">=" ]]; then
+            [[ $(_coda_semver_compare "$version" "$part") -ge 0 ]] || return 1
+        elif [[ "$prev_op" == ">" ]]; then
+            [[ $(_coda_semver_compare "$version" "$part") -gt 0 ]] || return 1
+        elif [[ "$prev_op" == "<" ]]; then
+            [[ $(_coda_semver_compare "$version" "$part") -lt 0 ]] || return 1
+        elif [[ "$prev_op" == "<=" ]]; then
+            [[ $(_coda_semver_compare "$version" "$part") -le 0 ]] || return 1
+        else
+            [[ $(_coda_semver_compare "$version" "$part") -eq 0 ]] || return 1
+        fi
+        prev_op=""
+    done
+    return 0
+}
+
+_coda_plugin_config_path() {
+    echo "${HOME}/.config/coda/config.json"
+}
+
+_coda_plugin_load_all() {
+    # Skip if jq is not available
+    command -v jq &>/dev/null || return 0
+
+    local config_path
+    config_path=$(_coda_plugin_config_path)
+    [ -f "$config_path" ] || return 0
+
+    # Reset global state
+    _CODA_PLUGIN_COMMANDS=()
+    _CODA_PLUGIN_HOOKS=()
+    _CODA_PLUGIN_PROVIDERS=()
+    _CODA_PLUGIN_NOTIFICATIONS=()
+
+    local plugins_dir
+    plugins_dir=$(_coda_plugin_dir)
+
+    # Read each plugin URL from config
+    local urls
+    urls=$(jq -r '.plugins // {} | keys[]' "$config_path" 2>/dev/null) || return 0
+
+    while IFS= read -r url; do
+        [ -z "$url" ] && continue
+
+        # Check if enabled
+        local enabled
+        enabled=$(jq -r --arg u "$url" '.plugins[$u].enabled // true' "$config_path" 2>/dev/null)
+        [ "$enabled" = "true" ] || continue
+
+        # Derive plugin name from URL
+        local name
+        name=$(_coda_plugin_name_from_url "$url")
+        [ -z "$name" ] && continue
+
+        local plugin_dir="$plugins_dir/$name"
+        [ -d "$plugin_dir" ] || continue
+
+        # Export plugin options as environment variables
+        local options
+        options=$(jq -r --arg u "$url" '.plugins[$u].options // {} | to_entries[] | "\(.key)=\(.value)"' "$config_path" 2>/dev/null)
+        while IFS='=' read -r key val; do
+            [ -z "$key" ] && continue
+            export "$key=$val"
+        done <<< "$options"
+
+        _coda_plugin_load "$name" "$plugin_dir"
+    done <<< "$urls"
+}
+
+_coda_plugin_load() {
+    local name="$1" dir="$2"
+
+    local manifest="$dir/plugin.json"
+    [ -f "$manifest" ] || return 0
+
+    local coda_constraint
+    coda_constraint=$(jq -r '.coda // empty' "$manifest" 2>/dev/null)
+    if [ -n "$coda_constraint" ] && ! _coda_semver_satisfies "${CODA_VERSION:-0.0.0}" "$coda_constraint"; then
+        echo "warning: plugin '$name' requires coda $coda_constraint (have ${CODA_VERSION:-0.0.0}), skipping" >&2
+        return 0
+    fi
+
+    local sys_deps
+    sys_deps=$(jq -r '.dependencies.system // [] | .[]' "$manifest" 2>/dev/null)
+    while IFS= read -r dep; do
+        [ -z "$dep" ] && continue
+        if ! command -v "$dep" &>/dev/null; then
+            echo "warning: plugin '$name' requires '$dep' which is not installed, skipping" >&2
+            return 0
+        fi
+    done <<< "$sys_deps"
+
+    local go_dir
+    go_dir=$(jq -r '.dependencies.go // empty' "$manifest" 2>/dev/null)
+    if [ -n "$go_dir" ]; then
+        local bin_name
+        bin_name=$(basename "$go_dir")
+        bin_name="${bin_name%/}"
+        if [ ! -f "$HOME/.local/bin/$bin_name" ]; then
+            echo "warning: plugin '$name' binary '$bin_name' not built, skipping (run: coda plugin update $name)" >&2
+            return 0
+        fi
+    fi
+
+    # Register commands
+    local cmds
+    cmds=$(jq -r '.provides.commands // {} | to_entries[] | "\(.key)\t\(.value.handler)\t\(.value.function)"' "$manifest" 2>/dev/null)
+    while IFS=$'\t' read -r cmd_name handler func; do
+        [ -z "$cmd_name" ] && continue
+        _CODA_PLUGIN_COMMANDS["$cmd_name"]="$dir/$handler:$func:$dir"
+    done <<< "$cmds"
+
+    # Register hooks
+    local hooks
+    hooks=$(jq -r '.provides.hooks // {} | to_entries[] | "\(.key)\t\(.value | if type == "array" then join("|") else . end)"' "$manifest" 2>/dev/null)
+    while IFS=$'\t' read -r event globs; do
+        [ -z "$event" ] && continue
+        _CODA_PLUGIN_HOOKS["$event:$name"]="$dir/$globs"
+    done <<< "$hooks"
+
+    # Register providers
+    local providers
+    providers=$(jq -r '.provides.providers // {} | to_entries[] | "\(.key)\t\(.value)"' "$manifest" 2>/dev/null)
+    while IFS=$'\t' read -r prov_name prov_dir; do
+        [ -z "$prov_name" ] && continue
+        _CODA_PLUGIN_PROVIDERS["$prov_name"]="$dir/$prov_dir"
+    done <<< "$providers"
+
+    # Register notifications
+    local notifs
+    notifs=$(jq -r '.provides.notifications // [] | .[]' "$manifest" 2>/dev/null)
+    while IFS= read -r glob; do
+        [ -z "$glob" ] && continue
+        _CODA_PLUGIN_NOTIFICATIONS+=("$dir/$glob")
+    done <<< "$notifs"
+}
+
+_coda_plugin_name_from_url() {
+    local url="$1"
+    # git@github.com:user/coda-github.git -> coda-github
+    # https://github.com/user/coda-github.git -> coda-github
+    local name
+    name=$(basename "$url")
+    name="${name%.git}"
+    echo "$name"
+}
+
+_coda_plugin_dispatch() {
+    local subcmd="$1"
+    shift
+
+    if [[ -z "${_CODA_PLUGIN_COMMANDS[$subcmd]+x}" ]]; then
+        return 1
+    fi
+
+    local entry="${_CODA_PLUGIN_COMMANDS[$subcmd]}"
+    local handler func plugin_dir
+    IFS=':' read -r handler func plugin_dir <<< "$entry"
+
+    if [ ! -f "$handler" ]; then
+        echo "Plugin handler not found: $handler" >&2
+        return 1
+    fi
+
+    # shellcheck source=/dev/null
+    source "$handler"
+
+    if ! declare -f "$func" &>/dev/null; then
+        echo "Plugin function not found: $func" >&2
+        return 1
+    fi
+
+    "$func" "$@"
+}
+
+_coda_plugin_check_installed() {
+    command -v jq &>/dev/null || return 0
+
+    local config_path
+    config_path=$(_coda_plugin_config_path)
+    [ -f "$config_path" ] || return 0
+
+    local plugins_dir
+    plugins_dir=$(_coda_plugin_dir)
+    local missing=()
+
+    local urls
+    urls=$(jq -r '.plugins // {} | keys[]' "$config_path" 2>/dev/null) || return 0
+
+    while IFS= read -r url; do
+        [ -z "$url" ] && continue
+        local enabled
+        enabled=$(jq -r --arg u "$url" '.plugins[$u].enabled // true' "$config_path" 2>/dev/null)
+        [ "$enabled" = "true" ] || continue
+
+        local name
+        name=$(_coda_plugin_name_from_url "$url")
+        if [ ! -d "$plugins_dir/$name" ]; then
+            missing+=("$url")
+        fi
+    done <<< "$urls"
+
+    if [ ${#missing[@]} -gt 0 ]; then
+        echo "The following plugins are configured but not installed:"
+        for url in "${missing[@]}"; do
+            echo "  $url"
+        done
+        echo ""
+        read -r -p "Install them now? [y/N] " answer
+        if [[ "$answer" =~ ^[Yy] ]]; then
+            for url in "${missing[@]}"; do
+                _coda_plugin_install "$url"
+            done
+        fi
+    fi
+}
+
+_coda_plugin_install() {
+    local url="$1"
+
+    if ! command -v jq &>/dev/null; then
+        echo "jq is required for plugin management. Install it with: sudo apt install jq"
+        return 1
+    fi
+
+    if ! command -v git &>/dev/null; then
+        echo "git is required for plugin management."
+        return 1
+    fi
+
+    local name
+    name=$(_coda_plugin_name_from_url "$url")
+    if [ -z "$name" ]; then
+        echo "Could not determine plugin name from: $url"
+        return 1
+    fi
+
+    local plugins_dir
+    plugins_dir=$(_coda_plugin_dir)
+    local plugin_dir="$plugins_dir/$name"
+
+    if [ -d "$plugin_dir" ]; then
+        echo "Plugin '$name' is already installed at $plugin_dir"
+        return 0
+    fi
+
+    echo "Installing plugin: $name"
+    mkdir -p "$plugins_dir"
+
+    if ! git clone "$url" "$plugin_dir" 2>&1; then
+        echo "Failed to clone $url"
+        rm -rf "$plugin_dir"
+        return 1
+    fi
+
+    local manifest="$plugin_dir/plugin.json"
+    if [ ! -f "$manifest" ]; then
+        echo "Warning: Plugin '$name' has no plugin.json manifest."
+    fi
+
+    if [ -f "$manifest" ]; then
+        local coda_constraint
+        coda_constraint=$(jq -r '.coda // empty' "$manifest" 2>/dev/null)
+        if [ -n "$coda_constraint" ] && ! _coda_semver_satisfies "${CODA_VERSION:-0.0.0}" "$coda_constraint"; then
+            echo "Warning: Plugin '$name' requires coda $coda_constraint (you have ${CODA_VERSION:-0.0.0})"
+            read -r -p "Install anyway? [y/N] " answer
+            if [[ ! "$answer" =~ ^[Yy] ]]; then
+                rm -rf "$plugin_dir"
+                return 1
+            fi
+        fi
+        _coda_plugin_install_deps "$plugin_dir"
+    fi
+
+    # Run custom install script
+    local install_script
+    install_script=$(jq -r '.install // empty' "$manifest" 2>/dev/null)
+    if [ -n "$install_script" ] && [ -f "$plugin_dir/$install_script" ]; then
+        echo "Running install script: $install_script"
+        (cd "$plugin_dir" && bash "$install_script")
+    fi
+
+    # Add to config if not already there
+    _coda_plugin_config_add "$url"
+
+    echo "Plugin '$name' installed successfully."
+}
+
+_coda_plugin_install_deps() {
+    local plugin_dir="$1"
+    local manifest="$plugin_dir/plugin.json"
+    [ -f "$manifest" ] || return 0
+
+    local missing_deps=()
+
+    local sys_deps
+    sys_deps=$(jq -r '.dependencies.system // [] | .[]' "$manifest" 2>/dev/null)
+    while IFS= read -r dep; do
+        [ -z "$dep" ] && continue
+        if command -v "$dep" &>/dev/null; then
+            echo "  $dep: found"
+        else
+            echo "  $dep: MISSING"
+            missing_deps+=("$dep")
+        fi
+    done <<< "$sys_deps"
+
+    local go_dir
+    go_dir=$(jq -r '.dependencies.go // empty' "$manifest" 2>/dev/null)
+    if [ -n "$go_dir" ] && [ -d "$plugin_dir/$go_dir" ]; then
+        if ! command -v go &>/dev/null; then
+            echo "  go: MISSING (needed to build $go_dir)"
+            missing_deps+=("go")
+        else
+            echo "Building Go binary: $go_dir"
+            mkdir -p "$HOME/.local/bin"
+            (cd "$plugin_dir" && GOBIN="$HOME/.local/bin" go install "./$go_dir")
+        fi
+    fi
+
+    local npm_deps
+    npm_deps=$(jq -r '.dependencies.npm // [] | .[]' "$manifest" 2>/dev/null)
+    while IFS= read -r dep; do
+        [ -z "$dep" ] && continue
+        if ! command -v npm &>/dev/null; then
+            echo "  npm: MISSING (needed to install $dep)"
+            missing_deps+=("npm")
+        else
+            echo "Installing npm package: $dep"
+            npm install -g "$dep" 2>&1
+        fi
+    done <<< "$npm_deps"
+
+    if [ ${#missing_deps[@]} -gt 0 ]; then
+        echo ""
+        echo "Missing dependencies: ${missing_deps[*]}"
+        echo "Plugin will be disabled until these are installed."
+        return 1
+    fi
+}
+
+_coda_plugin_remove() {
+    local name="$1"
+
+    if [ -z "$name" ]; then
+        echo "Usage: coda plugin remove <name>"
+        return 1
+    fi
+
+    local plugins_dir
+    plugins_dir=$(_coda_plugin_dir)
+    local plugin_dir="$plugins_dir/$name"
+
+    if [ ! -d "$plugin_dir" ]; then
+        echo "Plugin '$name' is not installed."
+        return 1
+    fi
+
+    echo "Removing plugin: $name"
+    rm -rf "$plugin_dir"
+
+    # Remove from config
+    _coda_plugin_config_remove "$name"
+
+    echo "Plugin '$name' removed."
+}
+
+_coda_plugin_update() {
+    local name="$1"
+    local plugins_dir
+    plugins_dir=$(_coda_plugin_dir)
+
+    if [ -n "$name" ]; then
+        local plugin_dir="$plugins_dir/$name"
+        if [ ! -d "$plugin_dir" ]; then
+            echo "Plugin '$name' is not installed."
+            return 1
+        fi
+        echo "Updating plugin: $name"
+        (cd "$plugin_dir" && git pull) 2>&1
+        _coda_plugin_install_deps "$plugin_dir"
+        echo "Plugin '$name' updated."
+    else
+        # Update all installed plugins
+        local found=0
+        for plugin_dir in "$plugins_dir"/*/; do
+            [ -d "$plugin_dir" ] || continue
+            found=1
+            name=$(basename "$plugin_dir")
+            echo "Updating plugin: $name"
+            (cd "$plugin_dir" && git pull) 2>&1
+            _coda_plugin_install_deps "$plugin_dir"
+        done
+        if [ "$found" -eq 0 ]; then
+            echo "No plugins installed."
+        else
+            echo "All plugins updated."
+        fi
+    fi
+}
+
+_coda_plugin_ls() {
+    local plugins_dir
+    plugins_dir=$(_coda_plugin_dir)
+
+    if [ ! -d "$plugins_dir" ] || [ -z "$(ls -A "$plugins_dir" 2>/dev/null)" ]; then
+        echo "No plugins installed."
+        echo "Install one with: coda plugin install <git-url>"
+        return 0
+    fi
+
+    echo "Installed plugins:"
+    for plugin_dir in "$plugins_dir"/*/; do
+        [ -d "$plugin_dir" ] || continue
+        local name
+        name=$(basename "$plugin_dir")
+        local version="" description=""
+        local manifest="$plugin_dir/plugin.json"
+        if [ -f "$manifest" ] && command -v jq &>/dev/null; then
+            version=$(jq -r '.version // ""' "$manifest" 2>/dev/null)
+            description=$(jq -r '.description // ""' "$manifest" 2>/dev/null)
+        fi
+        local info="$name"
+        [ -n "$version" ] && info="$info v$version"
+        [ -n "$description" ] && info="$info - $description"
+        echo "  $info"
+    done
+}
+
+_coda_plugin_config_add() {
+    local url="$1"
+    local config_path
+    config_path=$(_coda_plugin_config_path)
+
+    mkdir -p "$(dirname "$config_path")"
+
+    if [ ! -f "$config_path" ]; then
+        printf '{"plugins":{"%s":{"enabled":true}}}' "$url" | jq . > "$config_path"
+        return
+    fi
+
+    # Check if already in config
+    local exists
+    exists=$(jq -r --arg u "$url" '.plugins[$u] // empty' "$config_path" 2>/dev/null)
+    if [ -n "$exists" ]; then
+        return 0
+    fi
+
+    local tmp
+    tmp=$(mktemp)
+    jq --arg u "$url" '.plugins[$u] = {"enabled": true}' "$config_path" > "$tmp" && mv "$tmp" "$config_path"
+}
+
+_coda_plugin_config_remove() {
+    local name="$1"
+    local config_path
+    config_path=$(_coda_plugin_config_path)
+    [ -f "$config_path" ] || return 0
+
+    # Find the URL that matches this plugin name
+    local urls
+    urls=$(jq -r '.plugins // {} | keys[]' "$config_path" 2>/dev/null) || return 0
+
+    while IFS= read -r url; do
+        [ -z "$url" ] && continue
+        local url_name
+        url_name=$(_coda_plugin_name_from_url "$url")
+        if [ "$url_name" = "$name" ]; then
+            local tmp
+            tmp=$(mktemp)
+            jq --arg u "$url" 'del(.plugins[$u])' "$config_path" > "$tmp" && mv "$tmp" "$config_path"
+            return 0
+        fi
+    done <<< "$urls"
+}
+
+_coda_plugin_cmd() {
+    local subcmd="${1:-}"
+    shift 2>/dev/null || true
+
+    case "$subcmd" in
+        install)  _coda_plugin_install "$@" ;;
+        remove)   _coda_plugin_remove "$@" ;;
+        update)   _coda_plugin_update "$@" ;;
+        ls|list)  _coda_plugin_ls ;;
+        ""|help)
+            cat <<'EOF'
+Usage: coda plugin <install|remove|update|ls>
+
+  coda plugin install <git-url>   Clone and install a plugin
+  coda plugin remove <name>       Remove an installed plugin
+  coda plugin update [name]       Update plugin(s) via git pull
+  coda plugin ls                  List installed plugins
+EOF
+            ;;
+        *)  echo "Unknown plugin subcommand: $subcmd"
+            echo "Usage: coda plugin <install|remove|update|ls>"
+            return 1
+            ;;
+    esac
+}

--- a/lib/plugin.sh
+++ b/lib/plugin.sh
@@ -50,11 +50,16 @@ _coda_semver_satisfies() {
     for part in $constraint; do
         if [[ "$part" == ^* ]]; then
             local base="${part#^}"
-            local base_major
-            read -r base_major _ _ <<< "$(_coda_semver_parse "$base")"
-            local next_major=$((base_major + 1)).0.0
+            local base_major base_minor_c
+            read -r base_major base_minor_c _ <<< "$(_coda_semver_parse "$base")"
+            local ceiling
+            if (( base_major == 0 )); then
+                ceiling="0.$((base_minor_c + 1)).0"
+            else
+                ceiling="$((base_major + 1)).0.0"
+            fi
             [[ $(_coda_semver_compare "$version" "$base") -ge 0 ]] || return 1
-            [[ $(_coda_semver_compare "$version" "$next_major") -lt 0 ]] || return 1
+            [[ $(_coda_semver_compare "$version" "$ceiling") -lt 0 ]] || return 1
         elif [[ "$part" == ~* ]]; then
             local base="${part#\~}"
             local base_major base_minor
@@ -337,14 +342,13 @@ _coda_plugin_install() {
             fi
         fi
         _coda_plugin_install_deps "$plugin_dir"
-    fi
 
-    # Run custom install script
-    local install_script
-    install_script=$(jq -r '.install // empty' "$manifest" 2>/dev/null)
-    if [ -n "$install_script" ] && [ -f "$plugin_dir/$install_script" ]; then
-        echo "Running install script: $install_script"
-        (cd "$plugin_dir" && bash "$install_script")
+        local install_script
+        install_script=$(jq -r '.install // empty' "$manifest" 2>/dev/null)
+        if [ -n "$install_script" ] && [ -f "$plugin_dir/$install_script" ]; then
+            echo "Running install script: $install_script"
+            (cd "$plugin_dir" && bash "$install_script")
+        fi
     fi
 
     # Add to config if not already there

--- a/lib/plugin.sh
+++ b/lib/plugin.sh
@@ -46,6 +46,8 @@ _coda_semver_satisfies() {
     local version="$1" constraint="$2"
     [ -z "$constraint" ] && return 0
 
+    constraint=$(echo "$constraint" | sed -E 's/(>=|<=|>|<)([0-9])/\1 \2/g')
+
     local part prev_op=""
     for part in $constraint; do
         if [[ "$part" == ^* ]]; then
@@ -87,7 +89,7 @@ _coda_semver_satisfies() {
 }
 
 _coda_plugin_config_path() {
-    echo "${HOME}/.config/coda/config.json"
+    echo "${CODA_CONFIG_PATH:-${HOME}/.config/coda/config.json}"
 }
 
 _coda_plugin_load_all() {
@@ -187,7 +189,14 @@ _coda_plugin_load() {
     hooks=$(jq -r '.provides.hooks // {} | to_entries[] | "\(.key)\t\(.value | if type == "array" then join("|") else . end)"' "$manifest" 2>/dev/null)
     while IFS=$'\t' read -r event globs; do
         [ -z "$event" ] && continue
-        _CODA_PLUGIN_HOOKS["$event:$name"]="$dir/$globs"
+        local prefixed=""
+        local _hg
+        IFS='|' read -ra _hg_parts <<< "$globs"
+        for _hg in "${_hg_parts[@]}"; do
+            [ -n "$prefixed" ] && prefixed+="|"
+            prefixed+="$dir/$_hg"
+        done
+        _CODA_PLUGIN_HOOKS["$event:$name"]="$prefixed"
     done <<< "$hooks"
 
     # Register providers
@@ -217,12 +226,16 @@ _coda_plugin_name_from_url() {
     echo "$name"
 }
 
+_coda_plugin_has_command() {
+    [[ -n "${_CODA_PLUGIN_COMMANDS[$1]+x}" ]]
+}
+
 _coda_plugin_dispatch() {
     local subcmd="$1"
     shift
 
-    if [[ -z "${_CODA_PLUGIN_COMMANDS[$subcmd]+x}" ]]; then
-        return 1
+    if ! _coda_plugin_has_command "$subcmd"; then
+        return 127
     fi
 
     local entry="${_CODA_PLUGIN_COMMANDS[$subcmd]}"

--- a/lib/provider.sh
+++ b/lib/provider.sh
@@ -76,6 +76,15 @@ _coda_provider_ls() {
         fi
         echo "  $name  ($source)$active"
     done
+    for name in "${!_CODA_PLUGIN_PROVIDERS[@]}"; do
+        case "$seen" in *"|$name|"*) continue ;; esac
+        seen="$seen|$name|"
+        local active=""
+        if [ "$name" = "${CODA_PROVIDER_MODE:-claude-auth}" ]; then
+            active=" (active)"
+        fi
+        echo "  $name  (plugin)$active"
+    done
 }
 
 _coda_provider_mode() {
@@ -98,6 +107,8 @@ _coda_find_provider_dir() {
         echo "$CODA_PROVIDERS_DIR/$mode"
     elif [ -d "$_CODA_DIR/providers/$mode" ]; then
         echo "$_CODA_DIR/providers/$mode"
+    elif [[ -n "${_CODA_PLUGIN_PROVIDERS[$mode]+x}" ]]; then
+        echo "${_CODA_PLUGIN_PROVIDERS[$mode]}"
     else
         return 1
     fi
@@ -132,6 +143,11 @@ _coda_list_providers() {
     for d in "$CODA_PROVIDERS_DIR"/*/ "$_CODA_DIR/providers"/*/; do
         [ -d "$d" ] || continue
         name=$(basename "$d")
+        case "$seen" in *"|$name|"*) continue ;; esac
+        seen="$seen|$name|"
+        echo "$name"
+    done
+    for name in "${!_CODA_PLUGIN_PROVIDERS[@]}"; do
         case "$seen" in *"|$name|"*) continue ;; esac
         seen="$seen|$name|"
         echo "$name"

--- a/lib/watch.sh
+++ b/lib/watch.sh
@@ -31,6 +31,11 @@ _coda_watch_start() {
     local watcher_cmd
     if command -v coda-core &>/dev/null; then
         watcher_cmd="coda-core watch --interval ${CODA_WATCH_INTERVAL:-5} --cooldown ${CODA_WATCH_COOLDOWN:-60} --prefix ${SESSION_PREFIX} --notifications-dir ${_CODA_DIR}/notifications --user-notifications-dir ${CODA_NOTIFICATIONS_DIR}"
+        local glob
+        for glob in "${_CODA_PLUGIN_NOTIFICATIONS[@]}"; do
+            [ -z "$glob" ] && continue
+            watcher_cmd="$watcher_cmd --plugin-notifications-dir $glob"
+        done
     else
         watcher_cmd="$_CODA_DIR/coda-watcher.sh"
     fi

--- a/lib/watch.sh
+++ b/lib/watch.sh
@@ -31,11 +31,6 @@ _coda_watch_start() {
     local watcher_cmd
     if command -v coda-core &>/dev/null; then
         watcher_cmd="coda-core watch --interval ${CODA_WATCH_INTERVAL:-5} --cooldown ${CODA_WATCH_COOLDOWN:-60} --prefix ${SESSION_PREFIX} --notifications-dir ${_CODA_DIR}/notifications --user-notifications-dir ${CODA_NOTIFICATIONS_DIR}"
-        local glob
-        for glob in "${_CODA_PLUGIN_NOTIFICATIONS[@]}"; do
-            [ -z "$glob" ] && continue
-            watcher_cmd="$watcher_cmd --plugin-notifications-dir $glob"
-        done
     else
         watcher_cmd="$_CODA_DIR/coda-watcher.sh"
     fi

--- a/mcp-server/server.js
+++ b/mcp-server/server.js
@@ -5,6 +5,7 @@ const {
 const { execFile } = require("child_process");
 const { promisify } = require("util");
 const path = require("path");
+const fs = require("fs");
 const z = require("zod");
 
 const execFileAsync = promisify(execFile);
@@ -69,6 +70,8 @@ const server = new McpServer(
     ].join(" "),
   }
 );
+
+// ── Core tools (always available) ───────────────────────────────────
 
 server.tool(
   "coda_ls",
@@ -195,34 +198,6 @@ server.tool(
 );
 
 server.tool(
-  "coda_watch_status",
-  "Check if the coda session watcher is running",
-  {},
-  async () => formatResult(await runCoda(["watch", "status"]))
-);
-
-server.tool(
-  "coda_watch_start",
-  "Start the background watcher that monitors OpenCode sessions and sends notifications on idle",
-  {},
-  async () => formatResult(await runCoda(["watch", "start"]))
-);
-
-server.tool(
-  "coda_watch_stop",
-  "Stop the background session watcher",
-  {},
-  async () => formatResult(await runCoda(["watch", "stop"]))
-);
-
-server.tool(
-  "coda_provider_status",
-  "Show provider diagnostics for the current coda provider mode (claude-auth or cliproxyapi)",
-  {},
-  async () => formatResult(await runCoda(["provider", "status"], { timeout: 30000 }))
-);
-
-server.tool(
   "coda_layout_ls",
   "List available tmux layouts",
   {},
@@ -243,6 +218,102 @@ server.tool(
   async () => formatResult(await runCoda(["help"]))
 );
 
+// ── Dynamic plugin tools ────────────────────────────────────────────
+
+function pluginNameFromUrl(url) {
+  let name = path.basename(url);
+  if (name.endsWith(".git")) name = name.slice(0, -4);
+  return name;
+}
+
+function buildZodSchema(params) {
+  if (!params || Object.keys(params).length === 0) return {};
+  const schema = {};
+  for (const [name, def] of Object.entries(params)) {
+    const paramType = def.type || "string";
+    let field;
+    if (paramType === "boolean") {
+      field = z.boolean();
+    } else if (paramType === "cwd") {
+      field = z.string();
+    } else {
+      field = z.string();
+    }
+    if (def.description) field = field.describe(def.description);
+    if (def.optional) field = field.optional();
+    schema[name] = field;
+  }
+  return schema;
+}
+
+function buildHandler(command, params) {
+  return async (args) => {
+    const cmdArgs = [...command];
+    let cwd;
+
+    if (params) {
+      for (const [name, def] of Object.entries(params)) {
+        const val = args[name];
+        if (val === undefined || val === null) continue;
+
+        if (def.type === "cwd") {
+          cwd = val;
+        } else if (def.type === "boolean") {
+          if (val) cmdArgs.push(`--${name}`);
+        } else {
+          cmdArgs.push(`--${name}`, String(val));
+        }
+      }
+    }
+
+    return formatResult(await runCoda(cmdArgs, { cwd }));
+  };
+}
+
+function loadPluginTools() {
+  const configPath = process.env.CODA_CONFIG_PATH
+    || path.join(process.env.HOME, ".config", "coda", "config.json");
+  const pluginsDir = process.env.CODA_PLUGINS_DIR
+    || path.join(process.env.HOME, ".config", "coda", "plugins");
+
+  let config;
+  try {
+    config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+  } catch {
+    return;
+  }
+
+  const plugins = config.plugins;
+  if (!plugins || typeof plugins !== "object") return;
+
+  for (const [url, entry] of Object.entries(plugins)) {
+    if (entry.enabled === false) continue;
+
+    const name = pluginNameFromUrl(url);
+    if (!name) continue;
+
+    const pluginJsonPath = path.join(pluginsDir, name, "plugin.json");
+    let pluginJson;
+    try {
+      pluginJson = JSON.parse(fs.readFileSync(pluginJsonPath, "utf8"));
+    } catch {
+      continue;
+    }
+
+    const mcpTools = pluginJson.provides && pluginJson.provides.mcp_tools;
+    if (!mcpTools || typeof mcpTools !== "object") continue;
+
+    for (const [toolName, toolDef] of Object.entries(mcpTools)) {
+      const schema = buildZodSchema(toolDef.params);
+      const handler = buildHandler(toolDef.command, toolDef.params);
+      server.tool(toolName, toolDef.description, schema, handler);
+    }
+  }
+}
+
+loadPluginTools();
+
+// ── Start ───────────────────────────────────────────────────────────
 
 async function main() {
   const transport = new StdioServerTransport();

--- a/mcp-server/server.js
+++ b/mcp-server/server.js
@@ -304,9 +304,13 @@ function loadPluginTools() {
     if (!mcpTools || typeof mcpTools !== "object") continue;
 
     for (const [toolName, toolDef] of Object.entries(mcpTools)) {
+      if (!Array.isArray(toolDef.command) || toolDef.command.length === 0) {
+        console.error(`Plugin ${name}: skipping tool ${toolName} (invalid command)`);
+        continue;
+      }
       const schema = buildZodSchema(toolDef.params);
       const handler = buildHandler(toolDef.command, toolDef.params);
-      server.tool(toolName, toolDef.description, schema, handler);
+      server.tool(toolName, toolDef.description || toolName, schema, handler);
     }
   }
 }

--- a/mcp-server/test.sh
+++ b/mcp-server/test.sh
@@ -2,9 +2,6 @@
 #
 # test.sh — Smoke test for the coda MCP server
 #
-# Verifies the server starts, registers all expected tools, and can
-# execute a live tool call (coda_ls).
-#
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -15,17 +12,23 @@ FAIL=0
 pass() { PASS=$((PASS + 1)); echo "  [pass] $*"; }
 fail() { FAIL=$((FAIL + 1)); echo "  [FAIL] $*"; }
 
-# --- Check deps ---
 if [ ! -d "$SCRIPT_DIR/node_modules" ]; then
     echo "node_modules missing. Run: npm install" >&2
     exit 1
 fi
 
-# --- Helper: send JSON-RPC messages and capture response ---
 mcp_call() {
     local init='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}'
     local notify='{"jsonrpc":"2.0","method":"notifications/initialized"}'
     printf '%s\n%s\n%s\n' "$init" "$notify" "$1" | timeout 10 node "$SERVER" 2>/dev/null
+}
+
+mcp_call_env() {
+    local env_args="$1"
+    local msg="$2"
+    local init='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}'
+    local notify='{"jsonrpc":"2.0","method":"notifications/initialized"}'
+    printf '%s\n%s\n%s\n' "$init" "$notify" "$msg" | timeout 10 env $env_args node "$SERVER" 2>/dev/null
 }
 
 echo "MCP Server Tests"
@@ -41,11 +44,11 @@ else
     fail "Server did not return expected identity"
 fi
 
-# --- Test 2: All tools registered ---
-echo "2. Tool registration"
+# --- Test 2: All core tools registered ---
+echo "2. Core tool registration"
 tools_response=$(mcp_call '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' | tail -1)
 
-EXPECTED_TOOLS=(
+CORE_TOOLS=(
     coda_ls
     coda_project_ls
     coda_feature_ls
@@ -56,28 +59,38 @@ EXPECTED_TOOLS=(
     coda_project_create
     coda_project_workon
     coda_project_close
-    coda_watch_status
-    coda_watch_start
-    coda_watch_stop
-    coda_provider_status
     coda_layout_ls
     coda_layout_show
     coda_help
 )
 
 missing=0
-for tool in "${EXPECTED_TOOLS[@]}"; do
+for tool in "${CORE_TOOLS[@]}"; do
     if ! echo "$tools_response" | grep -q "\"$tool\""; then
-        fail "Missing tool: $tool"
+        fail "Missing core tool: $tool"
         missing=$((missing + 1))
     fi
 done
 if [ "$missing" -eq 0 ]; then
-    pass "All ${#EXPECTED_TOOLS[@]} tools registered"
+    pass "All ${#CORE_TOOLS[@]} core tools registered"
 fi
 
-# --- Test 3: Live tool call (coda_ls) ---
-echo "3. Live tool call"
+# --- Test 3: Plugin tools NOT in core list ---
+echo "3. Plugin tools absent from core"
+PLUGIN_TOOLS=(coda_watch_status coda_watch_start coda_watch_stop coda_provider_status)
+leaked=0
+for tool in "${PLUGIN_TOOLS[@]}"; do
+    if echo "$tools_response" | grep -q "\"$tool\""; then
+        fail "Plugin tool leaked into core: $tool"
+        leaked=$((leaked + 1))
+    fi
+done
+if [ "$leaked" -eq 0 ]; then
+    pass "No plugin tools in core-only list"
+fi
+
+# --- Test 4: Live tool call (coda_ls) ---
+echo "4. Live tool call"
 ls_response=$(mcp_call '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"coda_ls","arguments":{}}}' | tail -1)
 if echo "$ls_response" | grep -q '"type":"text"'; then
     pass "coda_ls returned text content"
@@ -85,13 +98,54 @@ else
     fail "coda_ls did not return expected format"
 fi
 
-# --- Test 4: Tool call with bad args returns error gracefully ---
-echo "4. Error handling"
+# --- Test 5: Bad args handled gracefully ---
+echo "5. Error handling"
 err_response=$(mcp_call '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"coda_layout_show","arguments":{}}}' | tail -1)
 if echo "$err_response" | grep -qi 'error\|exit code\|invalid\|required'; then
     pass "Bad args handled gracefully"
 else
     fail "Bad args call did not return an error response"
+fi
+
+# --- Test 6: Dynamic plugin tool registration ---
+echo "6. Dynamic plugin tools"
+TMPDIR_PLUGIN=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_PLUGIN"' EXIT
+
+mkdir -p "$TMPDIR_PLUGIN/plugins/mock-plugin"
+cat > "$TMPDIR_PLUGIN/plugins/mock-plugin/plugin.json" << 'PLUGIN_EOF'
+{
+  "name": "mock-plugin",
+  "provides": {
+    "mcp_tools": {
+      "coda_mock_test": {
+        "description": "A mock test tool",
+        "command": ["help"]
+      }
+    }
+  }
+}
+PLUGIN_EOF
+
+cat > "$TMPDIR_PLUGIN/config.json" << 'CONFIG_EOF'
+{"plugins": {"git@github.com:test/mock-plugin.git": {"enabled": true}}}
+CONFIG_EOF
+
+plugin_tools_response=$(mcp_call_env \
+    "CODA_CONFIG_PATH=$TMPDIR_PLUGIN/config.json CODA_PLUGINS_DIR=$TMPDIR_PLUGIN/plugins" \
+    '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' | tail -1)
+
+if echo "$plugin_tools_response" | grep -q '"coda_mock_test"'; then
+    pass "Dynamic plugin tool coda_mock_test registered"
+else
+    fail "Dynamic plugin tool coda_mock_test not found"
+fi
+
+# Verify core tools still present alongside plugin tools
+if echo "$plugin_tools_response" | grep -q '"coda_ls"'; then
+    pass "Core tools still present with plugin tools"
+else
+    fail "Core tools missing when plugin tools loaded"
 fi
 
 # --- Summary ---

--- a/shell-functions.sh
+++ b/shell-functions.sh
@@ -5,6 +5,8 @@
 # Source in .bashrc or .zshrc:
 #   source ~/coda/shell-functions.sh
 
+CODA_VERSION="0.1.1"
+
 _CODA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 _CODA_ENV_FILE="${CODA_ENV_FILE:-$_CODA_DIR/.env}"
@@ -24,7 +26,7 @@ OPENCODE_BASE_PORT="${OPENCODE_BASE_PORT:-4096}"
 OPENCODE_PORT_RANGE="${OPENCODE_PORT_RANGE:-10}"
 AUTO_ATTACH_TMUX="${AUTO_ATTACH_TMUX:-true}"
 DEFAULT_TMUX_SESSION="${DEFAULT_TMUX_SESSION:-default}"
-DEFAULT_LAYOUT="${DEFAULT_LAYOUT:-four-pane}"
+DEFAULT_LAYOUT="${DEFAULT_LAYOUT:-default}"
 DEFAULT_NVIM_APPNAME="${DEFAULT_NVIM_APPNAME:-nvim}"
 CODA_PROFILES_DIR="${CODA_PROFILES_DIR:-$HOME/.config/coda/profiles}"
 CODA_LAYOUTS_DIR="${CODA_LAYOUTS_DIR:-$HOME/.config/coda/layouts}"
@@ -34,13 +36,16 @@ CLIPROXYAPI_HEALTH_URL="${CLIPROXYAPI_HEALTH_URL:-}"
 CLIPROXYAPI_API_KEY="${CLIPROXYAPI_API_KEY:-}"
 CLAUDE_CREDENTIALS_PATH="${CLAUDE_CREDENTIALS_PATH:-$HOME/.claude/.credentials.json}"
 CODA_HOOKS_DIR="${CODA_HOOKS_DIR:-$HOME/.config/coda/hooks}"
+CODA_PLUGINS_DIR="${CODA_PLUGINS_DIR:-$HOME/.config/coda/plugins}"
 
 # Load modules
-for _coda_mod in helpers hooks core project feature layout provider profile watch github; do
+for _coda_mod in helpers hooks core project feature layout provider profile watch github plugin; do
     # shellcheck source=/dev/null
     source "$_CODA_DIR/lib/${_coda_mod}.sh"
 done
 unset _coda_mod
+
+_coda_plugin_load_all
 
 if [ -n "${CODA_OPENCODE_CONFIG_PATH:-}" ]; then
     export OPENCODE_CONFIG="$(_coda_resolve_opencode_config_path)"

--- a/test/shell-modules.bats
+++ b/test/shell-modules.bats
@@ -22,7 +22,7 @@ setup() {
 }
 
 @test "all lib modules exist on disk" {
-    for mod in helpers core project feature layout provider profile watch; do
+    for mod in helpers core project feature layout provider profile watch plugin; do
         [ -f "$SCRIPT_DIR/lib/${mod}.sh" ]
     done
 }
@@ -908,4 +908,213 @@ setup() {
 @test "coda provider ls is accessible" {
     run coda provider ls
     [ "$status" -eq 0 ]
+}
+
+# --- Plugin system tests ---
+
+@test "_coda_plugin_cmd is defined" {
+    declare -f _coda_plugin_cmd &>/dev/null
+}
+
+@test "_coda_plugin_load_all is defined" {
+    declare -f _coda_plugin_load_all &>/dev/null
+}
+
+@test "_coda_plugin_dispatch is defined" {
+    declare -f _coda_plugin_dispatch &>/dev/null
+}
+
+@test "_coda_plugin_install is defined" {
+    declare -f _coda_plugin_install &>/dev/null
+}
+
+@test "_coda_plugin_remove is defined" {
+    declare -f _coda_plugin_remove &>/dev/null
+}
+
+@test "_coda_plugin_ls is defined" {
+    declare -f _coda_plugin_ls &>/dev/null
+}
+
+@test "coda plugin help shows usage" {
+    run coda plugin help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage"* ]]
+    [[ "$output" == *"install"* ]]
+    [[ "$output" == *"remove"* ]]
+}
+
+@test "coda plugin ls shows message when no plugins" {
+    CODA_PLUGINS_DIR=$(mktemp -d)
+    run _coda_plugin_ls
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No plugins installed"* ]]
+    rm -rf "$CODA_PLUGINS_DIR"
+}
+
+@test "coda help includes plugin subcommands" {
+    run coda help
+    [[ "$output" == *"coda plugin"* ]]
+}
+
+@test "_coda_plugin_load registers commands from mock plugin" {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/lib"
+    printf '{"name":"test-plugin","version":"1.0.0","provides":{"commands":{"test-cmd":{"handler":"lib/test.sh","function":"_test_func"}}}}' > "$tmpdir/plugin.json"
+    printf '#!/usr/bin/env bash\n_test_func() { echo "plugin-ran"; }\n' > "$tmpdir/lib/test.sh"
+    _CODA_PLUGIN_COMMANDS=()
+    _coda_plugin_load "test-plugin" "$tmpdir"
+    [[ -n "${_CODA_PLUGIN_COMMANDS[test-cmd]}" ]]
+    rm -rf "$tmpdir"
+}
+
+@test "_coda_plugin_dispatch executes plugin command" {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/lib"
+    printf '#!/usr/bin/env bash\n_test_dispatch_func() { echo "dispatched"; }\n' > "$tmpdir/lib/handler.sh"
+    _CODA_PLUGIN_COMMANDS=([test-dispatch]="$tmpdir/lib/handler.sh:_test_dispatch_func:$tmpdir")
+    run _coda_plugin_dispatch test-dispatch
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"dispatched"* ]]
+    rm -rf "$tmpdir"
+}
+
+@test "_coda_plugin_dispatch returns 1 for unknown command" {
+    _CODA_PLUGIN_COMMANDS=()
+    run _coda_plugin_dispatch nonexistent-plugin-cmd
+    [ "$status" -eq 1 ]
+}
+
+@test "_coda_plugin_name_from_url extracts name from SSH URL" {
+    result=$(_coda_plugin_name_from_url "git@github.com:user/coda-github.git")
+    [ "$result" = "coda-github" ]
+}
+
+@test "_coda_plugin_name_from_url extracts name from HTTPS URL" {
+    result=$(_coda_plugin_name_from_url "https://github.com/user/coda-watch.git")
+    [ "$result" = "coda-watch" ]
+}
+
+@test "CODA_PLUGINS_DIR has a default" {
+    [ -n "$CODA_PLUGINS_DIR" ]
+}
+
+# --- Versioning tests ---
+
+@test "CODA_VERSION is set" {
+    [ -n "$CODA_VERSION" ]
+}
+
+@test "coda version prints version" {
+    run coda version
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"$CODA_VERSION"* ]]
+}
+
+@test "coda --version prints version" {
+    run coda --version
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"coda"* ]]
+}
+
+@test "_coda_semver_compare equal versions" {
+    result=$(_coda_semver_compare "1.2.3" "1.2.3")
+    [ "$result" -eq 0 ]
+}
+
+@test "_coda_semver_compare greater major" {
+    result=$(_coda_semver_compare "2.0.0" "1.9.9")
+    [ "$result" -eq 1 ]
+}
+
+@test "_coda_semver_compare lesser minor" {
+    result=$(_coda_semver_compare "1.1.0" "1.2.0")
+    [ "$result" -eq -1 ]
+}
+
+@test "_coda_semver_compare patch difference" {
+    result=$(_coda_semver_compare "1.0.1" "1.0.0")
+    [ "$result" -eq 1 ]
+}
+
+@test "_coda_semver_satisfies empty constraint" {
+    _coda_semver_satisfies "1.0.0" ""
+}
+
+@test "_coda_semver_satisfies caret same major" {
+    _coda_semver_satisfies "1.5.3" "^1.0.0"
+}
+
+@test "_coda_semver_satisfies caret rejects next major" {
+    run _coda_semver_satisfies "2.0.0" "^1.0.0"
+    [ "$status" -ne 0 ]
+}
+
+@test "_coda_semver_satisfies caret rejects below" {
+    run _coda_semver_satisfies "0.9.0" "^1.0.0"
+    [ "$status" -ne 0 ]
+}
+
+@test "_coda_semver_satisfies tilde same minor" {
+    _coda_semver_satisfies "1.2.9" "~1.2.0"
+}
+
+@test "_coda_semver_satisfies tilde rejects next minor" {
+    run _coda_semver_satisfies "1.3.0" "~1.2.0"
+    [ "$status" -ne 0 ]
+}
+
+@test "_coda_semver_satisfies exact match" {
+    _coda_semver_satisfies "1.0.0" "1.0.0"
+}
+
+@test "_coda_semver_satisfies exact mismatch" {
+    run _coda_semver_satisfies "1.0.1" "1.0.0"
+    [ "$status" -ne 0 ]
+}
+
+@test "_coda_semver_satisfies range" {
+    _coda_semver_satisfies "1.5.0" ">= 1.0.0 < 2.0.0"
+}
+
+@test "_coda_semver_satisfies range rejects above" {
+    run _coda_semver_satisfies "2.0.0" ">= 1.0.0 < 2.0.0"
+    [ "$status" -ne 0 ]
+}
+
+@test "_coda_semver_satisfies range rejects below" {
+    run _coda_semver_satisfies "0.9.0" ">= 1.0.0 < 2.0.0"
+    [ "$status" -ne 0 ]
+}
+
+@test "_coda_semver_satisfies caret 0.x allows same minor" {
+    _coda_semver_satisfies "0.1.5" "^0.1.0"
+}
+
+@test "_coda_semver_satisfies caret 0.x rejects next major" {
+    run _coda_semver_satisfies "1.0.0" "^0.1.0"
+    [ "$status" -ne 0 ]
+}
+
+@test "plugin load skips incompatible plugin" {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/bad-plugin"
+    printf '{"name":"bad","version":"1.0.0","coda":"^99.0.0","provides":{"commands":{"badcmd":{"handler":"h.sh","function":"f"}}}}' > "$tmpdir/bad-plugin/plugin.json"
+    _coda_plugin_load "bad-plugin" "$tmpdir/bad-plugin" 2>/dev/null
+    [ -z "${_CODA_PLUGIN_COMMANDS[badcmd]+x}" ]
+    rm -rf "$tmpdir"
+}
+
+@test "plugin load accepts compatible plugin" {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/good-plugin"
+    printf '{"name":"good","version":"1.0.0","coda":"^0.1.0","provides":{"commands":{"goodcmd":{"handler":"h.sh","function":"f"}}}}' > "$tmpdir/good-plugin/plugin.json"
+    _coda_plugin_load "good-plugin" "$tmpdir/good-plugin"
+    [ -n "${_CODA_PLUGIN_COMMANDS[goodcmd]+x}" ]
+    unset '_CODA_PLUGIN_COMMANDS[goodcmd]'
+    rm -rf "$tmpdir"
 }

--- a/test/shell-modules.bats
+++ b/test/shell-modules.bats
@@ -1093,6 +1093,11 @@ setup() {
     _coda_semver_satisfies "0.1.5" "^0.1.0"
 }
 
+@test "_coda_semver_satisfies caret 0.x rejects next minor" {
+    run _coda_semver_satisfies "0.2.0" "^0.1.0"
+    [ "$status" -ne 0 ]
+}
+
 @test "_coda_semver_satisfies caret 0.x rejects next major" {
     run _coda_semver_satisfies "1.0.0" "^0.1.0"
     [ "$status" -ne 0 ]

--- a/test/shell-modules.bats
+++ b/test/shell-modules.bats
@@ -981,10 +981,10 @@ setup() {
     rm -rf "$tmpdir"
 }
 
-@test "_coda_plugin_dispatch returns 1 for unknown command" {
+@test "_coda_plugin_dispatch returns 127 for unknown command" {
     _CODA_PLUGIN_COMMANDS=()
     run _coda_plugin_dispatch nonexistent-plugin-cmd
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 127 ]
 }
 
 @test "_coda_plugin_name_from_url extracts name from SSH URL" {
@@ -1087,6 +1087,10 @@ setup() {
 @test "_coda_semver_satisfies range rejects below" {
     run _coda_semver_satisfies "0.9.0" ">= 1.0.0 < 2.0.0"
     [ "$status" -ne 0 ]
+}
+
+@test "_coda_semver_satisfies spaceless range" {
+    _coda_semver_satisfies "1.5.0" ">=1.0.0 <2.0.0"
 }
 
 @test "_coda_semver_satisfies caret 0.x allows same minor" {


### PR DESCRIPTION
## Summary

- **Plugin system**: Composable plugins as git repos with `plugin.json` manifests. Plugins declare commands, hooks, providers, notifications, MCP tools, system dependencies, and coda version constraints.
- **Versioning**: `CODA_VERSION=0.1.1`, semver constraint engine (`^`, `~`, `>=`, `<`, ranges), plugins declare `"coda": "^0.1.0"` compatibility.
- **Slimmed installer**: `install.sh` reduced from 651 to 306 lines. Only installs core (shell functions, completions, man page, Go binary, MCP server). CLI options: `--projects-dir`, `--skip-go`, `--skip-mcp`. VM provisioning removed entirely.
- **Dynamic MCP**: Server trimmed to 13 core tools. Plugins inject their own MCP tools via `provides.mcp_tools` in `plugin.json`, loaded dynamically at startup.
- **Dependency checking**: Core errors on missing `bash`/`git`/`tmux`. Plugins with missing deps are disabled with a warning, not auto-installed.

## Plugin repos (separate, all pushed to GitHub)

| Repo | Type | What it provides |
|------|------|------------------|
| `coda-github` | plugin | `coda github` command, Go binary, 3 MCP tools |
| `coda-watch` | plugin | `coda watch` command, Go watcher, bell notification, 3 MCP tools |
| `coda-provider-claude-auth` | plugin | Claude CLI OAuth provider |
| `coda-provider-cliproxyapi` | plugin | CLIProxyAPI provider, Go helper, 1 MCP tool |
| `coda-layout-five-pane` | layout | Five-pane layout with `layout.json` dependency manifest |

All plugin repos have `plugin.json`, `test/plugin.bats`, and detailed READMEs.

## Tests

- **163 core bats tests** (22 new for versioning/semver/plugin compat)
- **7 MCP server tests** (core tools, plugin isolation, dynamic registration)
- **~65 tests across plugin repos** (manifests, handlers, Go builds, provider contracts)

## Files changed in core

| File | Change |
|------|--------|
| `lib/plugin.sh` | **New** — full plugin lifecycle + semver engine |
| `docs/plugin-contracts/plugins.md` | **New** — plugin manifest spec |
| `docs/plugin-contracts/notifications.md` | **New** — notification contract |
| `install.sh` | Slimmed: core-only, CLI options, dependency checking |
| `shell-functions.sh` | `CODA_VERSION`, `CODA_PLUGINS_DIR`, plugin module, `DEFAULT_LAYOUT=default` |
| `lib/core.sh` | Plugin dispatch, `coda version`, auto-detect missing plugins |
| `lib/hooks.sh` | Plugin hook integration |
| `lib/provider.sh` | Plugin provider integration |
| `lib/watch.sh` | Plugin notification integration |
| `mcp-server/server.js` | Core-only tools + dynamic plugin tool registration |
| `mcp-server/test.sh` | Updated for core tools, plugin isolation, dynamic loading |
| `layouts/default.sh` | Two-pane (opencode 80% / shell 20%) |
| `completions/coda.{bash,zsh}` | Added `plugin` subcommand |
| `docs/plugin-contracts/*.md` | Updated with plugin integration notes |
| `.env.example` | `DEFAULT_LAYOUT=default`, `CODA_PLUGINS_DIR` |