### PR TITLE
feat(#156): v2 schema migration system

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -86,10 +86,11 @@ func openWithMigrations(path string, migs []Migration) (*sql.DB, error) {
 		return nil, fmt.Errorf("read schema_version: %w", err)
 	}
 
-	latest := 0
-	if len(migs) > 0 {
-		latest = migs[len(migs)-1].Version
+	if len(migs) == 0 {
+		d.Close()
+		return nil, fmt.Errorf("no database migrations available")
 	}
+	latest := migs[len(migs)-1].Version
 
 	if dbVer > latest {
 		d.Close()
@@ -142,15 +143,17 @@ func currentSchemaVersion(d *sql.DB) (int, error) {
 }
 
 // applyMigration runs one migration inside a transaction. If the
-// migration SQL fails, the transaction is rolled back and no
-// schema_version row is written.
+// migration SQL fails or the commit fails, the transaction is rolled
+// back and no schema_version row is written. The deferred Rollback is
+// a no-op on a committed transaction.
 func applyMigration(d *sql.DB, m Migration) error {
 	tx, err := d.Begin()
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
+	defer func() { _ = tx.Rollback() }()
+
 	if _, err := tx.Exec(m.SQL); err != nil {
-		_ = tx.Rollback()
 		return err
 	}
 	return tx.Commit()

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,23 +1,21 @@
 // Package db provides SQLite access for the coda-core v2 lifecycle state
-// store. It embeds the schema and applies it idempotently on open.
+// store. On Open, it applies numbered forward-only migrations from
+// internal/db/migrations to bring the database up to the current schema.
 package db
 
 import (
 	"database/sql"
-	_ "embed"
 	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/evanstern/coda/internal/db/migrations"
 	_ "modernc.org/sqlite"
 )
 
-//go:embed schema.sql
-var schemaSQL string
-
-// SchemaVersion is the schema revision this coda-core binary understands.
-// Bumped in lockstep with breaking changes to schema.sql.
-const SchemaVersion = 1
+// Migration is re-exported from the migrations subpackage so tests and
+// callers of openWithMigrations don't need to import it separately.
+type Migration = migrations.Migration
 
 // DefaultHome returns the CODA_HOME directory, defaulting to
 // $XDG_STATE_HOME/coda (or ~/.local/state/coda).
@@ -46,10 +44,23 @@ func DefaultPath() (string, error) {
 
 // Open opens the database at the given path, creating the parent dir
 // with 0700 if it does not exist. It enables WAL and foreign keys and
-// applies the embedded schema idempotently.
+// applies any pending migrations to bring the DB up to the current
+// schema version.
 //
 // If path is empty, DefaultPath() is used.
 func Open(path string) (*sql.DB, error) {
+	migs, err := migrations.All()
+	if err != nil {
+		return nil, fmt.Errorf("load migrations: %w", err)
+	}
+	return openWithMigrations(path, migs)
+}
+
+// openWithMigrations is the testable seam behind Open: it accepts an
+// explicit migration slice so tests can inject a synthetic migration
+// (e.g., one whose SQL is intentionally invalid) to exercise the
+// transaction rollback behavior of the migration runner.
+func openWithMigrations(path string, migs []Migration) (*sql.DB, error) {
 	if path == "" {
 		p, err := DefaultPath()
 		if err != nil {
@@ -62,35 +73,85 @@ func Open(path string) (*sql.DB, error) {
 		return nil, fmt.Errorf("create db dir: %w", err)
 	}
 
-	// Pragmas are passed via DSN so they're applied per-connection.
 	dsn := fmt.Sprintf("file:%s?_pragma=journal_mode(WAL)&_pragma=foreign_keys(ON)&_pragma=busy_timeout(5000)", path)
 	d, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite: %w", err)
 	}
-
-	// Single connection avoids WAL concurrency surprises in a CLI tool.
 	d.SetMaxOpenConns(1)
 
-	// Check schema_version BEFORE applying schema so a newer incoming DB
-	// can be refused cleanly instead of failing inside d.Exec. An empty
-	// or missing table means fresh install; apply schema unconditionally.
-	var dbVer int
-	_ = d.QueryRow(
-		`SELECT COALESCE(MAX(version), 0) FROM schema_version`,
-	).Scan(&dbVer)
-	if dbVer > SchemaVersion {
+	dbVer, err := currentSchemaVersion(d)
+	if err != nil {
+		d.Close()
+		return nil, fmt.Errorf("read schema_version: %w", err)
+	}
+
+	latest := 0
+	if len(migs) > 0 {
+		latest = migs[len(migs)-1].Version
+	}
+
+	if dbVer > latest {
 		d.Close()
 		return nil, fmt.Errorf(
 			"coda.db schema version %d is newer than this coda-core (supports up to %d). Upgrade coda-core or use an older DB.",
-			dbVer, SchemaVersion,
+			dbVer, latest,
 		)
 	}
 
-	if _, err := d.Exec(schemaSQL); err != nil {
-		d.Close()
-		return nil, fmt.Errorf("apply schema: %w", err)
+	if dbVer == latest {
+		return d, nil
+	}
+
+	for _, m := range migs {
+		if m.Version <= dbVer {
+			continue
+		}
+		if err := applyMigration(d, m); err != nil {
+			d.Close()
+			return nil, fmt.Errorf("apply migration %03d_%s: %w", m.Version, m.Name, err)
+		}
 	}
 
 	return d, nil
+}
+
+// currentSchemaVersion returns MAX(version) from the schema_version
+// table, or 0 if the table does not yet exist (fresh DB). The existence
+// pre-check via sqlite_master avoids relying on sqlite driver error
+// string matching.
+func currentSchemaVersion(d *sql.DB) (int, error) {
+	var name string
+	err := d.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='table' AND name='schema_version'`,
+	).Scan(&name)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+
+	var v int
+	if err := d.QueryRow(
+		`SELECT COALESCE(MAX(version), 0) FROM schema_version`,
+	).Scan(&v); err != nil {
+		return 0, err
+	}
+	return v, nil
+}
+
+// applyMigration runs one migration inside a transaction. If the
+// migration SQL fails, the transaction is rolled back and no
+// schema_version row is written.
+func applyMigration(d *sql.DB, m Migration) error {
+	tx, err := d.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	if _, err := tx.Exec(m.SQL); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	return tx.Commit()
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,6 +1,8 @@
 package db
 
 import (
+	"database/sql"
+	"errors"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -210,6 +212,9 @@ SELECT syntax error;`,
 	).Scan(&name)
 	if err == nil {
 		t.Fatal("rollback_probe table exists; migration transaction did not roll back")
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected sql.ErrNoRows for missing rollback_probe row, got: %v", err)
 	}
 }
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -2,8 +2,20 @@ package db
 
 import (
 	"path/filepath"
+	"strconv"
 	"testing"
+
+	"github.com/evanstern/coda/internal/db/migrations"
 )
+
+func latestVersion(t *testing.T) int {
+	t.Helper()
+	v, err := migrations.Latest()
+	if err != nil {
+		t.Fatalf("migrations.Latest: %v", err)
+	}
+	return v
+}
 
 func TestOpen_CreatesSchemaIdempotently(t *testing.T) {
 	dir := t.TempDir()
@@ -79,12 +91,54 @@ func TestSchemaVersionIsRecordedOnFreshDB(t *testing.T) {
 	}
 	defer d.Close()
 
+	want := latestVersion(t)
 	var v int
-	if err := d.QueryRow(`SELECT version FROM schema_version`).Scan(&v); err != nil {
+	if err := d.QueryRow(`SELECT MAX(version) FROM schema_version`).Scan(&v); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if v != SchemaVersion {
-		t.Fatalf("schema_version = %d, want %d", v, SchemaVersion)
+	if v != want {
+		t.Fatalf("schema_version = %d, want %d", v, want)
+	}
+}
+
+func TestOpen_FreshDBAppliesAllMigrations(t *testing.T) {
+	d, err := Open(filepath.Join(t.TempDir(), "coda.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	want := latestVersion(t)
+	var v int
+	if err := d.QueryRow(`SELECT MAX(version) FROM schema_version`).Scan(&v); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if v != want {
+		t.Fatalf("schema_version = %d, want %d (all migrations applied)", v, want)
+	}
+}
+
+func TestOpen_StaleDBMigratesForward(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "coda.db")
+	d, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.Close()
+
+	d2, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer d2.Close()
+
+	want := latestVersion(t)
+	var v int
+	if err := d2.QueryRow(`SELECT MAX(version) FROM schema_version`).Scan(&v); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if v != want {
+		t.Fatalf("schema_version after reopen = %d, want %d", v, want)
 	}
 }
 
@@ -94,9 +148,10 @@ func TestOpenRejectsNewerSchema(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	future := latestVersion(t) + 1
 	if _, err := d.Exec(
 		`INSERT INTO schema_version (version, applied_at) VALUES (?, unixepoch())`,
-		SchemaVersion+1,
+		future,
 	); err != nil {
 		t.Fatalf("seed future version: %v", err)
 	}
@@ -108,6 +163,53 @@ func TestOpenRejectsNewerSchema(t *testing.T) {
 	}
 	if got := err.Error(); !contains(got, "newer than this coda-core") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestOpen_MigrationTransactionRollback(t *testing.T) {
+	base, err := migrations.All()
+	if err != nil {
+		t.Fatalf("migrations.All: %v", err)
+	}
+	latest := base[len(base)-1].Version
+
+	bad := make([]Migration, 0, len(base)+1)
+	bad = append(bad, base...)
+	bad = append(bad, Migration{
+		Version: latest + 1,
+		Name:    "intentional-failure",
+		SQL: `CREATE TABLE rollback_probe (id INTEGER PRIMARY KEY);
+INSERT INTO schema_version (version, applied_at) VALUES (` +
+			strconv.Itoa(latest+1) + `, unixepoch());
+SELECT syntax error;`,
+	})
+
+	path := filepath.Join(t.TempDir(), "coda.db")
+	_, err = openWithMigrations(path, bad)
+	if err == nil {
+		t.Fatal("expected migration failure, got nil")
+	}
+
+	d, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopen after failed migration: %v", err)
+	}
+	defer d.Close()
+
+	var v int
+	if err := d.QueryRow(`SELECT MAX(version) FROM schema_version`).Scan(&v); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if v != latest {
+		t.Fatalf("schema_version = %d, want %d (failed migration must not bump)", v, latest)
+	}
+
+	var name string
+	err = d.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='table' AND name='rollback_probe'`,
+	).Scan(&name)
+	if err == nil {
+		t.Fatal("rollback_probe table exists; migration transaction did not roll back")
 	}
 }
 

--- a/internal/db/migrations/001_init.sql
+++ b/internal/db/migrations/001_init.sql
@@ -48,4 +48,4 @@ CREATE TABLE IF NOT EXISTS schema_version (
   applied_at INTEGER NOT NULL
 );
 
-INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (1, unixepoch());
+INSERT INTO schema_version (version, applied_at) VALUES (1, unixepoch());

--- a/internal/db/migrations/migrations.go
+++ b/internal/db/migrations/migrations.go
@@ -45,13 +45,16 @@ var filenameRE = regexp.MustCompile(`^(\d{3})_([a-z0-9-]+)\.sql$`)
 // ascending. It errors if filenames are malformed, if there are
 // duplicate versions, or if the numbering has gaps.
 //
-// The result is cached: the first successful call loads and validates
-// the embedded FS once; subsequent calls return the same slice.
+// The embedded FS is loaded once; subsequent calls return a defensive
+// copy so callers cannot mutate the cached slice.
 func All() ([]Migration, error) {
 	loadOnce.Do(func() {
 		loaded, loadErr = load(embeddedFS)
 	})
-	return loaded, loadErr
+	if loadErr != nil {
+		return nil, loadErr
+	}
+	return append([]Migration(nil), loaded...), nil
 }
 
 // Latest returns the highest Version across All(). It returns 0 and

--- a/internal/db/migrations/migrations.go
+++ b/internal/db/migrations/migrations.go
@@ -1,0 +1,124 @@
+// Package migrations holds the forward-only, numbered SQL migrations
+// applied by db.Open() to bring a coda.db up to the current schema.
+//
+// Migrations are named `NNN_<slug>.sql`, where NNN is a three-digit
+// zero-padded integer starting at 001 and incrementing contiguously.
+// Each file is applied in its own transaction and is responsible for
+// its own `INSERT INTO schema_version (version, applied_at) ...` row.
+//
+// Forward-only: there are no downgrade files. Rollback of a partially
+// applied migration happens at the transaction level in db.Open().
+package migrations
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"regexp"
+	"sort"
+	"strconv"
+	"sync"
+)
+
+//go:embed *.sql
+var embeddedFS embed.FS
+
+// Migration is a single numbered SQL file loaded from the migrations
+// directory.
+type Migration struct {
+	Version int
+	Name    string // slug portion of the filename, for logs
+	SQL     string
+}
+
+var (
+	loadOnce sync.Once
+	loaded   []Migration
+	loadErr  error
+)
+
+// filenameRE matches `NNN_<slug>.sql` where NNN is three digits and
+// slug is lowercase alphanumeric with dashes.
+var filenameRE = regexp.MustCompile(`^(\d{3})_([a-z0-9-]+)\.sql$`)
+
+// All returns migrations embedded in the binary, sorted by Version
+// ascending. It errors if filenames are malformed, if there are
+// duplicate versions, or if the numbering has gaps.
+//
+// The result is cached: the first successful call loads and validates
+// the embedded FS once; subsequent calls return the same slice.
+func All() ([]Migration, error) {
+	loadOnce.Do(func() {
+		loaded, loadErr = load(embeddedFS)
+	})
+	return loaded, loadErr
+}
+
+// Latest returns the highest Version across All(). It returns 0 and
+// an error if the migration set is empty or fails to load.
+func Latest() (int, error) {
+	ms, err := All()
+	if err != nil {
+		return 0, err
+	}
+	if len(ms) == 0 {
+		return 0, fmt.Errorf("no migrations found")
+	}
+	return ms[len(ms)-1].Version, nil
+}
+
+// load reads and validates every `*.sql` entry at the root of fsys.
+// It is exposed unexported so tests can pass a fstest.MapFS to exercise
+// the negative-path validations (malformed names, gaps, duplicates).
+func load(fsys fs.FS) ([]Migration, error) {
+	entries, err := fs.ReadDir(fsys, ".")
+	if err != nil {
+		return nil, fmt.Errorf("read migrations dir: %w", err)
+	}
+
+	var migs []Migration
+	seen := make(map[int]string)
+
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		m := filenameRE.FindStringSubmatch(name)
+		if m == nil {
+			return nil, fmt.Errorf("migrations: malformed filename %q (want NNN_<slug>.sql)", name)
+		}
+		version, err := strconv.Atoi(m[1])
+		if err != nil {
+			return nil, fmt.Errorf("migrations: parse version in %q: %w", name, err)
+		}
+		if prev, dup := seen[version]; dup {
+			return nil, fmt.Errorf("migrations: duplicate version %d (%q and %q)", version, prev, name)
+		}
+		seen[version] = name
+
+		b, err := fs.ReadFile(fsys, name)
+		if err != nil {
+			return nil, fmt.Errorf("migrations: read %q: %w", name, err)
+		}
+		migs = append(migs, Migration{
+			Version: version,
+			Name:    m[2],
+			SQL:     string(b),
+		})
+	}
+
+	sort.Slice(migs, func(i, j int) bool {
+		return migs[i].Version < migs[j].Version
+	})
+
+	// Numbering must start at 1 and have no gaps.
+	for i, mi := range migs {
+		want := i + 1
+		if mi.Version != want {
+			return nil, fmt.Errorf("migrations: gap at version %d (found %d)", want, mi.Version)
+		}
+	}
+
+	return migs, nil
+}

--- a/internal/db/migrations/migrations_test.go
+++ b/internal/db/migrations/migrations_test.go
@@ -1,0 +1,127 @@
+package migrations
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func TestAll_ParsesAndOrders(t *testing.T) {
+	ms, err := All()
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(ms) == 0 {
+		t.Fatal("no migrations loaded")
+	}
+	for i, m := range ms {
+		if m.Version != i+1 {
+			t.Fatalf("migrations[%d].Version = %d, want %d", i, m.Version, i+1)
+		}
+	}
+	if ms[0].Version != 1 {
+		t.Fatalf("first migration version = %d, want 1", ms[0].Version)
+	}
+	if ms[0].Name != "init" {
+		t.Fatalf("first migration name = %q, want %q", ms[0].Name, "init")
+	}
+}
+
+func TestLatest_MatchesLastMigration(t *testing.T) {
+	ms, err := All()
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	latest, err := Latest()
+	if err != nil {
+		t.Fatalf("Latest: %v", err)
+	}
+	if latest != ms[len(ms)-1].Version {
+		t.Fatalf("Latest = %d, want %d", latest, ms[len(ms)-1].Version)
+	}
+}
+
+func TestLoad_RejectsMalformedFilename(t *testing.T) {
+	cases := []string{
+		"abc.sql",
+		"1_init.sql",
+		"001_BAD_CAPS.sql",
+		"001_has space.sql",
+		"001-init.sql",
+	}
+	for _, bad := range cases {
+		t.Run(bad, func(t *testing.T) {
+			fs := fstest.MapFS{
+				bad: &fstest.MapFile{Data: []byte("SELECT 1;")},
+			}
+			_, err := load(fs)
+			if err == nil {
+				t.Fatalf("expected error for %q, got nil", bad)
+			}
+			if !strings.Contains(err.Error(), "malformed filename") {
+				t.Fatalf("expected malformed filename error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoad_RejectsGap(t *testing.T) {
+	fs := fstest.MapFS{
+		"001_a.sql": &fstest.MapFile{Data: []byte("SELECT 1;")},
+		"003_c.sql": &fstest.MapFile{Data: []byte("SELECT 1;")},
+	}
+	_, err := load(fs)
+	if err == nil {
+		t.Fatal("expected gap error, got nil")
+	}
+	if !strings.Contains(err.Error(), "gap at version 2") {
+		t.Fatalf("expected gap error, got: %v", err)
+	}
+}
+
+func TestLoad_RejectsDuplicate(t *testing.T) {
+	fs := fstest.MapFS{
+		"001_a.sql":     &fstest.MapFile{Data: []byte("SELECT 1;")},
+		"001_other.sql": &fstest.MapFile{Data: []byte("SELECT 2;")},
+	}
+	_, err := load(fs)
+	if err == nil {
+		t.Fatal("expected duplicate error, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate version 1") {
+		t.Fatalf("expected duplicate error, got: %v", err)
+	}
+}
+
+func TestLoad_RejectsMissingVersionOne(t *testing.T) {
+	fs := fstest.MapFS{
+		"002_b.sql": &fstest.MapFile{Data: []byte("SELECT 1;")},
+	}
+	_, err := load(fs)
+	if err == nil {
+		t.Fatal("expected error for missing version 1, got nil")
+	}
+	if !strings.Contains(err.Error(), "gap at version 1") {
+		t.Fatalf("expected gap at 1 error, got: %v", err)
+	}
+}
+
+func TestLoad_HappyPath(t *testing.T) {
+	fs := fstest.MapFS{
+		"002_b.sql": &fstest.MapFile{Data: []byte("SELECT 2;")},
+		"001_a.sql": &fstest.MapFile{Data: []byte("SELECT 1;")},
+		"003_c.sql": &fstest.MapFile{Data: []byte("SELECT 3;")},
+	}
+	ms, err := load(fs)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(ms) != 3 {
+		t.Fatalf("got %d migrations, want 3", len(ms))
+	}
+	for i, want := range []string{"a", "b", "c"} {
+		if ms[i].Version != i+1 || ms[i].Name != want {
+			t.Fatalf("ms[%d] = {%d, %q}, want {%d, %q}", i, ms[i].Version, ms[i].Name, i+1, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Replace `internal/db/schema.sql` (single file, idempotent re-exec) with a **numbered, forward-only migration system** under `internal/db/migrations/`.
- `db.Open()` now discovers the current `schema_version` via `sqlite_master`, then applies each pending migration in its own transaction. A failed migration rolls back cleanly — `schema_version` does not bump.
- Drops the `SchemaVersion` const; latest version now derived from `migrations.Latest()`. This unblocks #149 (message bus tables) and #155 (stale feature state + reasons).

## What shipped

### `internal/db/migrations/` (new package)
- `//go:embed *.sql` loader with filename regex `^(\d{3})_([a-z0-9-]+)\.sql$`.
- Gap, duplicate, and malformed-name detection at load time.
- `All()` sync.Once-cached; `Latest()` returns the highest version.
- Unexported `load(fs.FS)` seam so tests drive `fstest.MapFS` for negative paths.

### `internal/db/migrations/001_init.sql`
- Verbatim copy of #148's `schema.sql`, with the trailing `INSERT OR IGNORE` tightened to plain `INSERT` (the version gate guarantees exactly one apply).

### `internal/db/db.go`
- `Open()` is now a thin wrapper over `openWithMigrations(path, []Migration)`; the internal seam lets tests inject a synthetic failing migration.
- `currentSchemaVersion(*sql.DB)` uses a `sqlite_master` pre-check instead of error-string matching (per brief 3.4).
- Each migration runs under `d.Begin()` → `tx.Exec` → `tx.Commit()` with explicit rollback on failure.
- `SchemaVersion` const removed; `schema.sql` deleted.

### Tests
**`migrations_test.go`** (new): happy-path ordering, malformed filename rejection (5 variants), gap detection, duplicate detection, missing-v1 detection, `Latest()` matches last.

**`db_test.go`** (extended): adds `TestOpen_FreshDBAppliesAllMigrations`, `TestOpen_StaleDBMigratesForward`, and the key new `TestOpen_MigrationTransactionRollback` — appends a synthetic migration whose SQL fails, then reopens with the real migration set and asserts (a) `schema_version` did not bump, (b) the migration's probe table was rolled back. Updates `TestSchemaVersionIsRecordedOnFreshDB` and `TestOpenRejectsNewerSchema` to read `migrations.Latest()` instead of the old const.

## Test results

All three suites green for this change:

- `go test ./...` — PASS (5 packages: coda-core, internal/db, internal/db/migrations, internal/hooks, internal/lifecycle).
- `bash tests/run.sh` — PASS (3/3 suites: core-lifecycle, plugin-dep-detection, window-mode).
- `bats test/` — 233/235 PASS. The 2 failures (`_coda_load_layout fails on unknown layout`, `default layout creates single-pane session`) are **pre-existing on `main`** — reproduced on a clean `git stash` of this branch. They are unrelated to `internal/db/` and are environment-level tmux/layout issues.

## Brief-vs-reality gaps

None material. One minor note for the record:

- The brief (§5) mentions a general rule against `IF NOT EXISTS` inside migration SQL. `001_init.sql` retains `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` because the brief also explicitly says the file is the **verbatim contents of #148's `schema.sql`** except for the final `INSERT ... schema_version` tightening. The version gate still protects re-runs; this is purely inherited shape from #148. Future migrations (`002_*.sql` and beyond) should follow the strict no-`IF NOT EXISTS` rule.

## Seam note

Public `Open(path string)` is unchanged for callers. The new testable seam is `openWithMigrations(path string, migs []db.Migration) (*sql.DB, error)`, with `db.Migration` aliased to `migrations.Migration` so test code doesn't need a second import.

closes #156