### PR TITLE
feat: add init field to plugin.json for eager shell init sourcing

### DIFF
--- a/lib/plugin.sh
+++ b/lib/plugin.sh
@@ -214,6 +214,14 @@ _coda_plugin_load() {
         [ -z "$glob" ] && continue
         _CODA_PLUGIN_NOTIFICATIONS+=("$dir/$glob")
     done <<< "$notifs"
+
+    # Source init script (eager load at shell init, not lazy)
+    local init_script
+    init_script=$(jq -r '.init // empty' "$manifest" 2>/dev/null)
+    if [ -n "$init_script" ] && [ -f "$dir/$init_script" ]; then
+        # shellcheck source=/dev/null
+        source "$dir/$init_script"
+    fi
 }
 
 _coda_plugin_name_from_url() {

--- a/lib/plugin.sh
+++ b/lib/plugin.sh
@@ -218,9 +218,15 @@ _coda_plugin_load() {
     # Source init script (eager load at shell init, not lazy)
     local init_script
     init_script=$(jq -r '.init // empty' "$manifest" 2>/dev/null)
-    if [ -n "$init_script" ] && [ -f "$dir/$init_script" ]; then
-        # shellcheck source=/dev/null
-        source "$dir/$init_script"
+    if [ -n "$init_script" ]; then
+        # Reject path traversal
+        case "$init_script" in
+            ../*|*/../*|/*) echo "warning: plugin '$name' init path '$init_script' is invalid, skipping" >&2; return 0 ;;
+        esac
+        if [ -f "$dir/$init_script" ]; then
+            # shellcheck source=/dev/null
+            source "$dir/$init_script"
+        fi
     fi
 }
 


### PR DESCRIPTION
## Summary
- Adds `"init"` field support to plugin.json spec
- When a plugin declares `"init": "lib/shell-init.sh"`, that script is sourced during `_coda_plugin_load_all` at shell init time (not lazily on first command dispatch)
- This allows plugins to define functions that need to be available before built-in commands run

## Motivation
The coda-orchestrator plugin needs to define `_coda_feature_orch_hook()` -- a function called by `coda feature start --orch`. Today, plugin handlers are only sourced when their registered command is dispatched. But `feature start` is a built-in, not a plugin command, so the handler never gets sourced before it runs.

The `init` field solves this: the plugin's init script is sourced at shell startup, making hook functions available to built-in commands.

## Change
5 lines in `lib/plugin.sh:_coda_plugin_load()` -- follows the exact same pattern as the existing `install` script support (line 360-364).

## Unblocks
- coda-orchestrator #68 (overloaded `coda feature start --orch`)