### PR TITLE
feat(#157): promote exit code constants to internal/codaexit

### DIFF
--- a/cmd/coda-core/lifecycle_cmd.go
+++ b/cmd/coda-core/lifecycle_cmd.go
@@ -12,20 +12,13 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/evanstern/coda/internal/codaexit"
 	"github.com/evanstern/coda/internal/db"
 	"github.com/evanstern/coda/internal/hooks"
 	"github.com/evanstern/coda/internal/lifecycle"
 )
 
 const codaCoreVersion = "0.1.0-dev"
-
-// Exit code contract. See docs/v2-lifecycle.md. Stable across v2 releases.
-const (
-	ExitSuccess          = 0
-	ExitUserError        = 1
-	ExitDBError          = 2
-	ExitLifecycleBlocked = 3
-)
 
 type codaCoreError struct {
 	code int
@@ -35,11 +28,11 @@ type codaCoreError struct {
 func (e *codaCoreError) Error() string { return e.msg }
 
 func userError(f string, a ...any) error {
-	return &codaCoreError{code: ExitUserError, msg: fmt.Sprintf(f, a...)}
+	return &codaCoreError{code: codaexit.UserError, msg: fmt.Sprintf(f, a...)}
 }
 
 func dbError(err error) error {
-	return &codaCoreError{code: ExitDBError, msg: err.Error()}
+	return &codaCoreError{code: codaexit.DBError, msg: err.Error()}
 }
 
 // parseInterleaved accepts flags anywhere in args (stdlib flag only

--- a/docs/v2-lifecycle.md
+++ b/docs/v2-lifecycle.md
@@ -112,6 +112,10 @@ Callers MUST treat any non-zero exit as an error. Exit code 3 signals
 "user action required, do not retry" and is stable across v2 releases
 even though #148 does not yet emit it.
 
+Go callers in this repository can import the constants from
+`github.com/evanstern/coda/internal/codaexit`. External tooling should
+treat the values as stable — any change is a breaking v2-major bump.
+
 ## Build
 
 ```

--- a/docs/v2-lifecycle.md
+++ b/docs/v2-lifecycle.md
@@ -110,7 +110,7 @@ fatal-hook block surfaces to the caller as coda-core exit code 3
 
 Callers MUST treat any non-zero exit as an error. Exit code 3 signals
 "user action required, do not retry" and is stable across v2 releases
-even though #148 does not yet emit it.
+even though `coda-core` does not yet emit it (it ships with #150).
 
 Go callers in this repository can import the constants from
 `github.com/evanstern/coda/internal/codaexit`. External tooling should

--- a/internal/codaexit/codes.go
+++ b/internal/codaexit/codes.go
@@ -1,0 +1,23 @@
+// Package codaexit defines the exit code contract that coda-core emits
+// and that callers (tests, plugins via exec, tooling) can pre-handle.
+// These values are stable across v2 releases — see docs/v2-lifecycle.md.
+package codaexit
+
+const (
+	// Success indicates the operation completed.
+	Success = 0
+
+	// UserError indicates bad arguments, not-found, duplicate, or similar
+	// caller-correctable conditions.
+	UserError = 1
+
+	// DBError indicates a schema or SQLite failure. Typically not
+	// recoverable without intervention.
+	DBError = 2
+
+	// LifecycleBlocked indicates a fatal hook refused the lifecycle
+	// transition. Callers MUST NOT retry — user action is required.
+	// Reserved for the plugin system (card #150); coda-core does not
+	// yet emit this value but the contract is stable.
+	LifecycleBlocked = 3
+)

--- a/internal/codaexit/codes_test.go
+++ b/internal/codaexit/codes_test.go
@@ -1,0 +1,24 @@
+package codaexit
+
+import "testing"
+
+func TestExitCodeStability(t *testing.T) {
+	// These values are documented in docs/v2-lifecycle.md and
+	// consumed by external callers. Changing any of them is a
+	// BREAKING CHANGE that requires a major version bump.
+	cases := []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"Success", Success, 0},
+		{"UserError", UserError, 1},
+		{"DBError", DBError, 2},
+		{"LifecycleBlocked", LifecycleBlocked, 3},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("%s = %d, want %d (breaking change)", c.name, c.got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Moves the four exit code constants (`ExitSuccess=0`, `ExitUserError=1`, `ExitDBError=2`, `ExitLifecycleBlocked=3`) from `package main` in `cmd/coda-core/lifecycle_cmd.go` into a new importable package `internal/codaexit`.
- The constants drop the `Exit` prefix per Go naming convention: `codaexit.Success`, `codaexit.UserError`, `codaexit.DBError`, `codaexit.LifecycleBlocked`.
- `cmd/coda-core` now imports from `internal/codaexit` — no duplication, zero behavior change.
- Adds a stability test in `internal/codaexit/codes_test.go` that fails loudly if any value changes (breaking change guard).
- Updates `docs/v2-lifecycle.md` to document the importable package location.

## Motivation

The exit codes form a stable v2 contract (`docs/v2-lifecycle.md`) but were unreachable from any other Go code because they lived in `package main`. This unblocks card #150 (plugin system), which needs to import and reference exit code 3 (`LifecycleBlocked`) from plugin SDK code.

## Brief-vs-reality gaps

None. The constants, their values, and their usage locations were exactly as specified in `IMPLEMENT.md`.

## Changes

- `internal/codaexit/codes.go` (new)
- `internal/codaexit/codes_test.go` (new)
- `cmd/coda-core/lifecycle_cmd.go` (const block removed, import added, 2 references updated)
- `docs/v2-lifecycle.md` (3-line addition to Exit codes section)

Closes #157