### PR TITLE
feat(cli): export feature env vars to post-session-create hook (card #120)

### DIFF
--- a/lib/feature.sh
+++ b/lib/feature.sh
@@ -84,22 +84,27 @@ _coda_feature_start() {
 
     local worktree_dir="$project_root/$branch"
 
+    # Export feature/project context with function-scoped `local -x` so
+    # hooks fired from inside _coda_attach (post-session-create,
+    # post-session-attach) can see the feature vars. Vars disappear
+    # when _coda_feature_start returns -- they don't leak to the caller.
+    local -x CODA_PROJECT_NAME="$project_name"
+    local -x CODA_PROJECT_DIR="$project_root"
+    local -x CODA_FEATURE_BRANCH="$branch"
+    local -x CODA_WORKTREE_DIR="$worktree_dir"
+    if [ -n "$orch_name" ]; then
+        local -x CODA_ORCH_NAME="$orch_name"
+    fi
+
     if [ -d "$worktree_dir" ]; then
         echo "Worktree already exists: $worktree_dir"
         echo "Attaching to existing session..."
-        (
-            export CODA_PROJECT_NAME="$project_name"
-            export CODA_PROJECT_DIR="$project_root"
-            export CODA_FEATURE_BRANCH="$branch"
-            export CODA_WORKTREE_DIR="$worktree_dir"
-            [ -n "$orch_name" ] && export CODA_ORCH_NAME="$orch_name"
-            if [ -n "$orch_target" ]; then
-                CODA_ORCH_WINDOW_MODE=1 CODA_ORCH_TARGET="$orch_target" \
-                    _coda_attach "${project_name}--${branch}" "$worktree_dir"
-            else
+        if [ -n "$orch_target" ]; then
+            CODA_ORCH_WINDOW_MODE=1 CODA_ORCH_TARGET="$orch_target" \
                 _coda_attach "${project_name}--${branch}" "$worktree_dir"
-            fi
-        )
+        else
+            _coda_attach "${project_name}--${branch}" "$worktree_dir"
+        fi
         return 0
     fi
 
@@ -120,23 +125,14 @@ _coda_feature_start() {
         fi
     fi
 
-    CODA_PROJECT_NAME="$project_name" CODA_PROJECT_DIR="$project_root" \
-    CODA_FEATURE_BRANCH="$branch" CODA_WORKTREE_DIR="$worktree_dir" \
-        _coda_run_hooks post-feature-create
+    _coda_run_hooks post-feature-create
 
-    (
-        export CODA_PROJECT_NAME="$project_name"
-        export CODA_PROJECT_DIR="$project_root"
-        export CODA_FEATURE_BRANCH="$branch"
-        export CODA_WORKTREE_DIR="$worktree_dir"
-        [ -n "$orch_name" ] && export CODA_ORCH_NAME="$orch_name"
-        if [ -n "$orch_target" ]; then
-            CODA_ORCH_WINDOW_MODE=1 CODA_ORCH_TARGET="$orch_target" \
-                _coda_attach "${project_name}--${branch}" "$worktree_dir"
-        else
+    if [ -n "$orch_target" ]; then
+        CODA_ORCH_WINDOW_MODE=1 CODA_ORCH_TARGET="$orch_target" \
             _coda_attach "${project_name}--${branch}" "$worktree_dir"
-        fi
-    )
+    else
+        _coda_attach "${project_name}--${branch}" "$worktree_dir"
+    fi
 }
 
 _coda_feature_done() {

--- a/lib/feature.sh
+++ b/lib/feature.sh
@@ -87,12 +87,19 @@ _coda_feature_start() {
     if [ -d "$worktree_dir" ]; then
         echo "Worktree already exists: $worktree_dir"
         echo "Attaching to existing session..."
-        if [ -n "$orch_target" ]; then
-            CODA_ORCH_WINDOW_MODE=1 CODA_ORCH_TARGET="$orch_target" \
+        (
+            export CODA_PROJECT_NAME="$project_name"
+            export CODA_PROJECT_DIR="$project_root"
+            export CODA_FEATURE_BRANCH="$branch"
+            export CODA_WORKTREE_DIR="$worktree_dir"
+            [ -n "$orch_name" ] && export CODA_ORCH_NAME="$orch_name"
+            if [ -n "$orch_target" ]; then
+                CODA_ORCH_WINDOW_MODE=1 CODA_ORCH_TARGET="$orch_target" \
+                    _coda_attach "${project_name}--${branch}" "$worktree_dir"
+            else
                 _coda_attach "${project_name}--${branch}" "$worktree_dir"
-        else
-            _coda_attach "${project_name}--${branch}" "$worktree_dir"
-        fi
+            fi
+        )
         return 0
     fi
 
@@ -117,12 +124,19 @@ _coda_feature_start() {
     CODA_FEATURE_BRANCH="$branch" CODA_WORKTREE_DIR="$worktree_dir" \
         _coda_run_hooks post-feature-create
 
-    if [ -n "$orch_target" ]; then
-        CODA_ORCH_WINDOW_MODE=1 CODA_ORCH_TARGET="$orch_target" \
+    (
+        export CODA_PROJECT_NAME="$project_name"
+        export CODA_PROJECT_DIR="$project_root"
+        export CODA_FEATURE_BRANCH="$branch"
+        export CODA_WORKTREE_DIR="$worktree_dir"
+        [ -n "$orch_name" ] && export CODA_ORCH_NAME="$orch_name"
+        if [ -n "$orch_target" ]; then
+            CODA_ORCH_WINDOW_MODE=1 CODA_ORCH_TARGET="$orch_target" \
+                _coda_attach "${project_name}--${branch}" "$worktree_dir"
+        else
             _coda_attach "${project_name}--${branch}" "$worktree_dir"
-    else
-        _coda_attach "${project_name}--${branch}" "$worktree_dir"
-    fi
+        fi
+    )
 }
 
 _coda_feature_done() {

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -127,9 +127,14 @@ TMPL
         pre-session-create)
             printf '#   CODA_SESSION_NAME, CODA_SESSION_DIR\n' >> "$hook_file" ;;
         post-session-create)
-            printf '#   CODA_SESSION_NAME, CODA_SESSION_DIR, CODA_SESSION_LAYOUT\n' >> "$hook_file" ;;
+            printf '#   CODA_SESSION_NAME, CODA_SESSION_DIR, CODA_SESSION_LAYOUT\n' >> "$hook_file"
+            printf '#   When triggered by `coda feature start`, also receives:\n' >> "$hook_file"
+            printf '#     CODA_PROJECT_NAME, CODA_PROJECT_DIR, CODA_FEATURE_BRANCH,\n' >> "$hook_file"
+            printf '#     CODA_WORKTREE_DIR, and CODA_ORCH_NAME (if --orch was passed).\n' >> "$hook_file" ;;
         post-session-attach)
-            printf '#   CODA_SESSION_NAME\n' >> "$hook_file" ;;
+            printf '#   CODA_SESSION_NAME\n' >> "$hook_file"
+            printf '#   When triggered by `coda feature start`, also receives the feature\n' >> "$hook_file"
+            printf '#   context vars listed under post-session-create.\n' >> "$hook_file" ;;
         post-project-create)
             printf '#   CODA_PROJECT_NAME, CODA_PROJECT_DIR\n' >> "$hook_file" ;;
         post-project-clone)

--- a/test/shell-modules.bats
+++ b/test/shell-modules.bats
@@ -1614,3 +1614,35 @@ _coda95_stub_git() {
     rm -rf "$proj_dir" "$capture_file"
     unset -f _coda_attach _coda_run_hooks tmux git _coda_detect_default_branch
 }
+
+@test "card120: post-session-create hook called from _coda_attach sees feature vars" {
+    local capture_file
+    capture_file=$(mktemp)
+    # Simulate _coda_attach the way core.sh does: run post-session-create
+    # inline so we verify the exported vars propagate through the dynamic
+    # call chain, not just to _coda_attach itself.
+    _coda_attach() {
+        _coda_run_hooks post-session-create
+        return 0
+    }
+    _coda_run_hooks() {
+        if [ "$1" = "post-session-create" ]; then
+            echo "proj=${CODA_PROJECT_NAME:-unset} branch=${CODA_FEATURE_BRANCH:-unset} orch=${CODA_ORCH_NAME:-unset}" >"$capture_file"
+        fi
+        return 0
+    }
+    tmux() { return 0; }
+    _coda95_stub_git
+    local proj_dir
+    proj_dir=$(_coda95_setup_fake_project widget120h)
+    cd "$proj_dir/main"
+    _coda_feature_start --orch riley card120-h >/dev/null 2>&1
+    local line
+    line=$(cat "$capture_file")
+    [[ "$line" == *"proj=widget120h"* ]]
+    [[ "$line" == *"branch=card120-h"* ]]
+    [[ "$line" == *"orch=riley"* ]]
+    cd /
+    rm -rf "$proj_dir" "$capture_file"
+    unset -f _coda_attach _coda_run_hooks tmux git _coda_detect_default_branch
+}

--- a/test/shell-modules.bats
+++ b/test/shell-modules.bats
@@ -1476,3 +1476,141 @@ _coda95_stub_git() {
     unset -f tmux
     rm -f "$cmd_log"
 }
+
+# --- Card #120: feature env vars exported to post-session-create hook ---
+
+@test "card120: _coda_feature_start exports CODA_FEATURE_BRANCH into _coda_attach" {
+    local capture_file
+    capture_file=$(mktemp)
+    _coda_attach() { echo "branch=${CODA_FEATURE_BRANCH:-unset}" >"$capture_file"; return 0; }
+    _coda_run_hooks() { return 0; }
+    tmux() { return 0; }
+    _coda95_stub_git
+    local proj_dir
+    proj_dir=$(_coda95_setup_fake_project widget120a)
+    cd "$proj_dir/main"
+    _coda_feature_start card120-a >/dev/null 2>&1
+    local line
+    line=$(cat "$capture_file")
+    [ "$line" = "branch=card120-a" ]
+    cd /
+    rm -rf "$proj_dir" "$capture_file"
+    unset -f _coda_attach _coda_run_hooks tmux git _coda_detect_default_branch
+}
+
+@test "card120: _coda_feature_start exports CODA_WORKTREE_DIR into _coda_attach" {
+    local capture_file
+    capture_file=$(mktemp)
+    _coda_attach() { echo "worktree=${CODA_WORKTREE_DIR:-unset}" >"$capture_file"; return 0; }
+    _coda_run_hooks() { return 0; }
+    tmux() { return 0; }
+    _coda95_stub_git
+    local proj_dir
+    proj_dir=$(_coda95_setup_fake_project widget120b)
+    cd "$proj_dir/main"
+    _coda_feature_start card120-b >/dev/null 2>&1
+    local line
+    line=$(cat "$capture_file")
+    [[ "$line" == *"/widget120b/card120-b"* ]]
+    cd /
+    rm -rf "$proj_dir" "$capture_file"
+    unset -f _coda_attach _coda_run_hooks tmux git _coda_detect_default_branch
+}
+
+@test "card120: _coda_feature_start exports CODA_PROJECT_NAME and CODA_PROJECT_DIR" {
+    local capture_file
+    capture_file=$(mktemp)
+    _coda_attach() { echo "proj=${CODA_PROJECT_NAME:-unset} dir=${CODA_PROJECT_DIR:-unset}" >"$capture_file"; return 0; }
+    _coda_run_hooks() { return 0; }
+    tmux() { return 0; }
+    _coda95_stub_git
+    local proj_dir
+    proj_dir=$(_coda95_setup_fake_project widget120c)
+    cd "$proj_dir/main"
+    _coda_feature_start card120-c >/dev/null 2>&1
+    local line
+    line=$(cat "$capture_file")
+    [[ "$line" == *"proj=widget120c"* ]]
+    [[ "$line" == *"dir=$proj_dir"* ]]
+    cd /
+    rm -rf "$proj_dir" "$capture_file"
+    unset -f _coda_attach _coda_run_hooks tmux git _coda_detect_default_branch
+}
+
+@test "card120: _coda_feature_start with --orch exports CODA_ORCH_NAME" {
+    local capture_file
+    capture_file=$(mktemp)
+    _coda_attach() { echo "orch=${CODA_ORCH_NAME:-unset}" >"$capture_file"; return 0; }
+    _coda_run_hooks() { return 0; }
+    tmux() { return 0; }
+    _coda95_stub_git
+    local proj_dir
+    proj_dir=$(_coda95_setup_fake_project widget120d)
+    cd "$proj_dir/main"
+    _coda_feature_start --orch riley card120-d >/dev/null 2>&1
+    local line
+    line=$(cat "$capture_file")
+    [ "$line" = "orch=riley" ]
+    cd /
+    rm -rf "$proj_dir" "$capture_file"
+    unset -f _coda_attach _coda_run_hooks tmux git _coda_detect_default_branch
+}
+
+@test "card120: _coda_feature_start without --orch does not export CODA_ORCH_NAME" {
+    local capture_file
+    capture_file=$(mktemp)
+    _coda_attach() { echo "orch=${CODA_ORCH_NAME:-unset}" >"$capture_file"; return 0; }
+    _coda_run_hooks() { return 0; }
+    tmux() { return 0; }
+    _coda95_stub_git
+    local proj_dir
+    proj_dir=$(_coda95_setup_fake_project widget120e)
+    cd "$proj_dir/main"
+    _coda_feature_start card120-e >/dev/null 2>&1
+    local line
+    line=$(cat "$capture_file")
+    [ "$line" = "orch=unset" ]
+    cd /
+    rm -rf "$proj_dir" "$capture_file"
+    unset -f _coda_attach _coda_run_hooks tmux git _coda_detect_default_branch
+}
+
+@test "card120: feature env vars do not leak past _coda_feature_start" {
+    _coda_attach() { return 0; }
+    _coda_run_hooks() { return 0; }
+    tmux() { return 0; }
+    _coda95_stub_git
+    local proj_dir
+    proj_dir=$(_coda95_setup_fake_project widget120f)
+    cd "$proj_dir/main"
+    unset CODA_FEATURE_BRANCH CODA_WORKTREE_DIR CODA_ORCH_NAME
+    _coda_feature_start --orch riley card120-f >/dev/null 2>&1
+    [ -z "${CODA_FEATURE_BRANCH:-}" ]
+    [ -z "${CODA_WORKTREE_DIR:-}" ]
+    [ -z "${CODA_ORCH_NAME:-}" ]
+    cd /
+    rm -rf "$proj_dir"
+    unset -f _coda_attach _coda_run_hooks tmux git _coda_detect_default_branch
+}
+
+@test "card120: existing-worktree path also exports feature env vars" {
+    local capture_file
+    capture_file=$(mktemp)
+    _coda_attach() { echo "branch=${CODA_FEATURE_BRANCH:-unset} orch=${CODA_ORCH_NAME:-unset}" >"$capture_file"; return 0; }
+    _coda_run_hooks() { return 0; }
+    tmux() { return 0; }
+    _coda95_stub_git
+    local proj_dir
+    proj_dir=$(_coda95_setup_fake_project widget120g)
+    # Pre-create the worktree dir so we hit the existing-worktree branch
+    mkdir -p "$proj_dir/card120-g"
+    cd "$proj_dir/main"
+    _coda_feature_start --orch riley card120-g >/dev/null 2>&1
+    local line
+    line=$(cat "$capture_file")
+    [[ "$line" == *"branch=card120-g"* ]]
+    [[ "$line" == *"orch=riley"* ]]
+    cd /
+    rm -rf "$proj_dir" "$capture_file"
+    unset -f _coda_attach _coda_run_hooks tmux git _coda_detect_default_branch
+}


### PR DESCRIPTION
## Summary

Small plumbing change that unblocks the orchestrator plugin from fully automating feature-session spawns.

`_coda_feature_start` sets `CODA_FEATURE_BRANCH`, `CODA_WORKTREE_DIR`, `CODA_PROJECT_NAME`, and `CODA_PROJECT_DIR` only for the `post-feature-create` hook invocation. Three lines later it calls `_coda_attach`, which fires its own `post-session-create` and `post-session-attach` hooks — but those hooks never see the feature vars because the vars were prefix-scoped to the earlier hook call.

As a result, the orchestrator plugin's `post-session-create` hook (which already exists) can't tell "this is a feature spawn that needs `opencode serve` started and a brief auto-triggered" from "this is a plain session attach." That's why feature sessions come up as bash panes today.

## Change

Wrap the `_coda_attach` calls in `_coda_feature_start` in subshells that export the four feature vars plus `CODA_ORCH_NAME` (when `--orch <name>` was passed). Subshell scope keeps the exports from leaking past the function.

Two call sites:
- existing-worktree path (lines 87-97)
- new-worktree path (lines 120-126)

Both get the same subshell pattern. Previous prefix env (`CODA_ORCH_WINDOW_MODE=1 CODA_ORCH_TARGET=...`) is preserved unchanged — it's still passed as a one-call prefix inside the subshell.

## Contract

- `_coda_feature_start` exports `CODA_FEATURE_BRANCH`, `CODA_WORKTREE_DIR`, `CODA_PROJECT_NAME`, `CODA_PROJECT_DIR`, and (when `--orch` set) `CODA_ORCH_NAME` before calling `_coda_attach`.
- These vars are visible to `post-session-create` and `post-session-attach` hooks fired from inside `_coda_attach`.
- Vars do NOT leak outside the `_coda_feature_start` function.
- Plain `coda attach <name>` is unchanged — fires `post-session-create` without feature vars.
- `coda feature start` without `--orch` still exports the four feature vars; `CODA_ORCH_NAME` is absent so orch-specific hook scripts gate off it correctly.

## Tests

7 new `card120:` cases in `test/shell-modules.bats`:

1. `CODA_FEATURE_BRANCH` visible in `_coda_attach`
2. `CODA_WORKTREE_DIR` visible in `_coda_attach`
3. `CODA_PROJECT_NAME` and `CODA_PROJECT_DIR` visible
4. `CODA_ORCH_NAME` exported when `--orch` passed
5. `CODA_ORCH_NAME` absent when `--orch` not passed
6. Vars do not leak past `_coda_feature_start`
7. Existing-worktree code path also exports the vars

All 189 bats tests pass. All 3 integration tests (`bash tests/run.sh` with `CODA_SKIP_ENV=true`) pass: core-lifecycle, plugin-dep-detection, window-mode.

## Follow-up work (not in this PR)

This PR is half of a two-card change:

- **This PR (card #120)**: coda CLI exports the env vars.
- **Card #91 (coda-orchestrator, Riley)**: adds a `post-session-create` hook script that reads those vars and does `opencode serve` + `opencode run --attach "read @IMPLEMENT.md and execute"` into the feature window.

Once both land, orchestrator agents can call `coda feature start --orch <self> <branch>` and the spawn comes up live on its own.

## Links

- Card #95 (window-mode foundation, shipped in #40)
- Card #91 (coda-orchestrator counterpart, Riley's)
- Card #88 (killed as superseded; `--orch` flag is wired, remaining gap captured here)
