### PR TITLE
fix(mcp): return 404 for unknown session id per MCP spec

### DIFF
--- a/mcp-server/server.js
+++ b/mcp-server/server.js
@@ -406,7 +406,11 @@ function startHttp() {
 
       if (sessionId && transports.has(sessionId)) {
         await transports.get(sessionId).handleRequest(req, res, body);
-      } else if (!sessionId && isInitializeRequest(body)) {
+      } else if (sessionId && !transports.has(sessionId)) {
+        // Stale session — tell the client to re-initialize
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Session not found" }));
+      } else if (isInitializeRequest(body)) {
         const transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: () => randomUUID(),
           onsessioninitialized: (sid) => transports.set(sid, transport),

--- a/mcp-server/server.js
+++ b/mcp-server/server.js
@@ -407,9 +407,13 @@ function startHttp() {
       if (sessionId && transports.has(sessionId)) {
         await transports.get(sessionId).handleRequest(req, res, body);
       } else if (sessionId && !transports.has(sessionId)) {
-        // Stale session — tell the client to re-initialize
+        // Stale/unknown session — return 404 per MCP spec so clients re-initialize
         res.writeHead(404, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: "Session not found" }));
+        res.end(JSON.stringify({
+          jsonrpc: "2.0",
+          error: { code: -32001, message: "Session not found" },
+          id: null,
+        }));
       } else if (isInitializeRequest(body)) {
         const transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: () => randomUUID(),

--- a/mcp-server/test.sh
+++ b/mcp-server/test.sh
@@ -20,7 +20,7 @@ fi
 mcp_call() {
     local init='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}'
     local notify='{"jsonrpc":"2.0","method":"notifications/initialized"}'
-    printf '%s\n%s\n%s\n' "$init" "$notify" "$1" | timeout 10 node "$SERVER" 2>/dev/null
+    printf '%s\n%s\n%s\n' "$init" "$notify" "$1" | timeout 10 node "$SERVER" --stdio 2>/dev/null
 }
 
 mcp_call_env() {
@@ -28,7 +28,7 @@ mcp_call_env() {
     local msg="$2"
     local init='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}'
     local notify='{"jsonrpc":"2.0","method":"notifications/initialized"}'
-    printf '%s\n%s\n%s\n' "$init" "$notify" "$msg" | timeout 10 env $env_args node "$SERVER" 2>/dev/null
+    printf '%s\n%s\n%s\n' "$init" "$notify" "$msg" | timeout 10 env $env_args node "$SERVER" --stdio 2>/dev/null
 }
 
 echo "MCP Server Tests"
@@ -37,7 +37,7 @@ echo ""
 
 # --- Test 1: Server initializes ---
 echo "1. Server initialization"
-response=$(printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}\n' | timeout 5 node "$SERVER" 2>/dev/null || true)
+response=$(printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}\n' | timeout 5 node "$SERVER" --stdio 2>/dev/null || true)
 if echo "$response" | grep -q '"name":"coda"'; then
     pass "Server starts and identifies as 'coda'"
 else
@@ -147,6 +147,114 @@ if echo "$plugin_tools_response" | grep -q '"coda_ls"'; then
 else
     fail "Core tools missing when plugin tools loaded"
 fi
+
+# --- Test 7: HTTP mode session handling ---
+echo "7. HTTP mode session handling"
+HTTP_PORT=3199
+HTTP_URL="http://127.0.0.1:$HTTP_PORT/mcp"
+HTTP_LOG=$(mktemp)
+HTTP_PID=""
+cleanup_http() {
+    if [ -n "$HTTP_PID" ]; then
+        kill "$HTTP_PID" 2>/dev/null || true
+        wait "$HTTP_PID" 2>/dev/null || true
+        HTTP_PID=""
+    fi
+    rm -f "$HTTP_LOG"
+}
+trap 'rm -rf "$TMPDIR_PLUGIN"; cleanup_http' EXIT
+
+CODA_MCP_PORT=$HTTP_PORT node "$SERVER" >"$HTTP_LOG" 2>&1 &
+HTTP_PID=$!
+
+# Wait for /health to respond (up to ~5s)
+for _ in $(seq 1 50); do
+    if curl -sf "http://127.0.0.1:$HTTP_PORT/health" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.1
+done
+
+if ! curl -sf "http://127.0.0.1:$HTTP_PORT/health" >/dev/null 2>&1; then
+    fail "HTTP server did not start on port $HTTP_PORT"
+    echo "--- server log ---"
+    cat "$HTTP_LOG"
+else
+    pass "HTTP server /health reachable"
+
+    # 7a: No session id + initialize request -> 200 with Mcp-Session-Id header
+    init_body='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}'
+    init_headers=$(mktemp)
+    curl -s -D "$init_headers" \
+        -H 'Content-Type: application/json' \
+        -H 'Accept: application/json, text/event-stream' \
+        -X POST --data "$init_body" "$HTTP_URL" -o /dev/null
+    init_status=$(awk 'NR==1{print $2}' "$init_headers")
+    session_id=$(awk -F': ' 'tolower($1)=="mcp-session-id"{gsub(/\r/,"",$2); print $2}' "$init_headers")
+    rm -f "$init_headers"
+
+    if [ "$init_status" = "200" ] && [ -n "$session_id" ]; then
+        pass "Initialize returns 200 with Mcp-Session-Id header"
+    else
+        fail "Initialize expected 200 + session id, got status=$init_status id='$session_id'"
+    fi
+
+    # 7b: Valid session id + tool call -> 200
+    if [ -n "$session_id" ]; then
+        call_body='{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+        call_status=$(curl -s -o /dev/null -w '%{http_code}' \
+            -H 'Content-Type: application/json' \
+            -H 'Accept: application/json, text/event-stream' \
+            -H "Mcp-Session-Id: $session_id" \
+            -X POST --data "$call_body" "$HTTP_URL")
+        if [ "$call_status" = "200" ]; then
+            pass "Valid session tool call returns 200"
+        else
+            fail "Valid session tool call expected 200, got $call_status"
+        fi
+    fi
+
+    # 7c: Unknown session id + tool call -> 404 with "Session not found"
+    stale_body_req='{"jsonrpc":"2.0","id":99,"method":"tools/list","params":{}}'
+    stale_resp=$(mktemp)
+    stale_status=$(curl -s -o "$stale_resp" -w '%{http_code}' \
+        -H 'Content-Type: application/json' \
+        -H 'Accept: application/json, text/event-stream' \
+        -H 'Mcp-Session-Id: bogus-nonexistent-session' \
+        -X POST --data "$stale_body_req" "$HTTP_URL")
+    if [ "$stale_status" = "404" ]; then
+        pass "Unknown session id returns HTTP 404"
+    else
+        fail "Unknown session id expected 404, got $stale_status"
+    fi
+    if grep -q 'Session not found' "$stale_resp"; then
+        pass "Stale session body contains 'Session not found'"
+    else
+        fail "Stale session body missing 'Session not found': $(cat "$stale_resp")"
+    fi
+    if grep -q '"jsonrpc"' "$stale_resp"; then
+        pass "Stale session body is JSON-RPC formatted"
+    else
+        fail "Stale session body not JSON-RPC formatted: $(cat "$stale_resp")"
+    fi
+    rm -f "$stale_resp"
+
+    # 7d: No session id + non-initialize body -> 400
+    bad_body='{"jsonrpc":"2.0","id":3,"method":"tools/list","params":{}}'
+    bad_resp=$(mktemp)
+    bad_status=$(curl -s -o "$bad_resp" -w '%{http_code}' \
+        -H 'Content-Type: application/json' \
+        -H 'Accept: application/json, text/event-stream' \
+        -X POST --data "$bad_body" "$HTTP_URL")
+    if [ "$bad_status" = "400" ]; then
+        pass "No session + non-initialize returns 400"
+    else
+        fail "No session + non-initialize expected 400, got $bad_status body=$(cat "$bad_resp")"
+    fi
+    rm -f "$bad_resp"
+fi
+
+cleanup_http
 
 # --- Summary ---
 echo ""


### PR DESCRIPTION
## Summary

- Split the final \`else\` in the POST \`/mcp\` handler into two branches so requests carrying an \`Mcp-Session-Id\` the server does not recognize get HTTP **404 Not Found** (the MCP spec's re-initialize signal) instead of HTTP **400**.
- \`400\` is now reserved for genuinely malformed requests (no session id + non-initialize body).
- 404 body is shaped as a JSON-RPC error object (\`code: -32001, message: \"Session not found\"\`) so SDK clients parsing the response get a real jsonrpc payload.

## Why

Before this fix, clients that hit the server with a stale session id (after a server restart, transport eviction, etc.) received a 400 \"Invalid request\" response. The MCP SDK treats 404 — not 400 — as the signal to drop the stale session id and re-initialize. Returning 400 trapped clients until they manually toggled the MCP connection off and back on.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Valid session id + tool call | 200 | 200 (unchanged) |
| No session id + \`InitializeRequest\` | 200 + \`Mcp-Session-Id\` | 200 + \`Mcp-Session-Id\` (unchanged) |
| Unknown / stale session id | **400** | **404** + \`{\"error\": {\"code\": -32001, \"message\": \"Session not found\"}}\` |
| No session id + non-initialize body | 400 | 400 (unchanged) |

## Spec citation

MCP 2025-06-18, *Basic / Transports / Streamable HTTP / Session Management*:

> The server **MAY** terminate the session at any time, after which it **MUST** respond to requests containing that session ID with HTTP 404 Not Found.
>
> When a client receives HTTP 404 in response to a request containing an \`Mcp-Session-Id\`, it **MUST** start a new session by sending a new \`InitializeRequest\` without a session ID attached.

https://modelcontextprotocol.io/specification/2025-06-18/basic/transports

## Tests

\`mcp-server/test.sh\` now covers all four HTTP POST \`/mcp\` branches. The existing stdio-mode helpers (\`mcp_call\`, \`mcp_call_env\`) were also updated to pass the \`--stdio\` flag the server has required since it switched to HTTP-default.

\`\`\`
MCP Server Tests
=================

1. Server initialization
  [pass] Server starts and identifies as 'coda'
2. Core tool registration
  [pass] All 13 core tools registered
3. Plugin tools absent from core
  [pass] No plugin tools in core-only list
4. Live tool call
  [pass] coda_ls returned text content
5. Error handling
  [pass] Bad args handled gracefully
6. Dynamic plugin tools
  [pass] Dynamic plugin tool coda_mock_test registered
  [pass] Core tools still present with plugin tools
7. HTTP mode session handling
  [pass] HTTP server /health reachable
  [pass] Initialize returns 200 with Mcp-Session-Id header
  [pass] Valid session tool call returns 200
  [pass] Unknown session id returns HTTP 404
  [pass] Stale session body contains 'Session not found'
  [pass] Stale session body is JSON-RPC formatted
  [pass] No session + non-initialize returns 400

Results: 14 passed, 0 failed
\`\`\`

Closes #119.