### PR TITLE
fix(cli): fire pre-feature-teardown before worktree removal in finish

### DIFF
--- a/lib/feature.sh
+++ b/lib/feature.sh
@@ -253,6 +253,10 @@ _coda_feature_finish() {
 
     (
         sleep 1
+        CODA_PROJECT_NAME="$project_name" CODA_PROJECT_DIR="$project_root" \
+        CODA_FEATURE_BRANCH="$branch" CODA_WORKTREE_DIR="$worktree_dir" \
+        CODA_SESSION_NAME="$session" \
+            _coda_run_hooks pre-feature-teardown
         if tmux has-session -t "$session" 2>/dev/null; then
             tmux kill-session -t "$session"
         fi

--- a/test/shell-modules.bats
+++ b/test/shell-modules.bats
@@ -1646,3 +1646,161 @@ _coda95_stub_git() {
     rm -rf "$proj_dir" "$capture_file"
     unset -f _coda_attach _coda_run_hooks tmux git _coda_detect_default_branch
 }
+
+# --- Card #123: pre-feature-teardown fires before worktree removal ---
+
+@test "card123: _coda_feature_done fires pre-feature-teardown before worktree removal" {
+    local capture_file
+    capture_file=$(mktemp)
+    _coda_run_hooks() {
+        if [ "$1" = "pre-feature-teardown" ]; then
+            # Record whether the worktree still exists when the hook fires.
+            if [ -d "${CODA_WORKTREE_DIR:-/nonexistent}" ]; then
+                echo "worktree-exists-at-hook=yes branch=${CODA_FEATURE_BRANCH:-unset}" >"$capture_file"
+            else
+                echo "worktree-exists-at-hook=no branch=${CODA_FEATURE_BRANCH:-unset}" >"$capture_file"
+            fi
+        fi
+        return 0
+    }
+    tmux() { return 0; }
+    _coda95_stub_git
+    local proj_dir
+    proj_dir=$(_coda95_setup_fake_project widget123a)
+    export PROJECTS_DIR=$(dirname "$proj_dir")
+    mkdir -p "$proj_dir/card123-a"
+    cd "$proj_dir/main"
+    _coda_feature_done card123-a widget123a >/dev/null 2>&1
+    local line
+    line=$(cat "$capture_file")
+    [[ "$line" == *"worktree-exists-at-hook=yes"* ]]
+    [[ "$line" == *"branch=card123-a"* ]]
+    cd /
+    rm -rf "$proj_dir" "$capture_file"
+    unset -f _coda_run_hooks tmux git _coda_detect_default_branch _coda_prune_sessions_for_dir
+}
+
+@test "card123: _coda_feature_done passes all expected env vars to pre-feature-teardown" {
+    local capture_file
+    capture_file=$(mktemp)
+    _coda_run_hooks() {
+        if [ "$1" = "pre-feature-teardown" ]; then
+            echo "proj=${CODA_PROJECT_NAME:-unset} dir=${CODA_PROJECT_DIR:-unset} branch=${CODA_FEATURE_BRANCH:-unset} worktree=${CODA_WORKTREE_DIR:-unset} session=${CODA_SESSION_NAME:-unset}" >"$capture_file"
+        fi
+        return 0
+    }
+    tmux() { return 0; }
+    _coda95_stub_git
+    local proj_dir
+    proj_dir=$(_coda95_setup_fake_project widget123b)
+    export PROJECTS_DIR=$(dirname "$proj_dir")
+    mkdir -p "$proj_dir/card123-b"
+    cd "$proj_dir/main"
+    _coda_feature_done card123-b widget123b >/dev/null 2>&1
+    local line
+    line=$(cat "$capture_file")
+    [[ "$line" == *"proj=widget123b"* ]]
+    [[ "$line" == *"branch=card123-b"* ]]
+    [[ "$line" == *"worktree=$proj_dir/card123-b"* ]]
+    [[ "$line" == *"session=${SESSION_PREFIX}widget123b--card123-b"* ]]
+    cd /
+    rm -rf "$proj_dir" "$capture_file"
+    unset -f _coda_run_hooks tmux git _coda_detect_default_branch _coda_prune_sessions_for_dir
+}
+
+@test "card123: _coda_feature_finish fires pre-feature-teardown before worktree removal" {
+    local capture_file
+    capture_file=$(mktemp)
+    _coda_run_hooks() {
+        if [ "$1" = "pre-feature-teardown" ]; then
+            if [ -d "${CODA_WORKTREE_DIR:-/nonexistent}" ]; then
+                echo "worktree-exists-at-hook=yes branch=${CODA_FEATURE_BRANCH:-unset}" >"$capture_file"
+            else
+                echo "worktree-exists-at-hook=no branch=${CODA_FEATURE_BRANCH:-unset}" >"$capture_file"
+            fi
+        fi
+        return 0
+    }
+    tmux() { return 0; }
+    # Stub git: rev-parse returns the branch name; worktree remove
+    # actually removes the dir so we can verify ordering.
+    git() {
+        case "$1" in
+            -C)
+                case "$3" in
+                    rev-parse) echo card123-c; return 0 ;;
+                    diff)      return 0 ;;
+                    ls-files)  return 0 ;;
+                    show-ref)  return 0 ;;
+                    worktree)
+                        case "$4" in
+                            remove) rm -rf "$5" 2>/dev/null; return 0 ;;
+                        esac
+                        return 0 ;;
+                    branch) return 0 ;;
+                esac
+                return 0 ;;
+            rev-parse) echo card123-c; return 0 ;;
+        esac
+        return 0
+    }
+    _coda_detect_default_branch() { echo main; }
+    local proj_dir
+    proj_dir=$(_coda95_setup_fake_project widget123c)
+    mkdir -p "$proj_dir/card123-c"
+    cd "$proj_dir/card123-c"
+    _coda_feature_finish --force >/dev/null 2>&1
+    # finish backgrounds work with sleep 1 -- poll for completion
+    local waited=0
+    while [ ! -s "$capture_file" ] && [ $waited -lt 30 ]; do
+        sleep 0.2
+        waited=$((waited + 1))
+    done
+    local line
+    line=$(cat "$capture_file")
+    [[ "$line" == *"worktree-exists-at-hook=yes"* ]]
+    [[ "$line" == *"branch=card123-c"* ]]
+    cd /
+    rm -rf "$proj_dir" "$capture_file"
+    unset -f _coda_run_hooks tmux git _coda_detect_default_branch _coda_prune_sessions_for_dir
+}
+
+@test "card123: _coda_feature_finish passes session name to pre-feature-teardown" {
+    local capture_file
+    capture_file=$(mktemp)
+    _coda_run_hooks() {
+        if [ "$1" = "pre-feature-teardown" ]; then
+            echo "session=${CODA_SESSION_NAME:-unset}" >"$capture_file"
+        fi
+        return 0
+    }
+    tmux() { return 0; }
+    git() {
+        case "$1" in
+            -C)
+                case "$3" in
+                    rev-parse) echo card123-d; return 0 ;;
+                    *) return 0 ;;
+                esac ;;
+            rev-parse) echo card123-d; return 0 ;;
+        esac
+        return 0
+    }
+    _coda_detect_default_branch() { echo main; }
+    local proj_dir
+    proj_dir=$(_coda95_setup_fake_project widget123d)
+    mkdir -p "$proj_dir/card123-d"
+    cd "$proj_dir/card123-d"
+    _coda_feature_finish --force >/dev/null 2>&1
+    local waited=0
+    while [ ! -s "$capture_file" ] && [ $waited -lt 30 ]; do
+        sleep 0.2
+        waited=$((waited + 1))
+    done
+    local line
+    line=$(cat "$capture_file")
+    [[ "$line" == *"session=${SESSION_PREFIX}widget123d--card123-d"* ]]
+    cd /
+    rm -rf "$proj_dir" "$capture_file"
+    unset -f _coda_run_hooks tmux git _coda_detect_default_branch _coda_prune_sessions_for_dir
+}

--- a/test/shell-modules.bats
+++ b/test/shell-modules.bats
@@ -1664,7 +1664,26 @@ _coda95_stub_git() {
         return 0
     }
     tmux() { return 0; }
-    _coda95_stub_git
+    # Override git so `git -C <root> worktree remove <dir>` actually removes
+    # the dir; this is what makes the ordering assertion meaningful. If the
+    # hook fired AFTER the removal call, worktree-exists-at-hook would be "no".
+    git() {
+        case "$1" in
+            -C)
+                case "$3" in
+                    worktree)
+                        case "$4" in
+                            remove) rm -rf "$5" 2>/dev/null; return 0 ;;
+                        esac
+                        return 0 ;;
+                    show-ref) return 1 ;;
+                    rev-parse) echo main; return 0 ;;
+                    *) return 0 ;;
+                esac ;;
+        esac
+        return 0
+    }
+    _coda_detect_default_branch() { echo main; }
     local proj_dir
     proj_dir=$(_coda95_setup_fake_project widget123a)
     export PROJECTS_DIR=$(dirname "$proj_dir")
@@ -1675,6 +1694,9 @@ _coda95_stub_git() {
     line=$(cat "$capture_file")
     [[ "$line" == *"worktree-exists-at-hook=yes"* ]]
     [[ "$line" == *"branch=card123-a"* ]]
+    # Sanity check: the stubbed removal actually ran, so the hook ordering
+    # assertion above is meaningful (not just "removal never happened").
+    [ ! -d "$proj_dir/card123-a" ]
     cd /
     rm -rf "$proj_dir" "$capture_file"
     unset -f _coda_run_hooks tmux git _coda_detect_default_branch _coda_prune_sessions_for_dir


### PR DESCRIPTION
## Summary

- \`_coda_feature_finish\` never fired the \`pre-feature-teardown\` hook, so orchestrator report-delivery logic (coda-orchestrator #87) that reads \`.orch-meta\` from the worktree could not run via \`coda feature finish\` -- only via \`coda feature done\`.
- Fix adds the hook call inside the backgrounded subshell, **after \`sleep 1\` but before the tmux/worktree/branch cleanup**, so \`.orch-meta\` is still readable when the hook fires and the calling agent stays non-blocking.
- Env-var signature matches what \`_coda_feature_done\` already exports (\`CODA_PROJECT_NAME\`, \`CODA_PROJECT_DIR\`, \`CODA_FEATURE_BRANCH\`, \`CODA_WORKTREE_DIR\`, \`CODA_SESSION_NAME\`) so hook scripts don't have to branch on which caller invoked them.

## Bug

Before this change, calling \`coda feature finish\` went straight to teardown and only fired \`post-feature-finish\` *after* the worktree had been removed. Any hook that depended on reading state from the worktree (e.g. Riley's orchestrator report-delivery hook in coda-orchestrator #87) silently did nothing on the \`finish\` path.

\`_coda_feature_done\` already had correct ordering; only \`_coda_feature_finish\` was missing the hook call.

## Fix placement rationale

The hook must fire:

1. **Inside the backgrounded subshell** -- \`finish\` backgrounds teardown via \`(...) &\` after a 1-second sleep specifically so the calling agent can finish its own output before the worktree is yanked. Firing the hook inline (outside the subshell) would block the caller.
2. **Before \`tmux kill-session\` / \`git worktree remove\` / \`git branch -D\`** -- \`.orch-meta\` lives in the worktree; once the worktree is gone, there is nothing for the hook to read.

The insertion sits immediately after \`sleep 1\` and before any cleanup, matching those two constraints.

## Contract

| Behavior | \`_coda_feature_done\` | \`_coda_feature_finish\` (before) | \`_coda_feature_finish\` (after) |
|---|---|---|---|
| Fires \`pre-feature-teardown\` | yes | **no** | **yes** |
| Hook fires before worktree removal | yes | n/a | yes |
| Exports \`CODA_PROJECT_NAME\` | yes | n/a | yes |
| Exports \`CODA_PROJECT_DIR\` | yes | n/a | yes |
| Exports \`CODA_FEATURE_BRANCH\` | yes | n/a | yes |
| Exports \`CODA_WORKTREE_DIR\` | yes | n/a | yes |
| Exports \`CODA_SESSION_NAME\` | yes | n/a | yes |
| Teardown stays non-blocking for caller | n/a | yes | yes |

\`_coda_feature_done\` behavior is unchanged.

## Tests

Four new cases in \`test/shell-modules.bats\` under a \`# --- Card #123: ...\` section, all prefixed \`card123:\`:

1. \`_coda_feature_done fires pre-feature-teardown before worktree removal\` (regression test -- \`done\` ordering was already correct)
2. \`_coda_feature_done passes all expected env vars to pre-feature-teardown\`
3. \`_coda_feature_finish fires pre-feature-teardown before worktree removal\` (the fix)
4. \`_coda_feature_finish passes session name to pre-feature-teardown\`

The \`_coda_feature_finish\` tests poll for the backgrounded subshell to complete (with a 6s timeout).

\`\`\`
$ CODA_SKIP_ENV=true bats test/shell-modules.bats --filter 'card123:'
1..4
ok 1 card123: _coda_feature_done fires pre-feature-teardown before worktree removal
ok 2 card123: _coda_feature_done passes all expected env vars to pre-feature-teardown
ok 3 card123: _coda_feature_finish fires pre-feature-teardown before worktree removal
ok 4 card123: _coda_feature_finish passes session name to pre-feature-teardown
\`\`\`

Full suite: **194 ok** (190 existing + 4 new). Integration suite (\`bash tests/run.sh\`): all 3 tests pass (core-lifecycle, plugin-dep-detection, window-mode).

## Related

- Unblocks Riley's **coda-orchestrator #87** (the report-delivery hook consumer that needs \`.orch-meta\` readable during \`pre-feature-teardown\` for both \`done\` and \`finish\` paths).

Closes #123.