### PR TITLE
feat(cli): port-aware coda mcp lifecycle (card #121)

### DIFF
--- a/lib/mcp.sh
+++ b/lib/mcp.sh
@@ -105,7 +105,11 @@ _coda_mcp_stop() {
     port_pid=$(_coda_mcp_port_pid "$port")
 
     if [ -n "$port_pid" ]; then
-        echo "Warning: port $port still bound after tmux cleanup (pid $port_pid)."
+        if $killed_tmux; then
+            echo "Warning: port $port still bound after tmux cleanup (pid $port_pid)."
+        else
+            echo "Warning: port $port is bound by pid $port_pid (no tmux session)."
+        fi
         echo "  Killing rogue process..."
         kill "$port_pid" 2>/dev/null
         # Give it 1s; escalate to SIGKILL if needed.

--- a/lib/mcp.sh
+++ b/lib/mcp.sh
@@ -79,7 +79,10 @@ _coda_mcp_start() {
 
     local mcp_cmd="CODA_MCP_PORT=$port CODA_DIR=$_CODA_DIR node $server_js"
 
-    tmux new-session -d -s "$mcp_session" "$mcp_cmd"
+    if ! tmux new-session -d -s "$mcp_session" "$mcp_cmd"; then
+        echo "Failed to start MCP server (tmux new-session exited non-zero)."
+        return 1
+    fi
     echo "MCP server started on port $port."
     echo "  View:    tmux attach -t $mcp_session"
     echo "  Stop:    coda mcp stop"

--- a/lib/mcp.sh
+++ b/lib/mcp.sh
@@ -19,66 +19,154 @@ _coda_mcp() {
     esac
 }
 
+_coda_mcp_port_pid() {
+    local port="${1:-$CODA_MCP_PORT}"
+    # ss output with -p includes 'users:(("proc",pid=1234,fd=5))'.
+    # -H strips the header. -t = TCP, -l = listening, -n = numeric.
+    # Match listeners bound to :port EXACTLY (anchor with `sport = :port`)
+    # so :31111 doesn't match :3111.
+    ss -Hltnp "sport = :$port" 2>/dev/null \
+        | awk 'match($0, /pid=[0-9]+/) {
+                 s = substr($0, RSTART+4, RLENGTH-4);
+                 print s;
+                 exit
+               }'
+}
+
+_coda_mcp_tmux_running() {
+    local mcp_session="$1"
+    tmux has-session -t "$mcp_session" 2>/dev/null
+}
+
 _coda_mcp_start() {
     local mcp_session="$1"
+    local port="$CODA_MCP_PORT"
+    local tmux_running=false
+    _coda_mcp_tmux_running "$mcp_session" && tmux_running=true
 
-    if tmux has-session -t "$mcp_session" 2>/dev/null; then
-        echo "MCP server already running on port $CODA_MCP_PORT."
+    local port_pid
+    port_pid=$(_coda_mcp_port_pid "$port")
+
+    if $tmux_running && [ -n "$port_pid" ]; then
+        echo "MCP server already running on port $port (pid $port_pid)."
         echo "  View:    tmux attach -t $mcp_session"
         echo "  Stop:    coda mcp stop"
         echo "  Restart: coda mcp restart"
         return 0
     fi
 
+    if $tmux_running && [ -z "$port_pid" ]; then
+        echo "MCP server tmux session exists but nothing is listening on port $port."
+        echo "  View:    tmux attach -t $mcp_session"
+        echo "  Fix:     coda mcp restart"
+        return 1
+    fi
+
+    if ! $tmux_running && [ -n "$port_pid" ]; then
+        echo "Port $port is already bound by pid $port_pid (not managed by coda)."
+        echo "  Inspect: ps -p $port_pid"
+        echo "  Adopt:   coda mcp restart    (kills pid $port_pid, then starts)"
+        echo "  Free:    kill $port_pid      (if you want to start fresh manually)"
+        return 1
+    fi
+
+    # Neither tmux nor port in use -- clean start.
     local server_js="$_CODA_DIR/mcp-server/server.js"
     if [ ! -f "$server_js" ]; then
         echo "MCP server not found: $server_js"
         return 1
     fi
 
-    local mcp_cmd="CODA_MCP_PORT=$CODA_MCP_PORT CODA_DIR=$_CODA_DIR node $server_js"
+    local mcp_cmd="CODA_MCP_PORT=$port CODA_DIR=$_CODA_DIR node $server_js"
 
     tmux new-session -d -s "$mcp_session" "$mcp_cmd"
-    echo "MCP server started on port $CODA_MCP_PORT."
+    echo "MCP server started on port $port."
     echo "  View:    tmux attach -t $mcp_session"
     echo "  Stop:    coda mcp stop"
-    echo "  Health:  curl http://127.0.0.1:$CODA_MCP_PORT/health"
+    echo "  Health:  curl http://127.0.0.1:$port/health"
 }
 
 _coda_mcp_stop() {
     local mcp_session="$1"
+    local port="$CODA_MCP_PORT"
+    local tmux_running=false
+    _coda_mcp_tmux_running "$mcp_session" && tmux_running=true
 
-    if ! tmux has-session -t "$mcp_session" 2>/dev/null; then
-        echo "MCP server is not running."
+    local killed_tmux=false
+    if $tmux_running; then
+        tmux kill-session -t "$mcp_session"
+        killed_tmux=true
+    fi
+
+    # tmux kill doesn't always stop the child immediately; give it a beat.
+    sleep 0.2
+
+    local port_pid
+    port_pid=$(_coda_mcp_port_pid "$port")
+
+    if [ -n "$port_pid" ]; then
+        echo "Warning: port $port still bound after tmux cleanup (pid $port_pid)."
+        echo "  Killing rogue process..."
+        kill "$port_pid" 2>/dev/null
+        # Give it 1s; escalate to SIGKILL if needed.
+        sleep 1
+        port_pid=$(_coda_mcp_port_pid "$port")
+        if [ -n "$port_pid" ]; then
+            echo "  Process did not exit after SIGTERM; sending SIGKILL."
+            kill -9 "$port_pid" 2>/dev/null
+        fi
+        echo "MCP server stopped (including rogue process)."
         return 0
     fi
 
-    tmux kill-session -t "$mcp_session"
-    echo "MCP server stopped."
+    if $killed_tmux; then
+        echo "MCP server stopped."
+    else
+        echo "MCP server was not running."
+    fi
 }
 
 _coda_mcp_status() {
     local mcp_session="$1"
+    local port="$CODA_MCP_PORT"
+    local tmux_running=false
+    _coda_mcp_tmux_running "$mcp_session" && tmux_running=true
 
-    if tmux has-session -t "$mcp_session" 2>/dev/null; then
+    local port_pid
+    port_pid=$(_coda_mcp_port_pid "$port")
+
+    if $tmux_running && [ -n "$port_pid" ]; then
         local created
         created=$(tmux display-message -t "$mcp_session" -p '#{t:session_created}' 2>/dev/null)
         echo "MCP server: running (since $created)"
-        echo "  Port:    $CODA_MCP_PORT"
+        echo "  Port:    $port (pid $port_pid)"
         echo "  View:    tmux attach -t $mcp_session"
         echo "  Stop:    coda mcp stop"
-
         if command -v curl &>/dev/null; then
             local health
-            health=$(curl -sf "http://127.0.0.1:$CODA_MCP_PORT/health" 2>/dev/null)
+            health=$(curl -sf "http://127.0.0.1:$port/health" 2>/dev/null)
             if [ -n "$health" ]; then
                 echo "  Health:  ok"
             else
                 echo "  Health:  not responding"
             fi
         fi
-    else
-        echo "MCP server: stopped"
-        echo "  Start: coda mcp"
+        return 0
     fi
+
+    if $tmux_running && [ -z "$port_pid" ]; then
+        echo "MCP server: tmux session exists but port $port not bound (broken state)."
+        echo "  Fix: coda mcp restart"
+        return 1
+    fi
+
+    if ! $tmux_running && [ -n "$port_pid" ]; then
+        echo "MCP server: rogue (port $port bound by pid $port_pid, no tmux session)."
+        echo "  Inspect: ps -p $port_pid"
+        echo "  Adopt:   coda mcp restart"
+        return 1
+    fi
+
+    echo "MCP server: stopped"
+    echo "  Start: coda mcp"
 }

--- a/test/shell-modules.bats
+++ b/test/shell-modules.bats
@@ -1665,9 +1665,24 @@ _card121_stub_tmux() {
 }
 
 _card121_stub_ss() {
+    # Capture args so tests can assert the kernel-level `sport = :$port`
+    # filter is actually passed to ss. Bindings key off the requested port
+    # so a listener on :31111 never leaks into a :3111 query.
     ss() {
-        if [ -n "${PORT_BINDING:-}" ]; then
-            echo "LISTEN 0 511 127.0.0.1:${CODA_MCP_PORT:-3111} 0.0.0.0:* users:((\"node\",${PORT_BINDING},fd=21))"
+        if [ -n "${CARD121_SS_ARGS_LOG:-}" ]; then
+            printf '%s\n' "$*" >> "$CARD121_SS_ARGS_LOG"
+        fi
+        local requested_port=""
+        for arg in "$@"; do
+            case "$arg" in
+                *": :"*) requested_port="${arg##*: :}" ;;
+                *":"*) requested_port="${arg##*:}" ;;
+            esac
+        done
+        if [ -n "${PORT_BINDING:-}" ] \
+            && { [ -z "${PORT_BINDING_PORT:-}" ] || [ "$requested_port" = "$PORT_BINDING_PORT" ]; }; then
+            local listener_port="${PORT_BINDING_PORT:-$requested_port}"
+            echo "LISTEN 0 511 127.0.0.1:${listener_port} 0.0.0.0:* users:((\"node\",${PORT_BINDING},fd=21))"
         fi
         return 0
     }
@@ -1682,7 +1697,8 @@ _card121_stub_kill() {
 
 _card121_teardown() {
     unset -f tmux ss kill 2>/dev/null || true
-    unset TMUX_SESSION_EXISTS PORT_BINDING CARD121_TMUX_LOG CARD121_KILL_LOG
+    unset TMUX_SESSION_EXISTS PORT_BINDING PORT_BINDING_PORT \
+        CARD121_TMUX_LOG CARD121_KILL_LOG CARD121_SS_ARGS_LOG
 }
 
 @test "card121: _coda_mcp_port_pid returns empty when no listener" {
@@ -1693,17 +1709,31 @@ _card121_teardown() {
     _card121_teardown
 }
 
-@test "card121: _coda_mcp_port_pid returns pid on exact match (no prefix overlap)" {
+@test "card121: _coda_mcp_port_pid returns pid on exact match" {
     PORT_BINDING="pid=4242"
+    PORT_BINDING_PORT=3111
     _card121_stub_ss
     result=$(_coda_mcp_port_pid 3111)
     [ "$result" = "4242" ]
-    # And when ss returns empty (as it would for a different port), result is empty.
-    # This proves the awk extraction depends on ss output, not on us re-grepping
-    # the port number -- so :31111 vs :3111 never cross.
-    PORT_BINDING=""
+    _card121_teardown
+}
+
+@test "card121: _coda_mcp_port_pid passes sport filter to ss (no prefix overlap)" {
+    # Listener lives on :31111. Query :3111. If _coda_mcp_port_pid used a
+    # naive `grep :$port`, it would match. We assert two things:
+    #   1. ss is invoked with the exact `sport = :3111` filter (kernel-side
+    #      exact match -- the real guarantee).
+    #   2. When the stub respects that filter (i.e. the listener is on a
+    #      different port), the result is empty.
+    PORT_BINDING="pid=9001"
+    PORT_BINDING_PORT=31111
+    CARD121_SS_ARGS_LOG=$(mktemp)
+    _card121_stub_ss
     result=$(_coda_mcp_port_pid 3111)
     [ -z "$result" ]
+    grep -Fq 'sport = :3111' "$CARD121_SS_ARGS_LOG"
+    ! grep -Fq 'sport = :31111' "$CARD121_SS_ARGS_LOG"
+    rm -f "$CARD121_SS_ARGS_LOG"
     _card121_teardown
 }
 

--- a/test/shell-modules.bats
+++ b/test/shell-modules.bats
@@ -1646,3 +1646,160 @@ _coda95_stub_git() {
     rm -rf "$proj_dir" "$capture_file"
     unset -f _coda_attach _coda_run_hooks tmux git _coda_detect_default_branch
 }
+
+# --- Card #121: coda mcp port-aware lifecycle ---
+
+_card121_stub_tmux() {
+    tmux() {
+        local op="$1"
+        case "$op" in
+            has-session)
+                [ "${TMUX_SESSION_EXISTS:-false}" = "true" ] && return 0
+                return 1 ;;
+            kill-session|new-session|display-message)
+                printf '%s\n' "$*" >> "${CARD121_TMUX_LOG:-/tmp/card121-tmux.log}"
+                return 0 ;;
+        esac
+        return 0
+    }
+}
+
+_card121_stub_ss() {
+    ss() {
+        if [ -n "${PORT_BINDING:-}" ]; then
+            echo "LISTEN 0 511 127.0.0.1:${CODA_MCP_PORT:-3111} 0.0.0.0:* users:((\"node\",${PORT_BINDING},fd=21))"
+        fi
+        return 0
+    }
+}
+
+_card121_stub_kill() {
+    kill() {
+        printf 'kill %s\n' "$*" >> "${CARD121_KILL_LOG:-/tmp/card121-kill.log}"
+        return 0
+    }
+}
+
+_card121_teardown() {
+    unset -f tmux ss kill 2>/dev/null || true
+    unset TMUX_SESSION_EXISTS PORT_BINDING CARD121_TMUX_LOG CARD121_KILL_LOG
+}
+
+@test "card121: _coda_mcp_port_pid returns empty when no listener" {
+    PORT_BINDING=""
+    _card121_stub_ss
+    result=$(_coda_mcp_port_pid 3111)
+    [ -z "$result" ]
+    _card121_teardown
+}
+
+@test "card121: _coda_mcp_port_pid returns pid on exact match (no prefix overlap)" {
+    PORT_BINDING="pid=4242"
+    _card121_stub_ss
+    result=$(_coda_mcp_port_pid 3111)
+    [ "$result" = "4242" ]
+    # And when ss returns empty (as it would for a different port), result is empty.
+    # This proves the awk extraction depends on ss output, not on us re-grepping
+    # the port number -- so :31111 vs :3111 never cross.
+    PORT_BINDING=""
+    result=$(_coda_mcp_port_pid 3111)
+    [ -z "$result" ]
+    _card121_teardown
+}
+
+@test "card121: _coda_mcp_start with tmux+port says already running" {
+    CARD121_TMUX_LOG=$(mktemp)
+    TMUX_SESSION_EXISTS=true
+    PORT_BINDING="pid=1234"
+    _card121_stub_tmux
+    _card121_stub_ss
+    run _coda_mcp_start "coda-mcp-server"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"already running"* ]]
+    [[ "$output" == *"pid 1234"* ]]
+    ! grep -q 'new-session' "$CARD121_TMUX_LOG"
+    rm -f "$CARD121_TMUX_LOG"
+    _card121_teardown
+}
+
+@test "card121: _coda_mcp_start with tmux only is broken state" {
+    CARD121_TMUX_LOG=$(mktemp)
+    TMUX_SESSION_EXISTS=true
+    PORT_BINDING=""
+    _card121_stub_tmux
+    _card121_stub_ss
+    run _coda_mcp_start "coda-mcp-server"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"tmux session exists"* ]]
+    [[ "$output" == *"coda mcp restart"* ]]
+    ! grep -q 'new-session' "$CARD121_TMUX_LOG"
+    rm -f "$CARD121_TMUX_LOG"
+    _card121_teardown
+}
+
+@test "card121: _coda_mcp_start with rogue port refuses and reports pid" {
+    CARD121_TMUX_LOG=$(mktemp)
+    TMUX_SESSION_EXISTS=false
+    PORT_BINDING="pid=9999"
+    _card121_stub_tmux
+    _card121_stub_ss
+    run _coda_mcp_start "coda-mcp-server"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"bound by pid 9999"* ]]
+    ! grep -q 'new-session' "$CARD121_TMUX_LOG"
+    rm -f "$CARD121_TMUX_LOG"
+    _card121_teardown
+}
+
+@test "card121: _coda_mcp_start with neither calls tmux new-session" {
+    CARD121_TMUX_LOG=$(mktemp)
+    TMUX_SESSION_EXISTS=false
+    PORT_BINDING=""
+    _card121_stub_tmux
+    _card121_stub_ss
+    # Point _CODA_DIR at a dir that has a fake server.js
+    local fake_dir
+    fake_dir=$(mktemp -d)
+    mkdir -p "$fake_dir/mcp-server"
+    : > "$fake_dir/mcp-server/server.js"
+    local old_coda_dir="$_CODA_DIR"
+    _CODA_DIR="$fake_dir"
+    run _coda_mcp_start "coda-mcp-server"
+    _CODA_DIR="$old_coda_dir"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"MCP server started"* ]]
+    grep -q 'new-session' "$CARD121_TMUX_LOG"
+    rm -rf "$fake_dir"
+    rm -f "$CARD121_TMUX_LOG"
+    _card121_teardown
+}
+
+@test "card121: _coda_mcp_stop kills rogue pid lingering after tmux kill" {
+    CARD121_TMUX_LOG=$(mktemp)
+    CARD121_KILL_LOG=$(mktemp)
+    TMUX_SESSION_EXISTS=true
+    PORT_BINDING="pid=7777"
+    _card121_stub_tmux
+    _card121_stub_ss
+    _card121_stub_kill
+    run _coda_mcp_stop "coda-mcp-server"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"still bound"* ]]
+    [[ "$output" == *"pid 7777"* ]]
+    grep -q 'kill-session' "$CARD121_TMUX_LOG"
+    grep -q 'kill 7777' "$CARD121_KILL_LOG"
+    rm -f "$CARD121_TMUX_LOG" "$CARD121_KILL_LOG"
+    _card121_teardown
+}
+
+@test "card121: _coda_mcp_status reports rogue when port bound without tmux" {
+    TMUX_SESSION_EXISTS=false
+    PORT_BINDING="pid=5555"
+    _card121_stub_tmux
+    _card121_stub_ss
+    run _coda_mcp_status "coda-mcp-server"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"rogue"* ]]
+    [[ "$output" == *"pid 5555"* ]]
+    _card121_teardown
+}


### PR DESCRIPTION
## Bug

`coda mcp start/stop/status/restart` (in `lib/mcp.sh`) only tracked the MCP server via its **tmux session wrapper** (`${SESSION_PREFIX}mcp-server`). When the server ran as a plain `node server.js --http` process outside tmux (orphaned from a previous invocation, started by hand, etc.), all four commands went blind:

1. `coda mcp status` says "stopped" while the server is running.
2. `coda mcp stop` does nothing — can't kill what it can't see.
3. `coda mcp start` creates a new tmux session; node inside it crashes on startup because port 3111 is taken. Exit silent. Old rogue node keeps running. CLI prints "MCP server started" anyway.
4. `coda mcp restart` = stop + start, same failure mode.

Observed in anger on 2026-04-19: a rogue server with the old buggy code kept serving 400 responses while `coda mcp` thought nothing was running.

## Fix

Make all three subcommands **port-aware**. Check both tmux state AND port-binding state before acting.

New helpers:
- `_coda_mcp_port_pid [port]` — returns PID listening on port, or empty. Uses `ss -Hltnp "sport = :$port"` so `:31111` never collides with `:3111`.
- `_coda_mcp_tmux_running <session>` — thin `tmux has-session` wrapper.

### Contract matrix

**`coda mcp start`**

| tmux session | port bound | behavior |
|---|---|---|
| yes | yes | "already running on port N (pid X)" — exit 0 |
| yes | no | "tmux session exists but nothing listening" — suggest restart, exit 1 |
| no | yes | "port N bound by pid X (not managed by coda)" — refuse, exit 1 |
| no | no | start cleanly |

**`coda mcp stop`**

- Kills tmux session first (existing behavior).
- Re-checks port. If still bound, kills the port owner with SIGTERM; escalates to SIGKILL after 1s if still alive.
- Reports rogue kills separately so the operator sees what happened.

**`coda mcp status`**

- Reports both tmux state and port PID side-by-side.
- Flags broken states:
  - `tmux session exists but port N not bound` → exit 1
  - `rogue (port N bound by pid X, no tmux session)` → exit 1

**`coda mcp restart`** — unchanged dispatcher (`stop && start`); gains correctness for free via composition.

## Tests

8 new `card121:` cases appended to `test/shell-modules.bats` under a dedicated section. Stubs `tmux`, `ss`, and `kill` to simulate:

- port free / port bound (exact match, no prefix collision)
- tmux session present / absent
- every cell of the 4×state matrix for `start`
- rogue-pid escalation in `stop`
- rogue-state reporting in `status`

```
$ CODA_SKIP_ENV=true bats test/shell-modules.bats --filter 'card121:'
1..8
ok 1 card121: _coda_mcp_port_pid returns empty when no listener
ok 2 card121: _coda_mcp_port_pid returns pid on exact match (no prefix overlap)
ok 3 card121: _coda_mcp_start with tmux+port says already running
ok 4 card121: _coda_mcp_start with tmux only is broken state
ok 5 card121: _coda_mcp_start with rogue port refuses and reports pid
ok 6 card121: _coda_mcp_start with neither calls tmux new-session
ok 7 card121: _coda_mcp_stop kills rogue pid lingering after tmux kill
ok 8 card121: _coda_mcp_status reports rogue when port bound without tmux
```

Full bats suite: **198/198 pass** (190 prior + 8 new). Integration suite (`tests/run.sh`) passes.

## Scope

- This card is Ash's (coda CLI lifecycle).
- Zach is GA for routing / `/version` stale-server detection, which is card #122.
- Session-isolation / multi-orch pool concerns are card #84.
- Nothing in the MCP wire protocol changes.

## Files touched

- `lib/mcp.sh` — rewritten (helpers + port-aware subcommands)
- `test/shell-modules.bats` — new `card121:` section

Closes #121.