### PR TITLE
fix: prune opencode sessions on feature done/finish (#76)

### DIFF
--- a/lib/feature.sh
+++ b/lib/feature.sh
@@ -138,6 +138,13 @@ _coda_feature_done() {
         git -C "$project_root" branch -D "$branch"
     fi
 
+    # Prune opencode sessions tied to the torn-down worktree.
+    # _orch_prune_sessions_for_dir is provided by the orchestrator plugin;
+    # silently no-op when the plugin isn't loaded.
+    if declare -f _orch_prune_sessions_for_dir &>/dev/null; then
+        _orch_prune_sessions_for_dir "$worktree_dir" 2>/dev/null || true
+    fi
+
     echo "Done."
 }
 
@@ -209,6 +216,9 @@ _coda_feature_finish() {
         fi
         if git -C "$project_root" show-ref --verify --quiet "refs/heads/$branch" 2>/dev/null; then
             git -C "$project_root" branch -D "$branch" 2>/dev/null
+        fi
+        if declare -f _orch_prune_sessions_for_dir &>/dev/null; then
+            _orch_prune_sessions_for_dir "$worktree_dir" 2>/dev/null || true
         fi
         CODA_PROJECT_NAME="$project_name" CODA_FEATURE_BRANCH="$branch" \
             _coda_run_hooks post-feature-finish


### PR DESCRIPTION
## Summary

- Calls `_orch_prune_sessions_for_dir` in both `coda feature done` and `coda feature finish` to hard-delete opencode sessions tied to the torn-down worktree
- Guard-gated: silently no-ops when the orchestrator plugin is not loaded

## Cross-repo dependency

Requires `_orch_prune_sessions_for_dir` from `evanstern/coda-orchestrator` (PR #29).
The function is sourced via the orchestrator plugin's `shell-init.sh`.

## Card

Focus card #76: Session management and pruning for opencode serve instances