### PR TITLE
feat(cli): window-aware teardown for feature done/finish

### DIFF
--- a/lib/feature.sh
+++ b/lib/feature.sh
@@ -125,12 +125,80 @@ _coda_feature_start() {
     fi
 }
 
+# Locate a feature's tmux target across all known orch sessions.
+#
+# Args:
+#   $1 - branch name (the window name to search for)
+#   $2 - explicit orch override (may be empty)
+#
+# Prints:
+#   "<orch-session>:<window>" when exactly one match OR --orch override used
+#   "" when no match (caller falls back to legacy session path)
+#
+# Exits nonzero when multiple orchs contain a window with this branch
+# name AND no explicit orch given.
+_coda_feature_locate_window() {
+    local branch="$1"
+    local orch_name="${2:-}"
+
+    if [ -n "$orch_name" ]; then
+        local orch_target
+        orch_target="${SESSION_PREFIX}orch--$(_coda_sanitize_session_name "$orch_name")"
+        if tmux list-windows -t "$orch_target" -F '#{window_name}' 2>/dev/null \
+                | grep -Fxq -- "$branch"; then
+            echo "${orch_target}:${branch}"
+            return 0
+        fi
+        return 0
+    fi
+
+    # Probe: scan every coda-orch--* session for a window named $branch.
+    local matches=()
+    local sess
+    while IFS= read -r sess; do
+        [ -n "$sess" ] || continue
+        if tmux list-windows -t "$sess" -F '#{window_name}' 2>/dev/null \
+                | grep -Fxq -- "$branch"; then
+            matches+=("${sess}:${branch}")
+        fi
+    done < <(tmux list-sessions -F '#{session_name}' 2>/dev/null \
+                 | grep "^${SESSION_PREFIX}orch--" || true)
+
+    case ${#matches[@]} in
+        0) echo "" ;;
+        1) echo "${matches[0]}" ;;
+        *)
+            echo "Multiple orchestrator sessions contain a window named '$branch':" >&2
+            printf '  %s\n' "${matches[@]}" >&2
+            echo "" >&2
+            echo "Disambiguate with: coda feature done $branch --orch <name>" >&2
+            return 1
+            ;;
+    esac
+}
+
 _coda_feature_done() {
-    local branch="${1:-}"
-    local project_name="${2:-}"
+    local branch="" project_name="" orch_name=""
+    local positional=()
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --orch)
+                if [ $# -lt 2 ] || [ -z "${2:-}" ]; then
+                    echo "Usage: coda feature done <branch> [project-name] [--orch <name>]"
+                    return 1
+                fi
+                orch_name="$2"; shift 2 ;;
+            --orch=*) orch_name="${1#--orch=}"; shift ;;
+            *)        positional+=("$1"); shift ;;
+        esac
+    done
+
+    branch="${positional[0]:-}"
+    project_name="${positional[1]:-}"
 
     if [ -z "$branch" ]; then
-        echo "Usage: coda feature done <branch> [project-name]"
+        echo "Usage: coda feature done <branch> [project-name] [--orch <name>]"
         return 1
     fi
 
@@ -154,14 +222,28 @@ _coda_feature_done() {
     local session="${SESSION_PREFIX}$(_coda_sanitize_session_name "$project_name")--${branch}"
     local worktree_dir="$project_root/$branch"
 
+    # Probe for window-mode target before hooks so hooks see the right
+    # session name. Multi-match errors surface here.
+    local window_target
+    window_target=$(_coda_feature_locate_window "$branch" "$orch_name") || return 1
+
+    local hook_session_name="$session"
+    [ -n "$window_target" ] && hook_session_name="$window_target"
+
     echo "Cleaning up feature: $branch"
 
     CODA_PROJECT_NAME="$project_name" CODA_PROJECT_DIR="$project_root" \
     CODA_FEATURE_BRANCH="$branch" CODA_WORKTREE_DIR="$worktree_dir" \
-    CODA_SESSION_NAME="$session" \
+    CODA_SESSION_NAME="$hook_session_name" \
         _coda_run_hooks pre-feature-teardown
 
-    if tmux has-session -t "$session" 2>/dev/null; then
+    # Try window-mode first. If a window matches (either via --orch
+    # override or via probe), kill the window; leave the orch session
+    # untouched. Otherwise, fall back to legacy session teardown.
+    if [ -n "$window_target" ]; then
+        echo "  Killing window: $window_target"
+        tmux kill-window -t "$window_target"
+    elif tmux has-session -t "$session" 2>/dev/null; then
         echo "  Killing session: $session"
         tmux kill-session -t "$session"
     fi
@@ -185,10 +267,19 @@ _coda_feature_done() {
 
 _coda_feature_finish() {
     local force=false
+    local orch_name=""
+
     while [ $# -gt 0 ]; do
         case "$1" in
             --force|-f) force=true; shift ;;
-            *) echo "Usage: coda feature finish [--force]"; return 1 ;;
+            --orch)
+                if [ $# -lt 2 ] || [ -z "${2:-}" ]; then
+                    echo "Usage: coda feature finish [--force] [--orch <name>]"
+                    return 1
+                fi
+                orch_name="$2"; shift 2 ;;
+            --orch=*) orch_name="${1#--orch=}"; shift ;;
+            *) echo "Usage: coda feature finish [--force] [--orch <name>]"; return 1 ;;
         esac
     done
 
@@ -239,11 +330,18 @@ _coda_feature_finish() {
     local session="${SESSION_PREFIX}$(_coda_sanitize_session_name "$project_name")--${branch}"
     local worktree_dir="$project_root/$branch"
 
+    # Compute window target OUTSIDE the backgrounded subshell so any
+    # multi-match error surfaces to the user before teardown starts.
+    local window_target
+    window_target=$(_coda_feature_locate_window "$branch" "$orch_name") || return 1
+
     echo "Finishing feature: $branch"
 
     (
         sleep 1
-        if tmux has-session -t "$session" 2>/dev/null; then
+        if [ -n "$window_target" ]; then
+            tmux kill-window -t "$window_target" 2>/dev/null
+        elif tmux has-session -t "$session" 2>/dev/null; then
             tmux kill-session -t "$session"
         fi
         if [ -d "$worktree_dir" ]; then

--- a/test/shell-modules.bats
+++ b/test/shell-modules.bats
@@ -1476,3 +1476,350 @@ _coda95_stub_git() {
     unset -f tmux
     rm -f "$cmd_log"
 }
+
+# --- Card #96: window-aware teardown for feature done/finish ---
+
+_coda96_setup_fake_project() {
+    local project_name="$1"
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    export PROJECTS_DIR="$tmpdir"
+    local root="$tmpdir/$project_name"
+    mkdir -p "$root/.bare" "$root/main"
+    printf 'gitdir: ./.bare\n' > "$root/.git"
+    echo "$root"
+}
+
+_coda96_stub_git() {
+    git() {
+        local args=("$@")
+        for ((i=0; i<${#args[@]}; i++)); do
+            case "${args[i]}" in
+                show-ref) return 0 ;;
+                fetch|worktree) return 0 ;;
+                rev-parse) echo main; return 0 ;;
+                branch) return 0 ;;
+            esac
+        done
+        return 0
+    }
+    _coda_detect_default_branch() { echo main; }
+}
+
+@test "card96: _coda_feature_locate_window with no orch sessions returns empty" {
+    tmux() {
+        case "$1" in
+            list-sessions) return 0 ;;
+            list-windows) return 0 ;;
+        esac
+        return 0
+    }
+    local result
+    result=$(_coda_feature_locate_window "my-branch" "")
+    [ -z "$result" ]
+    unset -f tmux
+}
+
+@test "card96: _coda_feature_locate_window with one orch, window matches" {
+    tmux() {
+        case "$1" in
+            list-sessions) echo "${SESSION_PREFIX}orch--riley"; return 0 ;;
+            list-windows) echo "feat-x"; return 0 ;;
+        esac
+        return 0
+    }
+    local result
+    result=$(_coda_feature_locate_window "feat-x" "")
+    [ "$result" = "${SESSION_PREFIX}orch--riley:feat-x" ]
+    unset -f tmux
+}
+
+@test "card96: _coda_feature_locate_window with one orch, no matching window" {
+    tmux() {
+        case "$1" in
+            list-sessions) echo "${SESSION_PREFIX}orch--riley"; return 0 ;;
+            list-windows) echo "other-branch"; return 0 ;;
+        esac
+        return 0
+    }
+    local result
+    result=$(_coda_feature_locate_window "feat-x" "")
+    [ -z "$result" ]
+    unset -f tmux
+}
+
+@test "card96: _coda_feature_locate_window with explicit --orch, window matches" {
+    tmux() {
+        case "$1" in
+            list-windows) echo "feat-x"; return 0 ;;
+        esac
+        return 0
+    }
+    local result
+    result=$(_coda_feature_locate_window "feat-x" "riley")
+    [ "$result" = "${SESSION_PREFIX}orch--riley:feat-x" ]
+    unset -f tmux
+}
+
+@test "card96: _coda_feature_locate_window with explicit --orch, no matching window" {
+    tmux() {
+        case "$1" in
+            list-windows) return 0 ;;
+        esac
+        return 0
+    }
+    local result
+    result=$(_coda_feature_locate_window "feat-x" "riley")
+    [ -z "$result" ]
+    unset -f tmux
+}
+
+@test "card96: _coda_feature_locate_window with two orchs both having window exits 1" {
+    tmux() {
+        case "$1" in
+            list-sessions) printf '%s\n' "${SESSION_PREFIX}orch--alpha" "${SESSION_PREFIX}orch--beta"; return 0 ;;
+            list-windows) echo "feat-x"; return 0 ;;
+        esac
+        return 0
+    }
+    run _coda_feature_locate_window "feat-x" ""
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Multiple orchestrator sessions"* ]]
+    [[ "$output" == *"Disambiguate with"* ]]
+    unset -f tmux
+}
+
+@test "card96: _coda_feature_done parses --orch <name> (space form)" {
+    local capture_file
+    capture_file=$(mktemp)
+    _coda_run_hooks() { return 0; }
+    _coda_prune_sessions_for_dir() { return 0; }
+    _coda96_stub_git
+    local proj_dir
+    proj_dir=$(_coda96_setup_fake_project widget96a)
+    cd "$proj_dir/main"
+    # Set up mock tmux: orch session with window
+    tmux() {
+        case "$1" in
+            list-sessions) echo "${SESSION_PREFIX}orch--riley"; return 0 ;;
+            list-windows) echo "feat-a"; return 0 ;;
+            has-session) return 1 ;;
+            kill-window) echo "$3" > "$capture_file"; return 0 ;;
+        esac
+        return 0
+    }
+    _coda_feature_done feat-a --orch riley >/dev/null 2>&1
+    local killed
+    killed=$(cat "$capture_file")
+    [ "$killed" = "${SESSION_PREFIX}orch--riley:feat-a" ]
+    cd /
+    rm -rf "$proj_dir" "$capture_file"
+    unset -f _coda_run_hooks _coda_prune_sessions_for_dir tmux git _coda_detect_default_branch
+}
+
+@test "card96: _coda_feature_done parses --orch=<name> (equals form)" {
+    local capture_file
+    capture_file=$(mktemp)
+    _coda_run_hooks() { return 0; }
+    _coda_prune_sessions_for_dir() { return 0; }
+    _coda96_stub_git
+    local proj_dir
+    proj_dir=$(_coda96_setup_fake_project widget96b)
+    cd "$proj_dir/main"
+    tmux() {
+        case "$1" in
+            list-sessions) echo "${SESSION_PREFIX}orch--riley"; return 0 ;;
+            list-windows) echo "feat-b"; return 0 ;;
+            has-session) return 1 ;;
+            kill-window) echo "$3" > "$capture_file"; return 0 ;;
+        esac
+        return 0
+    }
+    _coda_feature_done feat-b --orch=riley >/dev/null 2>&1
+    local killed
+    killed=$(cat "$capture_file")
+    [ "$killed" = "${SESSION_PREFIX}orch--riley:feat-b" ]
+    cd /
+    rm -rf "$proj_dir" "$capture_file"
+    unset -f _coda_run_hooks _coda_prune_sessions_for_dir tmux git _coda_detect_default_branch
+}
+
+@test "card96: _coda_feature_done with window match calls kill-window not kill-session" {
+    local actions_file
+    actions_file=$(mktemp)
+    _coda_run_hooks() { return 0; }
+    _coda_prune_sessions_for_dir() { return 0; }
+    _coda96_stub_git
+    local proj_dir
+    proj_dir=$(_coda96_setup_fake_project widget96c)
+    cd "$proj_dir/main"
+    tmux() {
+        case "$1" in
+            list-sessions) echo "${SESSION_PREFIX}orch--riley"; return 0 ;;
+            list-windows) echo "feat-c"; return 0 ;;
+            has-session) return 1 ;;
+            kill-window) echo "kill-window:$3" >> "$actions_file"; return 0 ;;
+            kill-session) echo "kill-session:$3" >> "$actions_file"; return 0 ;;
+        esac
+        return 0
+    }
+    _coda_feature_done feat-c >/dev/null 2>&1
+    grep -q 'kill-window' "$actions_file"
+    ! grep -q 'kill-session' "$actions_file"
+    cd /
+    rm -rf "$proj_dir" "$actions_file"
+    unset -f _coda_run_hooks _coda_prune_sessions_for_dir tmux git _coda_detect_default_branch
+}
+
+@test "card96: _coda_feature_done without window match calls kill-session" {
+    local actions_file
+    actions_file=$(mktemp)
+    _coda_run_hooks() { return 0; }
+    _coda_prune_sessions_for_dir() { return 0; }
+    _coda96_stub_git
+    local proj_dir
+    proj_dir=$(_coda96_setup_fake_project widget96d)
+    cd "$proj_dir/main"
+    tmux() {
+        case "$1" in
+            list-sessions) return 0 ;;
+            list-windows) return 0 ;;
+            has-session) return 0 ;;
+            kill-window) echo "kill-window:$3" >> "$actions_file"; return 0 ;;
+            kill-session) echo "kill-session:$3" >> "$actions_file"; return 0 ;;
+        esac
+        return 0
+    }
+    _coda_feature_done feat-d >/dev/null 2>&1
+    grep -q 'kill-session' "$actions_file"
+    ! grep -q 'kill-window' "$actions_file"
+    cd /
+    rm -rf "$proj_dir" "$actions_file"
+    unset -f _coda_run_hooks _coda_prune_sessions_for_dir tmux git _coda_detect_default_branch
+}
+
+@test "card96: _coda_feature_finish parses --orch <name>" {
+    _coda_run_hooks() { return 0; }
+    _coda_prune_sessions_for_dir() { return 0; }
+    _coda96_stub_git
+    local proj_dir
+    proj_dir=$(_coda96_setup_fake_project widget96e)
+    cd "$proj_dir/main"
+    # Create a fake feature worktree dir so finish detects the project
+    mkdir -p "$proj_dir/feat-e"
+    # Stub git for finish: detect branch as feat-e
+    git() {
+        local args=("$@")
+        for ((i=0; i<${#args[@]}; i++)); do
+            case "${args[i]}" in
+                rev-parse) echo feat-e; return 0 ;;
+                show-ref) return 0 ;;
+                worktree) return 0 ;;
+                branch) return 0 ;;
+                diff) return 0 ;;
+            esac
+        done
+        return 0
+    }
+    _coda_detect_default_branch() { echo main; }
+    local capture_file
+    capture_file=$(mktemp)
+    tmux() {
+        case "$1" in
+            list-sessions) echo "${SESSION_PREFIX}orch--riley"; return 0 ;;
+            list-windows) echo "feat-e"; return 0 ;;
+            has-session) return 1 ;;
+            kill-window) echo "$3" > "$capture_file"; return 0 ;;
+        esac
+        return 0
+    }
+    # Need to cd into the feature dir for finish to detect branch
+    cd "$proj_dir/feat-e"
+    _coda_feature_finish --orch riley >/dev/null 2>&1
+    sleep 2
+    local killed
+    killed=$(cat "$capture_file")
+    [ "$killed" = "${SESSION_PREFIX}orch--riley:feat-e" ]
+    cd /
+    rm -rf "$proj_dir" "$capture_file"
+    unset -f _coda_run_hooks _coda_prune_sessions_for_dir tmux git _coda_detect_default_branch
+}
+
+@test "card96: _coda_feature_finish with window match uses kill-window in background" {
+    local actions_file
+    actions_file=$(mktemp)
+    _coda_run_hooks() { return 0; }
+    _coda_prune_sessions_for_dir() { return 0; }
+    local proj_dir
+    proj_dir=$(_coda96_setup_fake_project widget96f)
+    mkdir -p "$proj_dir/feat-f"
+    git() {
+        local args=("$@")
+        for ((i=0; i<${#args[@]}; i++)); do
+            case "${args[i]}" in
+                rev-parse) echo feat-f; return 0 ;;
+                show-ref) return 0 ;;
+                worktree) return 0 ;;
+                branch) return 0 ;;
+                diff) return 0 ;;
+            esac
+        done
+        return 0
+    }
+    _coda_detect_default_branch() { echo main; }
+    tmux() {
+        case "$1" in
+            list-sessions) echo "${SESSION_PREFIX}orch--riley"; return 0 ;;
+            list-windows) echo "feat-f"; return 0 ;;
+            has-session) return 1 ;;
+            kill-window) echo "kill-window:$3" >> "$actions_file"; return 0 ;;
+            kill-session) echo "kill-session:$3" >> "$actions_file"; return 0 ;;
+        esac
+        return 0
+    }
+    cd "$proj_dir/feat-f"
+    _coda_feature_finish --force >/dev/null 2>&1
+    sleep 2
+    grep -q 'kill-window' "$actions_file"
+    ! grep -q 'kill-session' "$actions_file"
+    cd /
+    rm -rf "$proj_dir" "$actions_file"
+    unset -f _coda_run_hooks _coda_prune_sessions_for_dir tmux git _coda_detect_default_branch
+}
+
+@test "card96: _coda_feature_finish multi-match error surfaces before backgrounding" {
+    _coda_run_hooks() { return 0; }
+    _coda_prune_sessions_for_dir() { return 0; }
+    local proj_dir
+    proj_dir=$(_coda96_setup_fake_project widget96g)
+    mkdir -p "$proj_dir/feat-g"
+    git() {
+        local args=("$@")
+        for ((i=0; i<${#args[@]}; i++)); do
+            case "${args[i]}" in
+                rev-parse) echo feat-g; return 0 ;;
+                show-ref) return 0 ;;
+                worktree) return 0 ;;
+                branch) return 0 ;;
+                diff) return 0 ;;
+            esac
+        done
+        return 0
+    }
+    _coda_detect_default_branch() { echo main; }
+    tmux() {
+        case "$1" in
+            list-sessions) printf '%s\n' "${SESSION_PREFIX}orch--alpha" "${SESSION_PREFIX}orch--beta"; return 0 ;;
+            list-windows) echo "feat-g"; return 0 ;;
+            has-session) return 1 ;;
+        esac
+        return 0
+    }
+    cd "$proj_dir/feat-g"
+    run _coda_feature_finish --force
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Multiple orchestrator sessions"* ]]
+    cd /
+    rm -rf "$proj_dir"
+    unset -f _coda_run_hooks _coda_prune_sessions_for_dir tmux git _coda_detect_default_branch
+}

--- a/tests/bin/tmux
+++ b/tests/bin/tmux
@@ -6,9 +6,10 @@ state_dir="${CODA_TEST_STATE_DIR:?CODA_TEST_STATE_DIR is required}"
 sessions_file="$state_dir/tmux-sessions"
 actions_file="$state_dir/tmux-actions"
 env_file="$state_dir/tmux-env"
+windows_file="$state_dir/tmux-windows"
 
 mkdir -p "$state_dir"
-touch "$sessions_file" "$actions_file" "$env_file"
+touch "$sessions_file" "$actions_file" "$env_file" "$windows_file"
 
 log_action() {
     printf '%s\n' "$*" >> "$actions_file"
@@ -87,10 +88,15 @@ case "$command_name" in
         ;;
     new-window)
         local_session=""
+        local_window_name=""
         while [ $# -gt 0 ]; do
             case "$1" in
                 -t)
                     local_session="$2"
+                    shift 2
+                    ;;
+                -n)
+                    local_window_name="$2"
                     shift 2
                     ;;
                 *)
@@ -100,7 +106,31 @@ case "$command_name" in
         done
         [ -n "$local_session" ] || exit 1
         add_session "$local_session"
+        # Track window: "session:window_name"
+        if [ -n "$local_window_name" ]; then
+            printf '%s:%s\n' "$local_session" "$local_window_name" >> "$windows_file"
+        fi
         log_action "new-window:$local_session"
+        ;;
+    kill-window)
+        local_target=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                -t)
+                    local_target="$2"
+                    shift 2
+                    ;;
+                *)
+                    shift
+                    ;;
+            esac
+        done
+        [ -n "$local_target" ] || exit 1
+        # Remove from windows file
+        local_tmp=$(mktemp)
+        grep -Fvx -- "$local_target" "$windows_file" > "$local_tmp" || true
+        mv "$local_tmp" "$windows_file"
+        log_action "kill-window:$local_target"
         ;;
     set-environment)
         [ "$1" = "-t" ] || exit 1
@@ -122,6 +152,30 @@ case "$command_name" in
         ;;
     list-sessions)
         list_sessions "$@"
+        ;;
+    list-windows)
+        local_target=""
+        local_format=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                -t) local_target="$2"; shift 2 ;;
+                -F) local_format="$2"; shift 2 ;;
+                *)  shift ;;
+            esac
+        done
+        [ -n "$local_target" ] || exit 1
+        while IFS= read -r line; do
+            [ -n "$line" ] || continue
+            case "$line" in
+                "$local_target":*)
+                    if [ "$local_format" = '#{session_name}:#{window_name}' ]; then
+                        printf '%s\n' "$line"
+                    else
+                        printf '%s\n' "${line#*:}"
+                    fi
+                    ;;
+            esac
+        done < "$windows_file"
         ;;
     set-option|select-pane|split-window|display-message|capture-pane)
         log_action "$command_name:$*"

--- a/tests/window-mode.sh
+++ b/tests/window-mode.sh
@@ -87,4 +87,80 @@ assert_contains "$feat_b_again" "Worktree already exists" \
 assert_contains "$feat_b_again" "Attaching to existing session" \
     "--orch with existing worktree should say attaching"
 
+# -- Test 5: feature done kills orch window for window-mode feature --
+
+# feat-b was started in window-mode (orch session my-orch).
+# Verify window exists before teardown.
+assert_contains "$(cat "$CODA_TEST_STATE_DIR/tmux-windows")" "coda-orch--my-orch:feat-b" \
+    "feat-b should be tracked as orch window before teardown"
+
+done_window_output="$(coda feature done feat-b 2>&1)"
+assert_contains "$done_window_output" "Killing window: coda-orch--my-orch:feat-b" \
+    "feature done should kill the orch window"
+assert_not_exists "$PROJECTS_DIR/window-test/feat-b" \
+    "feature done should remove worktree for window-mode feature"
+
+if git -C "$PROJECTS_DIR/window-test" show-ref --verify --quiet refs/heads/feat-b 2>/dev/null; then
+    fail "feature done should delete the window-mode feature branch"
+fi
+
+# Window should be gone from windows file
+assert_not_contains "$(cat "$CODA_TEST_STATE_DIR/tmux-windows")" "coda-orch--my-orch:feat-b" \
+    "feature done should remove orch window from tracking"
+
+# -- Test 6: feature done for standalone session still works --
+
+done_standalone_output="$(coda feature done feat-c 2>&1)"
+assert_contains "$done_standalone_output" "Killing session: coda-window-test--feat-c" \
+    "feature done for standalone session should kill session"
+assert_not_exists "$PROJECTS_DIR/window-test/feat-c" \
+    "feature done should remove worktree for standalone feature"
+
+# -- Test 7: feature done for fallback feature (feat-a, session mode via orch fallback) --
+
+done_fallback_output="$(coda feature done feat-a 2>&1)"
+assert_contains "$done_fallback_output" "Killing session: coda-window-test--feat-a" \
+    "feature done for fallback session should kill session"
+assert_not_exists "$PROJECTS_DIR/window-test/feat-a" \
+    "feature done should remove worktree for fallback feature"
+
+# -- Test 8: feature done with --orch explicit flag --
+
+# Create another feature in window-mode
+coda feature start feat-d --orch my-orch >/dev/null 2>&1
+assert_contains "$(cat "$CODA_TEST_STATE_DIR/tmux-windows")" "coda-orch--my-orch:feat-d" \
+    "feat-d should be tracked as orch window"
+
+done_orch_output="$(coda feature done feat-d --orch my-orch 2>&1)"
+assert_contains "$done_orch_output" "Killing window: coda-orch--my-orch:feat-d" \
+    "feature done --orch should kill the named orch window"
+assert_not_exists "$PROJECTS_DIR/window-test/feat-d" \
+    "feature done --orch should remove worktree"
+
+# -- Test 9: multi-match errors when two orchs have same window name --
+
+# Set up: create two orch sessions, each with a window named "feat-e"
+echo "coda-orch--alpha" >> "$CODA_TEST_STATE_DIR/tmux-sessions"
+echo "coda-orch--beta" >> "$CODA_TEST_STATE_DIR/tmux-sessions"
+echo "coda-orch--alpha:feat-e" >> "$CODA_TEST_STATE_DIR/tmux-windows"
+echo "coda-orch--beta:feat-e" >> "$CODA_TEST_STATE_DIR/tmux-windows"
+
+# Create worktree for feat-e manually so done doesn't fail on project lookup
+coda feature start feat-e >/dev/null 2>&1
+
+multi_status=0
+multi_done_output="$(coda feature done feat-e 2>&1)" || multi_status=$?
+assert_contains "$multi_done_output" "Multiple orchestrator sessions" \
+    "multi-match should produce disambiguation error"
+[ "$multi_status" -ne 0 ] || fail "multi-match should exit nonzero"
+
+# Both orch windows should still exist (no teardown happened)
+assert_contains "$(cat "$CODA_TEST_STATE_DIR/tmux-windows")" "coda-orch--alpha:feat-e" \
+    "multi-match should not kill any windows"
+assert_contains "$(cat "$CODA_TEST_STATE_DIR/tmux-windows")" "coda-orch--beta:feat-e" \
+    "multi-match should not kill any windows"
+
+# Clean up feat-e standalone session and worktree
+coda feature done feat-e --orch alpha >/dev/null 2>&1 || true
+
 printf 'PASS: window-mode tests\n'


### PR DESCRIPTION
## Summary

- Add `_coda_feature_locate_window` probe helper that scans `coda-orch--*` sessions for a window matching a branch name
- Make `_coda_feature_done` and `_coda_feature_finish` window-aware: detect window-mode features and use `tmux kill-window` instead of `kill-session`
- Add `--orch <name>` flag to both commands for explicit orchestrator targeting

## Contract

| Scenario | Behavior |
|---|---|
| `coda feature done <branch>` — window in one orch | Kills window, leaves orch session alive |
| `coda feature done <branch>` — standalone session | Kills session (unchanged from today) |
| `coda feature done <branch>` — window in two orchs | Error with disambiguation message, no teardown |
| `coda feature done <branch> --orch <name>` | Targets specific orch, kills window if found |
| `coda feature finish [--force] [--orch <name>]` | Same behavior, backgrounded |
| Multi-match in finish | Error surfaces before backgrounding |

## Tests

- 13 new bats unit tests (`card96:` prefix) covering the probe helper, `--orch` parsing, and both teardown paths
- 3 new E2E tests in `tests/window-mode.sh` covering window teardown, standalone teardown, and fallback teardown
- Extended mock tmux with `list-windows` and `kill-window` support
- All 195 bats tests pass, all shell tests pass

## Related

- Predecessor: #95 (card #95 — window-mode `feature start` / `_coda_attach`)
- Milestone: #90

Closes #96.