### PR TITLE
feat(mcp): /version endpoint and stale-server detection (card #122)

### DIFF
--- a/lib/mcp.sh
+++ b/lib/mcp.sh
@@ -170,7 +170,9 @@ _coda_mcp_status() {
                 head_sha=$(git -C "$_CODA_DIR" rev-parse --short HEAD 2>/dev/null)
                 if [ -z "$running_sha" ] || [ "$running_sha" = "unknown" ]; then
                     echo "  Version: unknown"
-                elif [ -n "$head_sha" ] && [ "$running_sha" != "$head_sha" ]; then
+                elif [ -z "$head_sha" ]; then
+                    echo "  Version: $running_sha (local HEAD unknown -- cannot compare)"
+                elif [ "$running_sha" != "$head_sha" ]; then
                     echo "  Version: $running_sha (stale; HEAD is $head_sha -- run 'coda mcp restart')"
                 else
                     echo "  Version: $running_sha (current)"

--- a/lib/mcp.sh
+++ b/lib/mcp.sh
@@ -158,6 +158,27 @@ _coda_mcp_status() {
                 echo "  Health:  not responding"
             fi
         fi
+        if command -v curl &>/dev/null; then
+            local version_json running_sha head_sha
+            version_json=$(curl -sf "http://127.0.0.1:$port/version" 2>/dev/null)
+            if [ -n "$version_json" ]; then
+                if command -v jq &>/dev/null; then
+                    running_sha=$(echo "$version_json" | jq -r '.sha // "unknown"')
+                else
+                    running_sha=$(echo "$version_json" | sed -n 's/.*"sha":"\([^"]*\)".*/\1/p')
+                fi
+                head_sha=$(git -C "$_CODA_DIR" rev-parse --short HEAD 2>/dev/null)
+                if [ -z "$running_sha" ] || [ "$running_sha" = "unknown" ]; then
+                    echo "  Version: unknown"
+                elif [ -n "$head_sha" ] && [ "$running_sha" != "$head_sha" ]; then
+                    echo "  Version: $running_sha (stale; HEAD is $head_sha -- run 'coda mcp restart')"
+                else
+                    echo "  Version: $running_sha (current)"
+                fi
+            else
+                echo "  Version: unknown (server predates /version endpoint)"
+            fi
+        fi
         return 0
     fi
 

--- a/mcp-server/server.js
+++ b/mcp-server/server.js
@@ -24,8 +24,8 @@ const SERVER_STARTED_AT = new Date().toISOString();
 
 let SERVER_GIT_SHA = "unknown";
 try {
-  const { execSync } = require("child_process");
-  SERVER_GIT_SHA = execSync("git rev-parse --short HEAD", {
+  const { execFileSync } = require("child_process");
+  SERVER_GIT_SHA = execFileSync("git", ["rev-parse", "--short", "HEAD"], {
     cwd: CODA_DIR,
     stdio: ["ignore", "pipe", "ignore"],
   }).toString().trim() || "unknown";

--- a/mcp-server/server.js
+++ b/mcp-server/server.js
@@ -19,6 +19,20 @@ const z = require("zod");
 const execFileAsync = promisify(execFile);
 
 const CODA_DIR = process.env.CODA_DIR || path.resolve(__dirname, "..");
+
+const SERVER_STARTED_AT = new Date().toISOString();
+
+let SERVER_GIT_SHA = "unknown";
+try {
+  const { execSync } = require("child_process");
+  SERVER_GIT_SHA = execSync("git rev-parse --short HEAD", {
+    cwd: CODA_DIR,
+    stdio: ["ignore", "pipe", "ignore"],
+  }).toString().trim() || "unknown";
+} catch (_) {
+  // SHA stays "unknown" if git isn't available or CODA_DIR isn't a repo.
+}
+
 const SHELL = "/bin/bash";
 
 async function runCoda(args, { cwd, timeout = 15000 } = {}) {
@@ -397,6 +411,15 @@ function startHttp() {
     if (req.method === "GET" && req.url === "/health") {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ status: "ok" }));
+      return;
+    }
+
+    if (req.method === "GET" && req.url === "/version") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        sha: SERVER_GIT_SHA,
+        started: SERVER_STARTED_AT,
+      }));
       return;
     }
 

--- a/mcp-server/test.sh
+++ b/mcp-server/test.sh
@@ -254,6 +254,43 @@ else
     rm -f "$bad_resp"
 fi
 
+# --- Test 8: HTTP mode version endpoint ---
+echo "8. HTTP mode version endpoint"
+if curl -sf "http://127.0.0.1:$HTTP_PORT/health" >/dev/null 2>&1; then
+    version_resp=$(mktemp)
+    version_status=$(curl -s -o "$version_resp" -w '%{http_code}' \
+        "http://127.0.0.1:$HTTP_PORT/version")
+    if [ "$version_status" = "200" ]; then
+        pass "/version returns HTTP 200"
+    else
+        fail "/version expected 200, got $version_status"
+    fi
+    version_body=$(cat "$version_resp")
+    if echo "$version_body" | grep -q '"sha"' && echo "$version_body" | grep -q '"started"'; then
+        pass "/version body has sha and started fields"
+    else
+        fail "/version body missing sha/started: $version_body"
+    fi
+    reported_sha=$(echo "$version_body" | sed -n 's/.*"sha":"\([^"]*\)".*/\1/p')
+    reported_started=$(echo "$version_body" | sed -n 's/.*"started":"\([^"]*\)".*/\1/p')
+    if [ -n "$reported_sha" ] && [ -n "$reported_started" ]; then
+        pass "/version sha and started are non-empty"
+    else
+        fail "/version sha='$reported_sha' started='$reported_started' (expected both non-empty)"
+    fi
+    expected_sha=$(git rev-parse --short HEAD 2>/dev/null)
+    if [ -n "$expected_sha" ] && [ "$reported_sha" = "$expected_sha" ]; then
+        pass "/version sha matches git rev-parse --short HEAD"
+    elif [ -z "$expected_sha" ]; then
+        pass "/version sha check skipped (not in a git repo)"
+    else
+        fail "/version sha '$reported_sha' != git HEAD '$expected_sha'"
+    fi
+    rm -f "$version_resp"
+else
+    fail "HTTP server not reachable for /version test"
+fi
+
 cleanup_http
 
 # --- Summary ---

--- a/test/shell-modules.bats
+++ b/test/shell-modules.bats
@@ -2013,3 +2013,110 @@ _card121_teardown() {
     rm -rf "$proj_dir" "$capture_file"
     unset -f _coda_run_hooks tmux git _coda_detect_default_branch _coda_prune_sessions_for_dir
 }
+
+# --- Card #122: MCP server /version endpoint ---
+
+_card122_setup() {
+    _coda_mcp_port_pid() { echo 12345; return 0; }
+    tmux() {
+        case "$1" in
+            has-session) return 0 ;;
+            display-message) echo "2026-04-20"; return 0 ;;
+        esac
+        return 0
+    }
+    export _CODA_DIR=/tmp/fake-repo-card122
+}
+
+_card122_teardown() {
+    unset -f _coda_mcp_port_pid tmux curl git 2>/dev/null || true
+}
+
+@test "card122: _coda_mcp_status prints Version: <sha> (current) when shas match" {
+    _card122_setup
+    curl() {
+        case "$*" in
+            *"/version"*) echo '{"sha":"abc1234","started":"2026-04-20T00:00:00Z"}'; return 0 ;;
+            *"/health"*)  echo '{"status":"ok"}'; return 0 ;;
+        esac
+        return 0
+    }
+    git() {
+        case "$*" in
+            *"rev-parse --short HEAD"*) echo abc1234; return 0 ;;
+        esac
+        return 0
+    }
+    run _coda_mcp_status "coda-mcp-server"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Version: abc1234 (current)"* ]]
+    _card122_teardown
+}
+
+@test "card122: _coda_mcp_status reports stale with both shas and restart hint" {
+    _card122_setup
+    curl() {
+        case "$*" in
+            *"/version"*) echo '{"sha":"abc1234","started":"2026-04-20T00:00:00Z"}'; return 0 ;;
+            *"/health"*)  echo '{"status":"ok"}'; return 0 ;;
+        esac
+        return 0
+    }
+    git() {
+        case "$*" in
+            *"rev-parse --short HEAD"*) echo def5678; return 0 ;;
+        esac
+        return 0
+    }
+    run _coda_mcp_status "coda-mcp-server"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]]
+    [[ "$output" == *"abc1234"* ]]
+    [[ "$output" == *"def5678"* ]]
+    [[ "$output" == *"coda mcp restart"* ]]
+    _card122_teardown
+}
+
+@test "card122: _coda_mcp_status notes predates when /version returns nothing" {
+    _card122_setup
+    curl() {
+        case "$*" in
+            *"/version"*) return 22 ;;
+            *"/health"*)  echo '{"status":"ok"}'; return 0 ;;
+        esac
+        return 0
+    }
+    git() {
+        case "$*" in
+            *"rev-parse --short HEAD"*) echo abc1234; return 0 ;;
+        esac
+        return 0
+    }
+    run _coda_mcp_status "coda-mcp-server"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"predates /version endpoint"* ]]
+    _card122_teardown
+}
+
+@test "card122: _coda_mcp_status prints plain unknown when server reports sha=unknown" {
+    _card122_setup
+    curl() {
+        case "$*" in
+            *"/version"*) echo '{"sha":"unknown","started":"2026-04-20T00:00:00Z"}'; return 0 ;;
+            *"/health"*)  echo '{"status":"ok"}'; return 0 ;;
+        esac
+        return 0
+    }
+    git() {
+        case "$*" in
+            *"rev-parse --short HEAD"*) echo abc1234; return 0 ;;
+        esac
+        return 0
+    }
+    run _coda_mcp_status "coda-mcp-server"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Version: unknown"* ]]
+    [[ "$output" != *"Version: unknown (current)"* ]]
+    [[ "$output" != *"Version: unknown (stale"* ]]
+    _card122_teardown
+}

--- a/test/shell-modules.bats
+++ b/test/shell-modules.bats
@@ -2120,3 +2120,27 @@ _card122_teardown() {
     [[ "$output" != *"Version: unknown (stale"* ]]
     _card122_teardown
 }
+
+@test "card122: _coda_mcp_status flags unknown local HEAD instead of falsely claiming current" {
+    _card122_setup
+    curl() {
+        case "$*" in
+            *"/version"*) echo '{"sha":"abc1234","started":"2026-04-20T00:00:00Z"}'; return 0 ;;
+            *"/health"*)  echo '{"status":"ok"}'; return 0 ;;
+        esac
+        return 0
+    }
+    git() {
+        case "$*" in
+            *"rev-parse --short HEAD"*) return 128 ;;
+        esac
+        return 0
+    }
+    run _coda_mcp_status "coda-mcp-server"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"abc1234"* ]]
+    [[ "$output" == *"local HEAD unknown"* ]]
+    [[ "$output" != *"(current)"* ]]
+    [[ "$output" != *"(stale"* ]]
+    _card122_teardown
+}


### PR DESCRIPTION
## Problem

After `git pull` lands a fix on main, the long-running `node mcp-server/server.js` process keeps the *old* code in memory. There is no signal to tell us the running server is stale — `coda mcp status` happily reports "running" and "Health: ok" while serving the previous SHA.

Observed 2026-04-19: the #119 fix merged and was pulled, but the running node process kept returning old 400 responses. Killing and restarting picked up the new code. No tooling caught the drift.

#121 (port-aware `coda mcp` lifecycle) tells us *whether* the server is running. This card tells us *whether it's running current code*.

## What changed

- **`mcp-server/server.js`**: capture `git rev-parse --short HEAD` and an ISO start timestamp at module load. New `GET /version` route returns `{"sha": "...", "started": "..."}`. No other routes or startup paths touched.
- **`lib/mcp.sh`**: `_coda_mcp_status` now fetches `/version`, compares against local HEAD, and prints a `Version:` line next to the existing `Health:` line.

## Behavior matrix

| Scenario | `coda mcp status` output |
|---|---|
| Running SHA matches HEAD | `Version: abc1234 (current)` |
| Running SHA differs from HEAD | `Version: abc1234 (stale; HEAD is def5678 -- run 'coda mcp restart')` |
| Server reports `sha: "unknown"` (no git at startup) | `Version: unknown` |
| `/version` endpoint missing (older server) | `Version: unknown (server predates /version endpoint)` |

The user decides when to restart — the warning is enough. No auto-restart, no graceful reload, no history.

## Tests

- **`test/shell-modules.bats`**: 4 new `card122:` cases covering each branch of the matrix above (current / stale / predates / unknown).
- **`mcp-server/test.sh`**: new "Test 8: HTTP mode version endpoint" asserts 200, non-empty `sha` + `started`, and that `sha` matches `git rev-parse --short HEAD` from the test CWD.

Results:

- `bats test/shell-modules.bats --filter 'card122:'` — 4/4 pass
- `bats test/shell-modules.bats` — 207/207 pass
- `bash tests/run.sh` — all pass
- `bash mcp-server/test.sh` — 18/18 pass

## Links

- Builds on #121 (port-aware `coda mcp` lifecycle) — shares `_coda_mcp_status`
- 2026-04-19 observation: `~/.config/coda/orchestrators/coda-core/memory/2026-04-19.md` ("Observations" section)

Closes #122.