### PR TITLE
feat(#155): v2 lifecycle reconciler

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,6 +129,12 @@ DEFAULT_TMUX_SESSION="default"
 # `coda-core orchestrator reconcile` always runs regardless.
 CODA_NO_AUTO_RECONCILE=""
 
+# Minimum seconds between lazy reconcile passes. The lazy pass attached
+# to `orchestrator ls` and `status` skips if the last successful pass
+# completed less than this many seconds ago. Default: 10. Set to 0 to
+# run every invocation. Explicit `orchestrator reconcile` ignores this.
+CODA_RECONCILE_MIN_INTERVAL_SECS=10
+
 # --- GitHub App (Coda bot identity) ---
 
 # GitHub App Client ID (recommended over App ID for JWT issuer)

--- a/.env.example
+++ b/.env.example
@@ -121,6 +121,14 @@ AUTO_ATTACH_TMUX="true"
 # Default tmux session name for auto-attach
 DEFAULT_TMUX_SESSION="default"
 
+# --- v2 lifecycle (coda-core) ---
+
+# Disable the lazy reconcile pass that `coda-core orchestrator ls` and
+# `coda-core status` run before rendering. Set to "1" to opt out; any
+# other value (or unset) keeps the default-on behavior. Explicit
+# `coda-core orchestrator reconcile` always runs regardless.
+CODA_NO_AUTO_RECONCILE=""
+
 # --- GitHub App (Coda bot identity) ---
 
 # GitHub App Client ID (recommended over App ID for JWT issuer)

--- a/cmd/coda-core/lifecycle_cmd.go
+++ b/cmd/coda-core/lifecycle_cmd.go
@@ -118,6 +118,7 @@ func runStatus(args []string) error {
 	defer d.Close()
 
 	ctx := context.Background()
+	maybeLazyReconcile(ctx, mgr)
 	orchs, err := mgr.ListOrchestrators(ctx)
 	if err != nil {
 		return dbError(err)
@@ -143,7 +144,7 @@ func runStatus(args []string) error {
 
 func runOrchestrator(args []string) error {
 	if len(args) == 0 {
-		return userError("usage: coda-core orchestrator <new|start|stop|ls|rm> ...")
+		return userError("usage: coda-core orchestrator <new|start|stop|ls|rm|reconcile> ...")
 	}
 	switch args[0] {
 	case "new":
@@ -156,6 +157,8 @@ func runOrchestrator(args []string) error {
 		return orchLs(args[1:])
 	case "rm":
 		return orchRm(args[1:])
+	case "reconcile":
+		return orchReconcile(args[1:])
 	default:
 		return userError("unknown orchestrator subcommand: %s", args[0])
 	}
@@ -254,7 +257,9 @@ func orchLs(args []string) error {
 	}
 	defer d.Close()
 
-	orchs, err := mgr.ListOrchestrators(context.Background())
+	ctx := context.Background()
+	maybeLazyReconcile(ctx, mgr)
+	orchs, err := mgr.ListOrchestrators(ctx)
 	if err != nil {
 		return dbError(err)
 	}
@@ -263,6 +268,69 @@ func orchLs(args []string) error {
 	}
 	printOrchTable(os.Stdout, orchs)
 	return nil
+}
+
+func orchReconcile(args []string) error {
+	fs := flag.NewFlagSet("orchestrator reconcile", flag.ContinueOnError)
+	asJSON := fs.Bool("json", false, "emit JSON")
+	if err := parseInterleaved(fs, args); err != nil {
+		return userError("%v", err)
+	}
+	if fs.NArg() > 1 {
+		return userError("usage: coda-core orchestrator reconcile [<name>] [--json]")
+	}
+	name := ""
+	if fs.NArg() == 1 {
+		name = fs.Arg(0)
+	}
+
+	d, mgr, _, err := openManager()
+	if err != nil {
+		return dbError(err)
+	}
+	defer d.Close()
+
+	results, err := mgr.Reconcile(context.Background(), name)
+	if err != nil {
+		return dbError(err)
+	}
+	if *asJSON {
+		if results == nil {
+			results = []lifecycle.ReconcileResult{}
+		}
+		return writeJSON(os.Stdout, results)
+	}
+	printReconcileResults(os.Stdout, results)
+	return nil
+}
+
+func printReconcileResults(w io.Writer, results []lifecycle.ReconcileResult) {
+	if len(results) == 0 {
+		fmt.Fprintln(w, "no rows transitioned")
+		return
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "KIND\tNAME\tORCH\tFROM\tTO\tREASON")
+	for _, r := range results {
+		orch := r.Orch
+		if orch == "" {
+			orch = "-"
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			r.Kind, r.Name, orch, r.PreviousSt, r.NewState, r.StaleReason)
+	}
+	tw.Flush()
+}
+
+// maybeLazyReconcile runs a best-effort reconcile pass unless the user
+// disabled it with CODA_NO_AUTO_RECONCILE=1. Errors are silently
+// ignored so read-only commands like ls/status stay usable when the
+// prober can't run.
+func maybeLazyReconcile(ctx context.Context, mgr *lifecycle.Manager) {
+	if os.Getenv("CODA_NO_AUTO_RECONCILE") == "1" {
+		return
+	}
+	_, _ = mgr.Reconcile(ctx, "")
 }
 
 func orchRm(args []string) error {
@@ -436,6 +504,9 @@ func orchsToJSON(orchs []*lifecycle.Orchestrator) []map[string]any {
 		if o.StartedAt.Valid {
 			m["started_at"] = o.StartedAt.Int64
 		}
+		if o.StaleReason.Valid {
+			m["stale_reason"] = o.StaleReason.String
+		}
 		out = append(out, m)
 	}
 	return out
@@ -465,6 +536,9 @@ func featuresToJSON(feats []*lifecycle.Feature) []map[string]any {
 		}
 		if f.EndedAt.Valid {
 			m["ended_at"] = f.EndedAt.Int64
+		}
+		if f.StaleReason.Valid {
+			m["stale_reason"] = f.StaleReason.String
 		}
 		out = append(out, m)
 	}

--- a/cmd/coda-core/lifecycle_cmd.go
+++ b/cmd/coda-core/lifecycle_cmd.go
@@ -9,14 +9,18 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/evanstern/coda/internal/codaexit"
 	"github.com/evanstern/coda/internal/db"
 	"github.com/evanstern/coda/internal/hooks"
 	"github.com/evanstern/coda/internal/lifecycle"
 )
+
+const defaultLazyReconcileIntervalSecs = 10
 
 const codaCoreVersion = "0.1.0-dev"
 
@@ -323,14 +327,38 @@ func printReconcileResults(w io.Writer, results []lifecycle.ReconcileResult) {
 }
 
 // maybeLazyReconcile runs a best-effort reconcile pass unless the user
-// disabled it with CODA_NO_AUTO_RECONCILE=1. Errors are silently
-// ignored so read-only commands like ls/status stay usable when the
-// prober can't run.
+// disabled it with CODA_NO_AUTO_RECONCILE=1. A reconciler_state row
+// serializes runs across invocations: a pass is skipped if the last
+// run completed less than CODA_RECONCILE_MIN_INTERVAL_SECS ago (default
+// 10s). Explicit `orchestrator reconcile` bypasses this rate-limit.
+// Errors are silently ignored so read-only commands like ls/status
+// stay usable when the prober can't run.
 func maybeLazyReconcile(ctx context.Context, mgr *lifecycle.Manager) {
 	if os.Getenv("CODA_NO_AUTO_RECONCILE") == "1" {
 		return
 	}
-	_, _ = mgr.Reconcile(ctx, "")
+
+	intervalSecs := int64(defaultLazyReconcileIntervalSecs)
+	if v := os.Getenv("CODA_RECONCILE_MIN_INTERVAL_SECS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			intervalSecs = int64(n)
+		}
+	}
+
+	var lastRun int64
+	_ = mgr.DB.QueryRowContext(ctx,
+		`SELECT last_run_at FROM reconciler_state WHERE id=1`).Scan(&lastRun)
+
+	now := time.Now().Unix()
+	if now-lastRun < intervalSecs {
+		return
+	}
+
+	if _, err := mgr.Reconcile(ctx, ""); err != nil {
+		return
+	}
+	_, _ = mgr.DB.ExecContext(ctx,
+		`UPDATE reconciler_state SET last_run_at=? WHERE id=1`, now)
 }
 
 func orchRm(args []string) error {

--- a/cmd/coda-core/lifecycle_cmd_test.go
+++ b/cmd/coda-core/lifecycle_cmd_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/evanstern/coda/internal/db"
+	"github.com/evanstern/coda/internal/hooks"
+	"github.com/evanstern/coda/internal/lifecycle"
+)
+
+type countingProber struct {
+	orchCalls int
+	featCalls int
+}
+
+func (p *countingProber) OrchestratorAlive(o *lifecycle.Orchestrator) (bool, string, error) {
+	p.orchCalls++
+	return true, "", nil
+}
+
+func (p *countingProber) FeatureAlive(f *lifecycle.Feature) (bool, string, error) {
+	p.featCalls++
+	return true, "", nil
+}
+
+func newRateLimitManager(t *testing.T) *lifecycle.Manager {
+	t.Helper()
+	home := t.TempDir()
+	d, err := db.Open(filepath.Join(home, "coda.db"))
+	if err != nil {
+		t.Fatalf("db open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return lifecycle.New(d, hooks.New(d, home))
+}
+
+func seedProbeCandidate(t *testing.T, mgr *lifecycle.Manager) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := mgr.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mgr.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 1111); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mgr.DB.ExecContext(ctx,
+		`UPDATE orchestrators SET updated_at=? WHERE name=?`, 1, "ash"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMaybeLazyReconcile_SkipsWithinInterval(t *testing.T) {
+	t.Setenv("CODA_NO_AUTO_RECONCILE", "")
+	t.Setenv("CODA_RECONCILE_MIN_INTERVAL_SECS", "3600")
+
+	mgr := newRateLimitManager(t)
+	ctx := context.Background()
+	seedProbeCandidate(t, mgr)
+
+	probe := &countingProber{}
+	mgr.SetProber(probe)
+
+	maybeLazyReconcile(ctx, mgr)
+	firstCalls := probe.orchCalls
+	if firstCalls == 0 {
+		t.Fatalf("first call expected to probe; orchCalls=0")
+	}
+
+	maybeLazyReconcile(ctx, mgr)
+	maybeLazyReconcile(ctx, mgr)
+
+	if probe.orchCalls != firstCalls {
+		t.Fatalf("lazy reconcile ran more than once inside the rate-limit window: orchCalls=%d (first=%d)",
+			probe.orchCalls, firstCalls)
+	}
+}
+
+func TestMaybeLazyReconcile_RunsWhenIntervalZero(t *testing.T) {
+	t.Setenv("CODA_NO_AUTO_RECONCILE", "")
+	t.Setenv("CODA_RECONCILE_MIN_INTERVAL_SECS", "0")
+
+	mgr := newRateLimitManager(t)
+	ctx := context.Background()
+	seedProbeCandidate(t, mgr)
+
+	probe := &countingProber{}
+	mgr.SetProber(probe)
+
+	maybeLazyReconcile(ctx, mgr)
+	maybeLazyReconcile(ctx, mgr)
+
+	if probe.orchCalls < 2 {
+		t.Fatalf("zero interval should not rate-limit; orchCalls=%d", probe.orchCalls)
+	}
+}
+
+func TestMaybeLazyReconcile_OptOutSkipsEverything(t *testing.T) {
+	t.Setenv("CODA_NO_AUTO_RECONCILE", "1")
+	t.Setenv("CODA_RECONCILE_MIN_INTERVAL_SECS", "0")
+
+	mgr := newRateLimitManager(t)
+	ctx := context.Background()
+	seedProbeCandidate(t, mgr)
+
+	probe := &countingProber{}
+	mgr.SetProber(probe)
+
+	maybeLazyReconcile(ctx, mgr)
+	if probe.orchCalls != 0 {
+		t.Fatalf("CODA_NO_AUTO_RECONCILE=1 must disable lazy reconcile; orchCalls=%d", probe.orchCalls)
+	}
+}

--- a/cmd/coda-core/main.go
+++ b/cmd/coda-core/main.go
@@ -68,6 +68,7 @@ v2 lifecycle (SQLite-backed):
   orchestrator stop    Mark orchestrator stopped
   orchestrator ls      List orchestrators
   orchestrator rm      Remove an orchestrator
+  orchestrator reconcile  Detect stale orchestrators (and features) via tmux/pid probes
   feature spawn        Register a feature (state=spawning)
   feature ls           List features
   feature attach       Mark feature running

--- a/docs/v2-lifecycle.md
+++ b/docs/v2-lifecycle.md
@@ -76,8 +76,18 @@ Events implemented by `coda-core`:
 - `post-orchestrator-stale` — fires when `Reconcile` transitions an
   orchestrator to `stale` (see "Reconciliation" below).
 - `post-feature-spawn`
+- `post-feature-stale` — fires when `Reconcile` transitions a feature
+  to `stale` (reconciler verdict from a dead liveness probe).
 - `pre-feature-teardown` — fires **before** the row is marked `done`, so
   hooks observing the DB see state=`running`.
+
+`post-orchestrator-stale` and `post-feature-stale` are always non-fatal,
+even under the #150 fatal-hook semantics: the state transition has
+already committed by the time the hook fires, so there is nothing left
+for a fatal hook to block. Fatal semantics apply only to `pre-*` events.
+Hook failures during reconciliation are logged and the reconcile loop
+continues with the remaining rows — reconciliation correctness does not
+depend on hook delivery.
 
 ## Hook dispatch ordering
 
@@ -113,8 +123,13 @@ State vocabulary:
 - `orchestrators.state = 'stale'` — row was `starting|running|stopping`
   but its `tmux_session` or `pid` no longer exists. Set by the
   reconciler; cleared when the operator calls `orchestrator start`.
-- `features.state = 'failed'` — row was `spawning|running|reporting`
-  but its `tmux_session` no longer exists. `failed` is terminal.
+- `features.state = 'stale'` — row was `spawning|running|reporting`
+  but its `tmux_session` no longer exists. `stale` is terminal and is
+  the reconciler's verdict from a dead liveness probe.
+- `features.state = 'failed'` — reserved for features that errored on
+  their own terms (e.g. a spawn-time failure). `failed` is terminal and
+  is distinct from `stale`: it is written by the feature's own code
+  path, not by the reconciler.
 
 Each transition also populates a `stale_reason` column (a short string
 like `tmux session "coda-orch--alice" gone` or `pid 12345 not alive`).
@@ -133,6 +148,14 @@ Lazy: `coda-core orchestrator ls` and `coda-core status` run a
 best-effort reconcile pass before rendering. Set
 `CODA_NO_AUTO_RECONCILE=1` to disable.
 
+The lazy pass is rate-limited by the `reconciler_state.last_run_at`
+column: if a pass completed less than `CODA_RECONCILE_MIN_INTERVAL_SECS`
+(default 10) seconds ago, the next invocation skips. This protects
+agents that poll `ls` / `status` in tight loops from hammering the
+prober (50 orchs × one tmux fork + one /proc read per row per
+invocation adds up quickly). The explicit `orchestrator reconcile`
+command ignores this rate-limit and always runs.
+
 ### Freshness window
 
 Rows updated within the last 30 seconds are skipped to avoid racing
@@ -147,8 +170,46 @@ recorded before the child has fully forked.
   (#149) concern and is deliberately out of scope here.
 
 The reconciler is observational. It updates DB rows and fires the
-`post-orchestrator-stale` hook; it never kills tmux sessions or pids.
-Filesystem cleanup remains a v1 `coda feature done/finish` responsibility.
+`post-orchestrator-stale` / `post-feature-stale` hooks; it never kills
+tmux sessions or pids. Filesystem cleanup remains a v1 `coda feature
+done/finish` responsibility.
+
+### Prober interface (for custom probes)
+
+Signal-combining policy lives behind the `Prober` interface:
+
+```go
+type Prober interface {
+    OrchestratorAlive(o *Orchestrator) (alive bool, reason string, err error)
+    FeatureAlive(f *Feature) (alive bool, reason string, err error)
+}
+```
+
+Contract that implementations MUST honor:
+
+- Both signals known, either alive → return `(true, "", nil)`.
+- All known signals dead → return `(false, <reason>, nil)`.
+- No known signals (empty tmux session name AND zero pid) → return
+  `(true, "no liveness signal", nil)` — never mark stale without
+  evidence.
+- Any probe failure (missing tmux binary, IO error, etc.) → return a
+  non-nil error. The reconciler skips that row for this pass instead
+  of treating probe failure as a dead signal.
+
+EPERM from `kill(pid, 0)` means the process exists but the caller
+lacks permission to signal it; treat it as alive. The default prober
+handles this for you.
+
+Custom probers can be installed via `Manager.SetProber`. Passing nil
+resets to the default tmux+pid prober.
+
+### Race safety
+
+Stale transitions use an optimistic UPDATE: the WHERE clause pins the
+row's state and updated_at to the values observed at SELECT time, and a
+zero RowsAffected is treated as "another writer won the race, skip
+this row silently." A concurrent `StartOrchestrator` / `StopOrchestrator`
+cannot have its transition clobbered by an in-flight reconcile pass.
 
 ### Restart from stale
 

--- a/docs/v2-lifecycle.md
+++ b/docs/v2-lifecycle.md
@@ -73,6 +73,8 @@ Events implemented by `coda-core`:
 
 - `post-orchestrator-start`
 - `post-orchestrator-stop`
+- `post-orchestrator-stale` — fires when `Reconcile` transitions an
+  orchestrator to `stale` (see "Reconciliation" below).
 - `post-feature-spawn`
 - `pre-feature-teardown` — fires **before** the row is marked `done`, so
   hooks observing the DB see state=`running`.
@@ -97,6 +99,66 @@ binding contract for plugin authors.
 Exit codes from hooks are recorded in `hook_events.exit_code`. A
 fatal-hook block surfaces to the caller as coda-core exit code 3
 (reserved; see Exit codes below).
+
+## Reconciliation
+
+`coda-core` does not supervise orchestrator or feature processes. When a
+row is written as `state=running`, nothing automatically detects that
+the tmux session was later killed or the process crashed. The
+**reconciler** closes that gap by probing tmux and pid liveness and
+transitioning dead rows to a terminal state.
+
+State vocabulary:
+
+- `orchestrators.state = 'stale'` — row was `starting|running|stopping`
+  but its `tmux_session` or `pid` no longer exists. Set by the
+  reconciler; cleared when the operator calls `orchestrator start`.
+- `features.state = 'failed'` — row was `spawning|running|reporting`
+  but its `tmux_session` no longer exists. `failed` is terminal.
+
+Each transition also populates a `stale_reason` column (a short string
+like `tmux session "coda-orch--alice" gone` or `pid 12345 not alive`).
+
+### Invocation
+
+Explicit:
+
+```
+coda-core orchestrator reconcile            # check all candidate rows
+coda-core orchestrator reconcile alice      # check only alice (+ its features)
+coda-core orchestrator reconcile --json     # machine-readable output
+```
+
+Lazy: `coda-core orchestrator ls` and `coda-core status` run a
+best-effort reconcile pass before rendering. Set
+`CODA_NO_AUTO_RECONCILE=1` to disable.
+
+### Freshness window
+
+Rows updated within the last 30 seconds are skipped to avoid racing
+in-flight `StartOrchestrator` transitions where `pid`/`tmux_session` are
+recorded before the child has fully forked.
+
+### Liveness signals
+
+- Orchestrators: `tmux has-session -t <name>` and either `/proc/<pid>/status`
+  (Linux, zombie-aware) or `kill(pid, 0)` fallback.
+- Features: tmux session only. `session_id` liveness is a message-bus
+  (#149) concern and is deliberately out of scope here.
+
+The reconciler is observational. It updates DB rows and fires the
+`post-orchestrator-stale` hook; it never kills tmux sessions or pids.
+Filesystem cleanup remains a v1 `coda feature done/finish` responsibility.
+
+### Restart from stale
+
+`StartOrchestrator` accepts rows in `stopped` or `stale` state. On a
+successful start transition, `stale_reason` is cleared automatically.
+
+### Exit codes for `reconcile`
+
+Reconcile uses 0/1/2 (success / user error / DB error). It does **not**
+emit exit code 3: reconciliation is not a lifecycle-blocked transition.
 
 ## Exit codes (coda-core)
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -142,19 +142,62 @@ func currentSchemaVersion(d *sql.DB) (int, error) {
 	return v, nil
 }
 
-// applyMigration runs one migration inside a transaction. If the
-// migration SQL fails or the commit fails, the transaction is rolled
-// back and no schema_version row is written. The deferred Rollback is
-// a no-op on a committed transaction.
+// applyMigration runs one migration inside a transaction following the
+// canonical SQLite "Making Other Kinds Of Table Schema Changes" pattern
+// (https://sqlite.org/lang_altertable.html §7):
+//
+//  1. PRAGMA foreign_keys=OFF outside any transaction
+//  2. BEGIN
+//  3. apply the migration SQL
+//  4. PRAGMA foreign_key_check inside the transaction, before commit
+//  5. if the check reports any rows, return error -> deferred rollback
+//     fires and the schema mutation is discarded
+//  6. COMMIT
+//  7. PRAGMA foreign_keys=ON outside any transaction
+//
+// Running the FK check inside the transaction is load-bearing: a check
+// after COMMIT would leave an FK-violating schema committed on disk.
 func applyMigration(d *sql.DB, m Migration) error {
+	if _, err := d.Exec(`PRAGMA foreign_keys=OFF`); err != nil {
+		return fmt.Errorf("disable foreign_keys: %w", err)
+	}
+	defer func() { _, _ = d.Exec(`PRAGMA foreign_keys=ON`) }()
+
 	tx, err := d.Begin()
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
-	defer func() { _ = tx.Rollback() }()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
 
 	if _, err := tx.Exec(m.SQL); err != nil {
 		return err
 	}
-	return tx.Commit()
+
+	rows, err := tx.Query(`PRAGMA foreign_key_check`)
+	if err != nil {
+		return fmt.Errorf("foreign_key_check: %w", err)
+	}
+	if rows.Next() {
+		var table, rowid, parent, fkid any
+		_ = rows.Scan(&table, &rowid, &parent, &fkid)
+		rows.Close()
+		return fmt.Errorf(
+			"migration %03d_%s violated FK (table=%v parent=%v)",
+			m.Version, m.Name, table, parent,
+		)
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	committed = true
+	return nil
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -218,6 +218,64 @@ SELECT syntax error;`,
 	}
 }
 
+func TestApplyMigration_ForeignKeyCheckRollsBack(t *testing.T) {
+	base, err := migrations.All()
+	if err != nil {
+		t.Fatalf("migrations.All: %v", err)
+	}
+	latest := base[len(base)-1].Version
+
+	bad := make([]Migration, 0, len(base)+1)
+	bad = append(bad, base...)
+	bad = append(bad, Migration{
+		Version: latest + 1,
+		Name:    "fk-violation",
+		SQL: `
+CREATE TABLE fk_parent (id INTEGER PRIMARY KEY);
+CREATE TABLE fk_child (
+  id         INTEGER PRIMARY KEY,
+  parent_id  INTEGER NOT NULL REFERENCES fk_parent(id)
+);
+INSERT INTO fk_parent (id) VALUES (1);
+INSERT INTO fk_child (id, parent_id) VALUES (1, 1);
+DELETE FROM fk_parent WHERE id = 1;
+INSERT INTO schema_version (version, applied_at) VALUES (` +
+			strconv.Itoa(latest+1) + `, unixepoch());
+`,
+	})
+
+	path := filepath.Join(t.TempDir(), "coda.db")
+	_, err = openWithMigrations(path, bad)
+	if err == nil {
+		t.Fatal("expected FK-violation error, got nil")
+	}
+	if !contains(err.Error(), "violated FK") {
+		t.Fatalf("expected 'violated FK' error, got: %v", err)
+	}
+
+	d, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopen after failed migration: %v", err)
+	}
+	defer d.Close()
+
+	var v int
+	if err := d.QueryRow(`SELECT MAX(version) FROM schema_version`).Scan(&v); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if v != latest {
+		t.Fatalf("schema_version = %d, want %d (FK-violating migration must not bump)", v, latest)
+	}
+
+	var name string
+	err = d.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='table' AND name='fk_child'`,
+	).Scan(&name)
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("fk_child table should not exist after rollback; got err=%v name=%q", err, name)
+	}
+}
+
 func TestCheckConstraintRejectsBogusOrchestratorState(t *testing.T) {
 	d, err := Open(filepath.Join(t.TempDir(), "coda.db"))
 	if err != nil {

--- a/internal/db/migrations/002_reconciler.sql
+++ b/internal/db/migrations/002_reconciler.sql
@@ -27,7 +27,45 @@ INSERT INTO orchestrators_new
 DROP TABLE orchestrators;
 ALTER TABLE orchestrators_new RENAME TO orchestrators;
 
--- Features: only add stale_reason. 'failed' is already in the CHECK.
-ALTER TABLE features ADD COLUMN stale_reason TEXT;
+-- Extend features.state CHECK to include 'stale' alongside 'failed'.
+-- 'stale' = reconciler verdict from a dead liveness probe.
+-- 'failed' = feature errored on its own terms (reserved for future use).
+-- Same table-swap pattern; also adds the stale_reason column here so
+-- the whole migration stays rebuild-based.
+CREATE TABLE features_new (
+  id              INTEGER PRIMARY KEY,
+  name            TEXT NOT NULL,
+  orchestrator_id INTEGER NOT NULL REFERENCES orchestrators(id) ON DELETE CASCADE,
+  project         TEXT NOT NULL,
+  branch          TEXT NOT NULL,
+  worktree_dir    TEXT NOT NULL,
+  tmux_session    TEXT,
+  state           TEXT NOT NULL
+                  CHECK (state IN ('spawning','running','reporting','done','failed','stale')),
+  brief_path      TEXT,
+  pr_url          TEXT,
+  stale_reason    TEXT,
+  created_at      INTEGER NOT NULL,
+  updated_at      INTEGER NOT NULL,
+  ended_at        INTEGER,
+  UNIQUE (orchestrator_id, name)
+);
+
+INSERT INTO features_new
+  (id, name, orchestrator_id, project, branch, worktree_dir, tmux_session,
+   state, brief_path, pr_url, stale_reason, created_at, updated_at, ended_at)
+  SELECT id, name, orchestrator_id, project, branch, worktree_dir, tmux_session,
+         state, brief_path, pr_url, NULL, created_at, updated_at, ended_at
+  FROM features;
+
+DROP TABLE features;
+ALTER TABLE features_new RENAME TO features;
+
+-- Rate-limit state for the lazy reconciler. Single-row singleton.
+CREATE TABLE IF NOT EXISTS reconciler_state (
+  id          INTEGER PRIMARY KEY CHECK (id = 1),
+  last_run_at INTEGER NOT NULL DEFAULT 0
+);
+INSERT OR IGNORE INTO reconciler_state (id, last_run_at) VALUES (1, 0);
 
 INSERT INTO schema_version (version, applied_at) VALUES (2, unixepoch());

--- a/internal/db/migrations/002_reconciler.sql
+++ b/internal/db/migrations/002_reconciler.sql
@@ -1,0 +1,33 @@
+-- Extend orchestrators.state CHECK to include 'stale' and add
+-- stale_reason column. SQLite does not support modifying CHECK
+-- constraints in place, so use the table-swap pattern.
+CREATE TABLE orchestrators_new (
+  id            INTEGER PRIMARY KEY,
+  name          TEXT NOT NULL UNIQUE,
+  config_dir    TEXT NOT NULL,
+  state         TEXT NOT NULL
+                CHECK (state IN ('stopped','starting','running','stopping','stale')),
+  tmux_session  TEXT,
+  session_id    TEXT,
+  port          INTEGER,
+  pid           INTEGER,
+  started_at    INTEGER,
+  stale_reason  TEXT,
+  created_at    INTEGER NOT NULL,
+  updated_at    INTEGER NOT NULL
+);
+
+INSERT INTO orchestrators_new
+  (id, name, config_dir, state, tmux_session, session_id, port, pid,
+   started_at, stale_reason, created_at, updated_at)
+  SELECT id, name, config_dir, state, tmux_session, session_id, port, pid,
+         started_at, NULL, created_at, updated_at
+  FROM orchestrators;
+
+DROP TABLE orchestrators;
+ALTER TABLE orchestrators_new RENAME TO orchestrators;
+
+-- Features: only add stale_reason. 'failed' is already in the CHECK.
+ALTER TABLE features ADD COLUMN stale_reason TEXT;
+
+INSERT INTO schema_version (version, applied_at) VALUES (2, unixepoch());

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -25,6 +25,7 @@ type Event string
 const (
 	EventPostOrchestratorStart Event = "post-orchestrator-start"
 	EventPostOrchestratorStop  Event = "post-orchestrator-stop"
+	EventPostOrchestratorStale Event = "post-orchestrator-stale"
 	EventPostFeatureSpawn      Event = "post-feature-spawn"
 	EventPreFeatureTeardown    Event = "pre-feature-teardown"
 )

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -27,6 +27,7 @@ const (
 	EventPostOrchestratorStop  Event = "post-orchestrator-stop"
 	EventPostOrchestratorStale Event = "post-orchestrator-stale"
 	EventPostFeatureSpawn      Event = "post-feature-spawn"
+	EventPostFeatureStale      Event = "post-feature-stale"
 	EventPreFeatureTeardown    Event = "pre-feature-teardown"
 )
 

--- a/internal/lifecycle/feature.go
+++ b/internal/lifecycle/feature.go
@@ -113,14 +113,14 @@ func (m *Manager) FinishFeature(ctx context.Context, orchName, name string) (*Fe
 func (m *Manager) GetFeature(ctx context.Context, orchName, name string) (*Feature, error) {
 	row := m.DB.QueryRowContext(ctx,
 		`SELECT f.id, f.name, f.orchestrator_id, f.project, f.branch, f.worktree_dir,
-		        f.tmux_session, f.state, f.brief_path, f.pr_url,
+		        f.tmux_session, f.state, f.brief_path, f.pr_url, f.stale_reason,
 		        f.created_at, f.updated_at, f.ended_at
 		 FROM features f
 		 JOIN orchestrators o ON o.id = f.orchestrator_id
 		 WHERE o.name=? AND f.name=?`, orchName, name)
 	f := &Feature{}
 	err := row.Scan(&f.ID, &f.Name, &f.OrchestratorID, &f.Project, &f.Branch,
-		&f.WorktreeDir, &f.TmuxSession, &f.State, &f.BriefPath, &f.PRURL,
+		&f.WorktreeDir, &f.TmuxSession, &f.State, &f.BriefPath, &f.PRURL, &f.StaleReason,
 		&f.CreatedAt, &f.UpdatedAt, &f.EndedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("%w: feature %q on orchestrator %q", ErrNotFound, name, orchName)
@@ -137,13 +137,13 @@ func (m *Manager) ListFeatures(ctx context.Context, orchName string) ([]*Feature
 	if orchName == "" {
 		rows, err = m.DB.QueryContext(ctx,
 			`SELECT id, name, orchestrator_id, project, branch, worktree_dir,
-			        tmux_session, state, brief_path, pr_url,
+			        tmux_session, state, brief_path, pr_url, stale_reason,
 			        created_at, updated_at, ended_at
 			 FROM features ORDER BY orchestrator_id, name`)
 	} else {
 		rows, err = m.DB.QueryContext(ctx,
 			`SELECT f.id, f.name, f.orchestrator_id, f.project, f.branch, f.worktree_dir,
-			        f.tmux_session, f.state, f.brief_path, f.pr_url,
+			        f.tmux_session, f.state, f.brief_path, f.pr_url, f.stale_reason,
 			        f.created_at, f.updated_at, f.ended_at
 			 FROM features f JOIN orchestrators o ON o.id=f.orchestrator_id
 			 WHERE o.name=? ORDER BY f.name`, orchName)
@@ -156,7 +156,7 @@ func (m *Manager) ListFeatures(ctx context.Context, orchName string) ([]*Feature
 	for rows.Next() {
 		f := &Feature{}
 		if err := rows.Scan(&f.ID, &f.Name, &f.OrchestratorID, &f.Project, &f.Branch,
-			&f.WorktreeDir, &f.TmuxSession, &f.State, &f.BriefPath, &f.PRURL,
+			&f.WorktreeDir, &f.TmuxSession, &f.State, &f.BriefPath, &f.PRURL, &f.StaleReason,
 			&f.CreatedAt, &f.UpdatedAt, &f.EndedAt); err != nil {
 			return nil, err
 		}
@@ -179,6 +179,9 @@ func featurePayload(f *Feature, orch *Orchestrator) map[string]any {
 	}
 	if f.TmuxSession.Valid {
 		p["tmux_session"] = f.TmuxSession.String
+	}
+	if f.StaleReason.Valid {
+		p["stale_reason"] = f.StaleReason.String
 	}
 	return map[string]any{"feature": p}
 }

--- a/internal/lifecycle/orchestrator.go
+++ b/internal/lifecycle/orchestrator.go
@@ -19,6 +19,7 @@ const (
 	StateStarting  = "starting"
 	StateRunning   = "running"
 	StateStopping  = "stopping"
+	StateStale     = "stale"
 	StateSpawning  = "spawning"
 	StateReporting = "reporting"
 	StateDone      = "done"
@@ -40,6 +41,7 @@ type Orchestrator struct {
 	Port        sql.NullInt64
 	PID         sql.NullInt64
 	StartedAt   sql.NullInt64
+	StaleReason sql.NullString
 	CreatedAt   int64
 	UpdatedAt   int64
 }
@@ -56,6 +58,7 @@ type Feature struct {
 	State          string
 	BriefPath      sql.NullString
 	PRURL          sql.NullString
+	StaleReason    sql.NullString
 	CreatedAt      int64
 	UpdatedAt      int64
 	EndedAt        sql.NullInt64
@@ -68,9 +71,10 @@ type HookFirer interface {
 
 // Manager is the stateful operations surface used by the CLI commands.
 type Manager struct {
-	DB    *sql.DB
-	Hooks HookFirer
-	Now   func() time.Time
+	DB     *sql.DB
+	Hooks  HookFirer
+	Now    func() time.Time
+	prober Prober
 }
 
 // New constructs a Manager. A nil hooks dispatcher disables hook firing.
@@ -106,14 +110,14 @@ func (m *Manager) StartOrchestrator(ctx context.Context, name string, tmuxSessio
 	now := m.now()
 	res, err := m.DB.ExecContext(ctx,
 		`UPDATE orchestrators
-		 SET state=?, tmux_session=?, port=?, pid=?, started_at=?, updated_at=?
-		 WHERE name=?`,
+		 SET state=?, tmux_session=?, port=?, pid=?, started_at=?, stale_reason=NULL, updated_at=?
+		 WHERE name=? AND state IN ('stopped','stale')`,
 		StateRunning, nullStr(tmuxSession), nullInt(int64(port)), nullInt(int64(pid)), now, now, name)
 	if err != nil {
 		return nil, err
 	}
 	if n, _ := res.RowsAffected(); n == 0 {
-		return nil, fmt.Errorf("%w: orchestrator %q", ErrNotFound, name)
+		return nil, fmt.Errorf("%w: orchestrator %q (not in stopped|stale)", ErrNotFound, name)
 	}
 	o, err := m.GetOrchestrator(ctx, name)
 	if err != nil {
@@ -157,11 +161,11 @@ func (m *Manager) StopOrchestrator(ctx context.Context, name string) (*Orchestra
 // GetOrchestrator fetches one row by name.
 func (m *Manager) GetOrchestrator(ctx context.Context, name string) (*Orchestrator, error) {
 	row := m.DB.QueryRowContext(ctx,
-		`SELECT id, name, config_dir, state, tmux_session, port, pid, started_at, created_at, updated_at
+		`SELECT id, name, config_dir, state, tmux_session, port, pid, started_at, stale_reason, created_at, updated_at
 		 FROM orchestrators WHERE name=?`, name)
 	o := &Orchestrator{}
 	err := row.Scan(&o.ID, &o.Name, &o.ConfigDir, &o.State, &o.TmuxSession,
-		&o.Port, &o.PID, &o.StartedAt, &o.CreatedAt, &o.UpdatedAt)
+		&o.Port, &o.PID, &o.StartedAt, &o.StaleReason, &o.CreatedAt, &o.UpdatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("%w: orchestrator %q", ErrNotFound, name)
 	}
@@ -171,7 +175,7 @@ func (m *Manager) GetOrchestrator(ctx context.Context, name string) (*Orchestrat
 // ListOrchestrators returns all rows ordered by name.
 func (m *Manager) ListOrchestrators(ctx context.Context) ([]*Orchestrator, error) {
 	rows, err := m.DB.QueryContext(ctx,
-		`SELECT id, name, config_dir, state, tmux_session, port, pid, started_at, created_at, updated_at
+		`SELECT id, name, config_dir, state, tmux_session, port, pid, started_at, stale_reason, created_at, updated_at
 		 FROM orchestrators ORDER BY name`)
 	if err != nil {
 		return nil, err
@@ -181,7 +185,7 @@ func (m *Manager) ListOrchestrators(ctx context.Context) ([]*Orchestrator, error
 	for rows.Next() {
 		o := &Orchestrator{}
 		if err := rows.Scan(&o.ID, &o.Name, &o.ConfigDir, &o.State, &o.TmuxSession,
-			&o.Port, &o.PID, &o.StartedAt, &o.CreatedAt, &o.UpdatedAt); err != nil {
+			&o.Port, &o.PID, &o.StartedAt, &o.StaleReason, &o.CreatedAt, &o.UpdatedAt); err != nil {
 			return nil, err
 		}
 		out = append(out, o)
@@ -215,6 +219,9 @@ func orchPayload(o *Orchestrator) map[string]any {
 	}
 	if o.PID.Valid {
 		p["pid"] = o.PID.Int64
+	}
+	if o.StaleReason.Valid {
+		p["stale_reason"] = o.StaleReason.String
 	}
 	return map[string]any{"orchestrator": p}
 }

--- a/internal/lifecycle/ordering_test.go
+++ b/internal/lifecycle/ordering_test.go
@@ -22,6 +22,15 @@ func (s *spyDispatcher) Fire(ctx context.Context, e hooks.Event, _ map[string]an
 	return nil
 }
 
+func (s *spyDispatcher) sawEvent(want hooks.Event) bool {
+	for _, e := range s.events {
+		if e == want {
+			return true
+		}
+	}
+	return false
+}
+
 func TestPreFeatureTeardownFiresBeforeStateUpdate(t *testing.T) {
 	home := t.TempDir()
 	d, err := db.Open(filepath.Join(home, "coda.db"))

--- a/internal/lifecycle/reconciler.go
+++ b/internal/lifecycle/reconciler.go
@@ -1,0 +1,310 @@
+package lifecycle
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/evanstern/coda/internal/hooks"
+)
+
+// reconcileFreshnessWindow protects in-flight StartOrchestrator calls
+// whose row has a pid/tmux_session recorded before the child has fully
+// forked. Rows updated inside this window are skipped by Reconcile.
+const reconcileFreshnessWindow = 30 * time.Second
+
+// Prober verifies whether a process or tmux session is alive. Production
+// uses tmuxPidProber; tests inject stubs.
+type Prober interface {
+	TmuxSessionExists(name string) (bool, error)
+	PidAlive(pid int) (bool, error)
+}
+
+// ReconcileResult describes a single row transitioned by Reconcile.
+type ReconcileResult struct {
+	Kind        string `json:"kind"`
+	Name        string `json:"name"`
+	Orch        string `json:"orchestrator,omitempty"`
+	PreviousSt  string `json:"previous_state"`
+	NewState    string `json:"new_state"`
+	StaleReason string `json:"stale_reason"`
+}
+
+// SetProber overrides the default tmux/pid prober. Tests use this to
+// inject deterministic behavior. Passing nil resets to the default.
+func (m *Manager) SetProber(p Prober) {
+	m.prober = p
+}
+
+func (m *Manager) probe() Prober {
+	if m.prober != nil {
+		return m.prober
+	}
+	return defaultProber{}
+}
+
+// Reconcile inspects lifecycle rows whose state suggests they should be
+// alive (orchestrators in starting|running|stopping; features in
+// spawning|running) and marks rows whose backing tmux session or pid no
+// longer exists as stale/failed. If name is empty all candidates are
+// checked; otherwise only that orchestrator (and its features).
+//
+// Rows updated within reconcileFreshnessWindow are skipped to avoid
+// racing in-flight Start transitions. Rows already terminal (stale,
+// done, failed, stopped) are skipped.
+//
+// Reconcile is observational: it updates DB rows and fires the
+// post-orchestrator-stale hook. It does not kill tmux sessions or pids.
+func (m *Manager) Reconcile(ctx context.Context, name string) ([]ReconcileResult, error) {
+	cutoff := m.Now().Add(-reconcileFreshnessWindow).Unix()
+	var results []ReconcileResult
+
+	orchs, err := m.reconcileOrchestrators(ctx, name, cutoff)
+	if err != nil {
+		return results, err
+	}
+	results = append(results, orchs...)
+
+	feats, err := m.reconcileFeatures(ctx, name, cutoff)
+	if err != nil {
+		return results, err
+	}
+	results = append(results, feats...)
+
+	return results, nil
+}
+
+func (m *Manager) reconcileOrchestrators(ctx context.Context, name string, cutoff int64) ([]ReconcileResult, error) {
+	query := `SELECT id, name, config_dir, state, tmux_session, port, pid, started_at, stale_reason, created_at, updated_at
+	          FROM orchestrators
+	          WHERE state IN ('starting','running','stopping')
+	            AND updated_at <= ?`
+	args := []any{cutoff}
+	if name != "" {
+		query += ` AND name = ?`
+		args = append(args, name)
+	}
+
+	rows, err := m.DB.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var candidates []*Orchestrator
+	for rows.Next() {
+		o := &Orchestrator{}
+		if err := rows.Scan(&o.ID, &o.Name, &o.ConfigDir, &o.State, &o.TmuxSession,
+			&o.Port, &o.PID, &o.StartedAt, &o.StaleReason, &o.CreatedAt, &o.UpdatedAt); err != nil {
+			return nil, err
+		}
+		candidates = append(candidates, o)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	p := m.probe()
+	var results []ReconcileResult
+	for _, o := range candidates {
+		reason := orchDeadReason(p, o)
+		if reason == "" {
+			continue
+		}
+		prev := o.State
+		if err := m.markOrchestratorStale(ctx, o, reason); err != nil {
+			return results, err
+		}
+		results = append(results, ReconcileResult{
+			Kind:        "orchestrator",
+			Name:        o.Name,
+			PreviousSt:  prev,
+			NewState:    StateStale,
+			StaleReason: reason,
+		})
+	}
+	return results, nil
+}
+
+func orchDeadReason(p Prober, o *Orchestrator) string {
+	if o.TmuxSession.Valid && o.TmuxSession.String != "" {
+		alive, err := p.TmuxSessionExists(o.TmuxSession.String)
+		if err == nil && !alive {
+			return fmt.Sprintf("tmux session %q gone", o.TmuxSession.String)
+		}
+	}
+	if o.PID.Valid && o.PID.Int64 > 0 {
+		alive, err := p.PidAlive(int(o.PID.Int64))
+		if err == nil && !alive {
+			return fmt.Sprintf("pid %d not alive", o.PID.Int64)
+		}
+	}
+	return ""
+}
+
+func (m *Manager) markOrchestratorStale(ctx context.Context, o *Orchestrator, reason string) error {
+	now := m.Now().Unix()
+	_, err := m.DB.ExecContext(ctx,
+		`UPDATE orchestrators SET state=?, stale_reason=?, updated_at=? WHERE id=?`,
+		StateStale, reason, now, o.ID)
+	if err != nil {
+		return err
+	}
+	o.State = StateStale
+	o.StaleReason = sql.NullString{String: reason, Valid: true}
+	o.UpdatedAt = now
+	if m.Hooks != nil {
+		if err := m.Hooks.Fire(ctx, hooks.EventPostOrchestratorStale, orchPayload(o)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *Manager) reconcileFeatures(ctx context.Context, orchName string, cutoff int64) ([]ReconcileResult, error) {
+	query := `SELECT f.id, f.name, f.orchestrator_id, f.project, f.branch, f.worktree_dir,
+	                 f.tmux_session, f.state, f.brief_path, f.pr_url, f.stale_reason,
+	                 f.created_at, f.updated_at, f.ended_at,
+	                 o.name
+	          FROM features f
+	          JOIN orchestrators o ON o.id = f.orchestrator_id
+	          WHERE f.state IN ('spawning','running','reporting')
+	            AND f.updated_at <= ?`
+	args := []any{cutoff}
+	if orchName != "" {
+		query += ` AND o.name = ?`
+		args = append(args, orchName)
+	}
+
+	rows, err := m.DB.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	type candidate struct {
+		feat *Feature
+		orch string
+	}
+	var candidates []candidate
+	for rows.Next() {
+		f := &Feature{}
+		var orch string
+		if err := rows.Scan(&f.ID, &f.Name, &f.OrchestratorID, &f.Project, &f.Branch,
+			&f.WorktreeDir, &f.TmuxSession, &f.State, &f.BriefPath, &f.PRURL, &f.StaleReason,
+			&f.CreatedAt, &f.UpdatedAt, &f.EndedAt, &orch); err != nil {
+			return nil, err
+		}
+		candidates = append(candidates, candidate{feat: f, orch: orch})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	p := m.probe()
+	var results []ReconcileResult
+	for _, c := range candidates {
+		if !c.feat.TmuxSession.Valid || c.feat.TmuxSession.String == "" {
+			continue
+		}
+		alive, err := p.TmuxSessionExists(c.feat.TmuxSession.String)
+		if err != nil || alive {
+			continue
+		}
+		reason := fmt.Sprintf("tmux session %q gone", c.feat.TmuxSession.String)
+		prev := c.feat.State
+		if err := m.markFeatureFailed(ctx, c.feat.ID, reason); err != nil {
+			return results, err
+		}
+		results = append(results, ReconcileResult{
+			Kind:        "feature",
+			Name:        c.feat.Name,
+			Orch:        c.orch,
+			PreviousSt:  prev,
+			NewState:    StateFailed,
+			StaleReason: reason,
+		})
+	}
+	return results, nil
+}
+
+func (m *Manager) markFeatureFailed(ctx context.Context, id int64, reason string) error {
+	now := m.Now().Unix()
+	_, err := m.DB.ExecContext(ctx,
+		`UPDATE features SET state=?, stale_reason=?, ended_at=?, updated_at=? WHERE id=?`,
+		StateFailed, reason, now, now, id)
+	return err
+}
+
+type defaultProber struct{}
+
+func (defaultProber) TmuxSessionExists(name string) (bool, error) {
+	if name == "" {
+		return false, nil
+	}
+	cmd := exec.Command("tmux", "has-session", "-t", name)
+	err := cmd.Run()
+	if err == nil {
+		return true, nil
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return false, nil
+	}
+	if errors.Is(err, exec.ErrNotFound) {
+		return false, nil
+	}
+	return false, err
+}
+
+func (defaultProber) PidAlive(pid int) (bool, error) {
+	if pid <= 0 {
+		return false, nil
+	}
+	if alive, ok := pidAliveProc(pid); ok {
+		return alive, nil
+	}
+	err := syscall.Kill(pid, 0)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, syscall.ESRCH) {
+		return false, nil
+	}
+	if errors.Is(err, syscall.EPERM) {
+		return false, nil
+	}
+	return false, err
+}
+
+// pidAliveProc consults /proc on Linux. Returns (alive, handled); if
+// handled=false the caller falls back to signal-0. A zombie is treated
+// as not alive.
+func pidAliveProc(pid int) (bool, bool) {
+	status, err := os.ReadFile(filepath.Join("/proc", fmt.Sprintf("%d", pid), "status"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			if _, statErr := os.Stat("/proc/self"); statErr == nil {
+				return false, true
+			}
+		}
+		return false, false
+	}
+	for _, line := range strings.Split(string(status), "\n") {
+		if strings.HasPrefix(line, "State:") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 && fields[1] == "Z" {
+				return false, true
+			}
+			return true, true
+		}
+	}
+	return true, true
+}

--- a/internal/lifecycle/reconciler.go
+++ b/internal/lifecycle/reconciler.go
@@ -2,9 +2,9 @@ package lifecycle
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,11 +20,15 @@ import (
 // forked. Rows updated inside this window are skipped by Reconcile.
 const reconcileFreshnessWindow = 30 * time.Second
 
-// Prober verifies whether a process or tmux session is alive. Production
-// uses tmuxPidProber; tests inject stubs.
+// Prober answers "is this row's backing process/session still alive?"
+// The default implementation encapsulates signal-combining policy so the
+// reconciler loop never has to make that decision itself: both
+// known-dead signals are required to declare an orchestrator dead, a
+// single unknown signal doesn't move the row, and any probe error
+// causes the row to be skipped rather than wrongly marked stale.
 type Prober interface {
-	TmuxSessionExists(name string) (bool, error)
-	PidAlive(pid int) (bool, error)
+	OrchestratorAlive(o *Orchestrator) (alive bool, reason string, err error)
+	FeatureAlive(f *Feature) (alive bool, reason string, err error)
 }
 
 // ReconcileResult describes a single row transitioned by Reconcile.
@@ -52,8 +56,8 @@ func (m *Manager) probe() Prober {
 
 // Reconcile inspects lifecycle rows whose state suggests they should be
 // alive (orchestrators in starting|running|stopping; features in
-// spawning|running) and marks rows whose backing tmux session or pid no
-// longer exists as stale/failed. If name is empty all candidates are
+// spawning|running|reporting) and marks rows whose backing tmux session
+// or pid no longer exists as stale. If name is empty all candidates are
 // checked; otherwise only that orchestrator (and its features).
 //
 // Rows updated within reconcileFreshnessWindow are skipped to avoid
@@ -61,7 +65,9 @@ func (m *Manager) probe() Prober {
 // done, failed, stopped) are skipped.
 //
 // Reconcile is observational: it updates DB rows and fires the
-// post-orchestrator-stale hook. It does not kill tmux sessions or pids.
+// post-orchestrator-stale / post-feature-stale hooks. It does not kill
+// tmux sessions or pids. Hook failures are logged and do not abort the
+// loop — reconciliation correctness does not depend on hook delivery.
 func (m *Manager) Reconcile(ctx context.Context, name string) ([]ReconcileResult, error) {
 	cutoff := m.Now().Add(-reconcileFreshnessWindow).Unix()
 	var results []ReconcileResult
@@ -114,13 +120,22 @@ func (m *Manager) reconcileOrchestrators(ctx context.Context, name string, cutof
 	p := m.probe()
 	var results []ReconcileResult
 	for _, o := range candidates {
-		reason := orchDeadReason(p, o)
-		if reason == "" {
+		alive, reason, err := p.OrchestratorAlive(o)
+		if err != nil {
+			log.Printf("reconcile: skipping orchestrator %q: probe error: %v", o.Name, err)
+			continue
+		}
+		if alive {
 			continue
 		}
 		prev := o.State
-		if err := m.markOrchestratorStale(ctx, o, reason); err != nil {
+		prevUpdatedAt := o.UpdatedAt
+		transitioned, err := m.markOrchestratorStale(ctx, o, prev, prevUpdatedAt, reason)
+		if err != nil {
 			return results, err
+		}
+		if !transitioned {
+			continue
 		}
 		results = append(results, ReconcileResult{
 			Kind:        "orchestrator",
@@ -133,39 +148,40 @@ func (m *Manager) reconcileOrchestrators(ctx context.Context, name string, cutof
 	return results, nil
 }
 
-func orchDeadReason(p Prober, o *Orchestrator) string {
-	if o.TmuxSession.Valid && o.TmuxSession.String != "" {
-		alive, err := p.TmuxSessionExists(o.TmuxSession.String)
-		if err == nil && !alive {
-			return fmt.Sprintf("tmux session %q gone", o.TmuxSession.String)
-		}
-	}
-	if o.PID.Valid && o.PID.Int64 > 0 {
-		alive, err := p.PidAlive(int(o.PID.Int64))
-		if err == nil && !alive {
-			return fmt.Sprintf("pid %d not alive", o.PID.Int64)
-		}
-	}
-	return ""
-}
-
-func (m *Manager) markOrchestratorStale(ctx context.Context, o *Orchestrator, reason string) error {
+// markOrchestratorStale transitions an orchestrator row to stale with
+// an optimistic UPDATE whose WHERE clause pins the row's state and
+// updated_at to the values this reconcile pass read at SELECT time. A
+// concurrent StartOrchestrator / StopOrchestrator between the SELECT
+// and this UPDATE causes RowsAffected to be zero, in which case the
+// function returns (false, nil) and the hook does not fire. Hook
+// errors are logged; they do not propagate, so a misbehaving hook
+// cannot abort the surrounding Reconcile loop.
+func (m *Manager) markOrchestratorStale(ctx context.Context, o *Orchestrator, prevState string, prevUpdatedAt int64, reason string) (bool, error) {
 	now := m.Now().Unix()
-	_, err := m.DB.ExecContext(ctx,
-		`UPDATE orchestrators SET state=?, stale_reason=?, updated_at=? WHERE id=?`,
-		StateStale, reason, now, o.ID)
+	res, err := m.DB.ExecContext(ctx,
+		`UPDATE orchestrators SET state=?, stale_reason=?, updated_at=?
+		 WHERE id=? AND state=? AND updated_at=?`,
+		StateStale, reason, now, o.ID, prevState, prevUpdatedAt)
 	if err != nil {
-		return err
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if n == 0 {
+		return false, nil
 	}
 	o.State = StateStale
-	o.StaleReason = sql.NullString{String: reason, Valid: true}
+	o.StaleReason.String = reason
+	o.StaleReason.Valid = true
 	o.UpdatedAt = now
 	if m.Hooks != nil {
 		if err := m.Hooks.Fire(ctx, hooks.EventPostOrchestratorStale, orchPayload(o)); err != nil {
-			return err
+			log.Printf("reconcile: post-orchestrator-stale hook for %q failed: %v", o.Name, err)
 		}
 	}
-	return nil
+	return true, nil
 }
 
 func (m *Manager) reconcileFeatures(ctx context.Context, orchName string, cutoff int64) ([]ReconcileResult, error) {
@@ -211,41 +227,174 @@ func (m *Manager) reconcileFeatures(ctx context.Context, orchName string, cutoff
 	p := m.probe()
 	var results []ReconcileResult
 	for _, c := range candidates {
-		if !c.feat.TmuxSession.Valid || c.feat.TmuxSession.String == "" {
+		alive, reason, err := p.FeatureAlive(c.feat)
+		if err != nil {
+			log.Printf("reconcile: skipping feature %q on %q: probe error: %v", c.feat.Name, c.orch, err)
 			continue
 		}
-		alive, err := p.TmuxSessionExists(c.feat.TmuxSession.String)
-		if err != nil || alive {
+		if alive {
 			continue
 		}
-		reason := fmt.Sprintf("tmux session %q gone", c.feat.TmuxSession.String)
 		prev := c.feat.State
-		if err := m.markFeatureFailed(ctx, c.feat.ID, reason); err != nil {
+		prevUpdatedAt := c.feat.UpdatedAt
+		transitioned, err := m.markFeatureStale(ctx, c.feat, c.orch, prev, prevUpdatedAt, reason)
+		if err != nil {
 			return results, err
+		}
+		if !transitioned {
+			continue
 		}
 		results = append(results, ReconcileResult{
 			Kind:        "feature",
 			Name:        c.feat.Name,
 			Orch:        c.orch,
 			PreviousSt:  prev,
-			NewState:    StateFailed,
+			NewState:    StateStale,
 			StaleReason: reason,
 		})
 	}
 	return results, nil
 }
 
-func (m *Manager) markFeatureFailed(ctx context.Context, id int64, reason string) error {
+// markFeatureStale writes state='stale' on a feature via an optimistic
+// UPDATE pinned to the (state, updated_at) this reconcile pass read at
+// SELECT time. The extra IN-list predicate guards against a concurrent
+// writer moving the row out of the candidate vocabulary entirely
+// (e.g. spawning -> done). Zero RowsAffected means another writer won
+// the race; this function returns (false, nil) without firing the hook.
+func (m *Manager) markFeatureStale(ctx context.Context, f *Feature, orchName, prevState string, prevUpdatedAt int64, reason string) (bool, error) {
 	now := m.Now().Unix()
-	_, err := m.DB.ExecContext(ctx,
-		`UPDATE features SET state=?, stale_reason=?, ended_at=?, updated_at=? WHERE id=?`,
-		StateFailed, reason, now, now, id)
-	return err
+	res, err := m.DB.ExecContext(ctx,
+		`UPDATE features
+		 SET state=?, stale_reason=?, ended_at=?, updated_at=?
+		 WHERE id=? AND state=? AND updated_at=?
+		   AND state IN ('spawning','running','reporting')`,
+		StateStale, reason, now, now, f.ID, prevState, prevUpdatedAt)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if n == 0 {
+		return false, nil
+	}
+	f.State = StateStale
+	f.StaleReason.String = reason
+	f.StaleReason.Valid = true
+	f.UpdatedAt = now
+	f.EndedAt.Int64 = now
+	f.EndedAt.Valid = true
+	if m.Hooks != nil {
+		payload := featureStalePayload(f, orchName)
+		if err := m.Hooks.Fire(ctx, hooks.EventPostFeatureStale, payload); err != nil {
+			log.Printf("reconcile: post-feature-stale hook for %q failed: %v", f.Name, err)
+		}
+	}
+	return true, nil
+}
+
+func featureStalePayload(f *Feature, orchName string) map[string]any {
+	p := map[string]any{
+		"name":         f.Name,
+		"orchestrator": orchName,
+		"project":      f.Project,
+		"branch":       f.Branch,
+		"worktree_dir": f.WorktreeDir,
+		"state":        f.State,
+	}
+	if f.TmuxSession.Valid {
+		p["tmux_session"] = f.TmuxSession.String
+	}
+	if f.BriefPath.Valid {
+		p["brief_path"] = f.BriefPath.String
+	}
+	if f.StaleReason.Valid {
+		p["stale_reason"] = f.StaleReason.String
+	}
+	return map[string]any{"feature": p}
 }
 
 type defaultProber struct{}
 
-func (defaultProber) TmuxSessionExists(name string) (bool, error) {
+// OrchestratorAlive combines the tmux-session and pid signals under an
+// explicit policy: a single live signal is enough to keep the row,
+// unknown signals (empty session name, zero pid) are treated as
+// no-information rather than dead, and the row is only declared dead
+// when every known signal reports dead. Any probe error propagates so
+// the caller skips the row instead of marking it wrongly stale.
+func (defaultProber) OrchestratorAlive(o *Orchestrator) (bool, string, error) {
+	hasTmux := o.TmuxSession.Valid && o.TmuxSession.String != ""
+	hasPID := o.PID.Valid && o.PID.Int64 > 0
+
+	if !hasTmux && !hasPID {
+		return true, "no liveness signal", nil
+	}
+
+	var tmuxDead bool
+	var tmuxReason string
+	if hasTmux {
+		alive, err := tmuxSessionExists(o.TmuxSession.String)
+		if err != nil {
+			return false, "", err
+		}
+		if alive {
+			return true, "", nil
+		}
+		tmuxDead = true
+		tmuxReason = fmt.Sprintf("tmux session %q gone", o.TmuxSession.String)
+	}
+
+	var pidDead bool
+	var pidReason string
+	if hasPID {
+		alive, err := pidAlive(int(o.PID.Int64))
+		if err != nil {
+			return false, "", err
+		}
+		if alive {
+			return true, "", nil
+		}
+		pidDead = true
+		pidReason = fmt.Sprintf("pid %d not alive", o.PID.Int64)
+	}
+
+	switch {
+	case tmuxDead && pidDead:
+		return false, tmuxReason + " and " + pidReason, nil
+	case tmuxDead:
+		return false, tmuxReason, nil
+	case pidDead:
+		return false, pidReason, nil
+	default:
+		return true, "", nil
+	}
+}
+
+// FeatureAlive probes tmux only: the features schema has no pid column.
+// Features with no recorded tmux session have no liveness signal and
+// are left untouched.
+func (defaultProber) FeatureAlive(f *Feature) (bool, string, error) {
+	if !f.TmuxSession.Valid || f.TmuxSession.String == "" {
+		return true, "no liveness signal", nil
+	}
+	alive, err := tmuxSessionExists(f.TmuxSession.String)
+	if err != nil {
+		return false, "", err
+	}
+	if alive {
+		return true, "", nil
+	}
+	return false, fmt.Sprintf("tmux session %q gone", f.TmuxSession.String), nil
+}
+
+// tmuxSessionExists reports whether `tmux has-session -t name` succeeds.
+// A non-zero exit from tmux itself means "session absent" (alive=false,
+// nil err). Any other failure — including tmux missing from PATH —
+// surfaces as a non-nil error so the caller can skip the row instead
+// of wrongly declaring every orchestrator stale.
+func tmuxSessionExists(name string) (bool, error) {
 	if name == "" {
 		return false, nil
 	}
@@ -258,13 +407,14 @@ func (defaultProber) TmuxSessionExists(name string) (bool, error) {
 	if errors.As(err, &ee) {
 		return false, nil
 	}
-	if errors.Is(err, exec.ErrNotFound) {
-		return false, nil
-	}
 	return false, err
 }
 
-func (defaultProber) PidAlive(pid int) (bool, error) {
+// pidAlive reports whether pid is a running, non-zombie process.
+// /proc/<pid>/status is consulted first on Linux; the signal-0 fallback
+// is used elsewhere. EPERM from kill(2) means the process exists but
+// we're not allowed to signal it — the process IS alive.
+func pidAlive(pid int) (bool, error) {
 	if pid <= 0 {
 		return false, nil
 	}
@@ -279,7 +429,7 @@ func (defaultProber) PidAlive(pid int) (bool, error) {
 		return false, nil
 	}
 	if errors.Is(err, syscall.EPERM) {
-		return false, nil
+		return true, nil
 	}
 	return false, err
 }

--- a/internal/lifecycle/reconciler_test.go
+++ b/internal/lifecycle/reconciler_test.go
@@ -2,8 +2,11 @@ package lifecycle
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,31 +14,91 @@ import (
 	"github.com/evanstern/coda/internal/hooks"
 )
 
+// stubProber gives tests per-(name) alive/dead answers for both
+// orchestrators and features, modeling the same signal-combining policy
+// the default prober enforces.
 type stubProber struct {
 	tmuxAlive map[string]bool
 	pidAlive  map[int]bool
 	tmuxErr   error
 	pidErr    error
+	orchErr   error
+	featErr   error
 }
 
-func (s *stubProber) TmuxSessionExists(name string) (bool, error) {
+func (s *stubProber) OrchestratorAlive(o *Orchestrator) (bool, string, error) {
+	if s.orchErr != nil {
+		return false, "", s.orchErr
+	}
+	hasTmux := o.TmuxSession.Valid && o.TmuxSession.String != ""
+	hasPID := o.PID.Valid && o.PID.Int64 > 0
+
+	if !hasTmux && !hasPID {
+		return true, "no liveness signal", nil
+	}
+
+	var tmuxDead bool
+	var tmuxReason string
+	if hasTmux {
+		if s.tmuxErr != nil {
+			return false, "", s.tmuxErr
+		}
+		alive, known := s.tmuxAlive[o.TmuxSession.String]
+		if known && alive {
+			return true, "", nil
+		}
+		if known && !alive {
+			tmuxDead = true
+			tmuxReason = fmt.Sprintf("tmux session %q gone", o.TmuxSession.String)
+		}
+	}
+
+	var pidDead bool
+	var pidReason string
+	if hasPID {
+		if s.pidErr != nil {
+			return false, "", s.pidErr
+		}
+		alive, known := s.pidAlive[int(o.PID.Int64)]
+		if known && alive {
+			return true, "", nil
+		}
+		if known && !alive {
+			pidDead = true
+			pidReason = fmt.Sprintf("pid %d not alive", o.PID.Int64)
+		}
+	}
+
+	switch {
+	case hasTmux && hasPID && tmuxDead && pidDead:
+		return false, tmuxReason + " and " + pidReason, nil
+	case hasTmux && !hasPID && tmuxDead:
+		return false, tmuxReason, nil
+	case hasPID && !hasTmux && pidDead:
+		return false, pidReason, nil
+	default:
+		return true, "", nil
+	}
+}
+
+func (s *stubProber) FeatureAlive(f *Feature) (bool, string, error) {
+	if s.featErr != nil {
+		return false, "", s.featErr
+	}
+	if !f.TmuxSession.Valid || f.TmuxSession.String == "" {
+		return true, "no liveness signal", nil
+	}
 	if s.tmuxErr != nil {
-		return false, s.tmuxErr
+		return false, "", s.tmuxErr
 	}
-	if v, ok := s.tmuxAlive[name]; ok {
-		return v, nil
+	alive, known := s.tmuxAlive[f.TmuxSession.String]
+	if !known {
+		return true, "", nil
 	}
-	return false, nil
-}
-
-func (s *stubProber) PidAlive(pid int) (bool, error) {
-	if s.pidErr != nil {
-		return false, s.pidErr
+	if alive {
+		return true, "", nil
 	}
-	if v, ok := s.pidAlive[pid]; ok {
-		return v, nil
-	}
-	return false, nil
+	return false, fmt.Sprintf("tmux session %q gone", f.TmuxSession.String), nil
 }
 
 func newReconcileManager(t *testing.T) (*Manager, *hooks.Dispatcher) {
@@ -66,7 +129,7 @@ func backdateFeature(t *testing.T, m *Manager, id int64, seconds int64) {
 	}
 }
 
-func TestReconcile_TmuxGoneMarksStale(t *testing.T) {
+func TestReconcile_TmuxGoneWithUnknownPidKeepsAlive(t *testing.T) {
 	m, _ := newReconcileManager(t)
 	ctx := context.Background()
 
@@ -87,6 +150,62 @@ func TestReconcile_TmuxGoneMarksStale(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile: %v", err)
 	}
+	if len(results) != 0 {
+		t.Fatalf("tmux-dead but pid-alive should keep orch alive, got %+v", results)
+	}
+	o, _ := m.GetOrchestrator(ctx, "ash")
+	if o.State != StateRunning {
+		t.Fatalf("state=%s, want running", o.State)
+	}
+}
+
+func TestReconcile_PidDeadButTmuxAliveKeepsAlive(t *testing.T) {
+	m, _ := newReconcileManager(t)
+	ctx := context.Background()
+
+	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 2222); err != nil {
+		t.Fatal(err)
+	}
+	backdateOrchestrator(t, m, "ash", 60)
+
+	m.SetProber(&stubProber{
+		tmuxAlive: map[string]bool{"tmux-ash": true},
+		pidAlive:  map[int]bool{2222: false},
+	})
+
+	results, err := m.Reconcile(ctx, "")
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("pid-dead but tmux-alive should keep orch alive, got %+v", results)
+	}
+}
+
+func TestReconcile_BothDeadMarksStale(t *testing.T) {
+	m, _ := newReconcileManager(t)
+	ctx := context.Background()
+
+	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 1111); err != nil {
+		t.Fatal(err)
+	}
+	backdateOrchestrator(t, m, "ash", 60)
+
+	m.SetProber(&stubProber{
+		tmuxAlive: map[string]bool{"tmux-ash": false},
+		pidAlive:  map[int]bool{1111: false},
+	})
+
+	results, err := m.Reconcile(ctx, "")
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
 	if len(results) != 1 || results[0].NewState != StateStale {
 		t.Fatalf("results=%+v, want one stale", results)
 	}
@@ -95,15 +214,42 @@ func TestReconcile_TmuxGoneMarksStale(t *testing.T) {
 	if o.State != StateStale {
 		t.Fatalf("state=%s, want stale", o.State)
 	}
-	if !o.StaleReason.Valid || !strings.Contains(o.StaleReason.String, "tmux session") {
-		t.Fatalf("stale_reason=%+v, want 'tmux session...'", o.StaleReason)
-	}
-	if !strings.Contains(o.StaleReason.String, "tmux-ash") {
-		t.Fatalf("stale_reason=%q missing session name", o.StaleReason.String)
+	if !o.StaleReason.Valid ||
+		!strings.Contains(o.StaleReason.String, "tmux session") ||
+		!strings.Contains(o.StaleReason.String, "pid 1111") {
+		t.Fatalf("stale_reason=%+v, want combined tmux+pid reason", o.StaleReason)
 	}
 }
 
-func TestReconcile_PidGoneMarksStale(t *testing.T) {
+func TestReconcile_TmuxOnlyDead(t *testing.T) {
+	m, _ := newReconcileManager(t)
+	ctx := context.Background()
+
+	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 0); err != nil {
+		t.Fatal(err)
+	}
+	backdateOrchestrator(t, m, "ash", 60)
+
+	m.SetProber(&stubProber{
+		tmuxAlive: map[string]bool{"tmux-ash": false},
+	})
+
+	results, err := m.Reconcile(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results=%+v, want 1", results)
+	}
+	if !strings.Contains(results[0].StaleReason, "tmux-ash") {
+		t.Fatalf("reason=%q missing session name", results[0].StaleReason)
+	}
+}
+
+func TestReconcile_PidOnlyDead(t *testing.T) {
 	m, _ := newReconcileManager(t)
 	ctx := context.Background()
 
@@ -121,18 +267,65 @@ func TestReconcile_PidGoneMarksStale(t *testing.T) {
 
 	results, err := m.Reconcile(ctx, "")
 	if err != nil {
-		t.Fatalf("reconcile: %v", err)
+		t.Fatal(err)
 	}
 	if len(results) != 1 {
 		t.Fatalf("results=%+v, want 1", results)
 	}
-
-	o, _ := m.GetOrchestrator(ctx, "ash")
-	if o.State != StateStale {
-		t.Fatalf("state=%s, want stale", o.State)
+	if !strings.Contains(results[0].StaleReason, "pid 2222") {
+		t.Fatalf("reason=%q missing pid", results[0].StaleReason)
 	}
-	if !strings.Contains(o.StaleReason.String, "pid 2222") {
-		t.Fatalf("stale_reason=%q missing pid", o.StaleReason.String)
+}
+
+func TestReconcile_NoSignalsSkipped(t *testing.T) {
+	m, _ := newReconcileManager(t)
+	ctx := context.Background()
+
+	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.StartOrchestrator(ctx, "ash", "", 0, 0); err != nil {
+		t.Fatal(err)
+	}
+	backdateOrchestrator(t, m, "ash", 60)
+
+	m.SetProber(&stubProber{})
+	results, err := m.Reconcile(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("row with no liveness signal must not be marked stale: %+v", results)
+	}
+	o, _ := m.GetOrchestrator(ctx, "ash")
+	if o.State != StateRunning {
+		t.Fatalf("state=%s, want running", o.State)
+	}
+}
+
+func TestReconcile_ProbeErrorSkipsRow(t *testing.T) {
+	m, _ := newReconcileManager(t)
+	ctx := context.Background()
+
+	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 3333); err != nil {
+		t.Fatal(err)
+	}
+	backdateOrchestrator(t, m, "ash", 60)
+
+	m.SetProber(&stubProber{orchErr: errors.New("tmux missing")})
+	results, err := m.Reconcile(ctx, "")
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("probe error must skip row, got %+v", results)
+	}
+	o, _ := m.GetOrchestrator(ctx, "ash")
+	if o.State != StateRunning {
+		t.Fatalf("state=%s, want running (probe error must not mark stale)", o.State)
 	}
 }
 
@@ -209,6 +402,7 @@ func TestReconcile_StaleRowIsIdempotent(t *testing.T) {
 
 	m.SetProber(&stubProber{
 		tmuxAlive: map[string]bool{"tmux-ash": false},
+		pidAlive:  map[int]bool{5555: false},
 	})
 	if _, err := m.Reconcile(ctx, ""); err != nil {
 		t.Fatal(err)
@@ -224,7 +418,50 @@ func TestReconcile_StaleRowIsIdempotent(t *testing.T) {
 	}
 }
 
-func TestReconcile_FeatureMarkedFailed(t *testing.T) {
+func TestReconcile_ConcurrentStartWinsOverReconcile(t *testing.T) {
+	m, _ := newReconcileManager(t)
+	ctx := context.Background()
+
+	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 9999); err != nil {
+		t.Fatal(err)
+	}
+	backdateOrchestrator(t, m, "ash", 60)
+
+	o, _ := m.GetOrchestrator(ctx, "ash")
+	origUpdated := o.UpdatedAt
+
+	now := m.Now().Unix()
+	if now <= origUpdated {
+		now = origUpdated + 1
+	}
+	if _, err := m.DB.ExecContext(ctx,
+		`UPDATE orchestrators SET state=?, tmux_session=?, pid=?, updated_at=? WHERE name=?`,
+		StateRunning, "tmux-ash-restarted", 8888, now, "ash"); err != nil {
+		t.Fatal(err)
+	}
+
+	m.SetProber(&stubProber{
+		tmuxAlive: map[string]bool{"tmux-ash": false, "tmux-ash-restarted": true},
+		pidAlive:  map[int]bool{9999: false, 8888: true},
+	})
+
+	results, err := m.Reconcile(ctx, "")
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("concurrent restart should win; got %+v", results)
+	}
+	o2, _ := m.GetOrchestrator(ctx, "ash")
+	if o2.State != StateRunning {
+		t.Fatalf("state=%s, want running (post-restart row must not be clobbered)", o2.State)
+	}
+}
+
+func TestReconcile_FeatureMarkedStale(t *testing.T) {
 	m, _ := newReconcileManager(t)
 	ctx := context.Background()
 
@@ -253,20 +490,20 @@ func TestReconcile_FeatureMarkedFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile: %v", err)
 	}
-	if len(results) != 1 || results[0].Kind != "feature" || results[0].NewState != StateFailed {
-		t.Fatalf("results=%+v, want one failed feature", results)
+	if len(results) != 1 || results[0].Kind != "feature" || results[0].NewState != StateStale {
+		t.Fatalf("results=%+v, want one stale feature", results)
 	}
 
 	f2, _ := m.GetFeature(ctx, "ash", "feat-x")
-	if f2.State != StateFailed {
-		t.Fatalf("state=%s, want failed", f2.State)
+	if f2.State != StateStale {
+		t.Fatalf("state=%s, want stale", f2.State)
 	}
 	if !f2.StaleReason.Valid || !strings.Contains(f2.StaleReason.String, "tmux session") {
 		t.Fatalf("stale_reason=%+v", f2.StaleReason)
 	}
 }
 
-func TestReconcile_FiresHook(t *testing.T) {
+func TestReconcile_FiresOrchestratorStaleHook(t *testing.T) {
 	home := t.TempDir()
 	d, err := db.Open(filepath.Join(home, "coda.db"))
 	if err != nil {
@@ -288,20 +525,115 @@ func TestReconcile_FiresHook(t *testing.T) {
 
 	m.SetProber(&stubProber{
 		tmuxAlive: map[string]bool{"tmux-ash": false},
+		pidAlive:  map[int]bool{6666: false},
 	})
 	if _, err := m.Reconcile(ctx, ""); err != nil {
 		t.Fatal(err)
 	}
 
-	found := false
-	for _, e := range spy.events {
-		if e == hooks.EventPostOrchestratorStale {
-			found = true
-			break
+	if !spy.sawEvent(hooks.EventPostOrchestratorStale) {
+		t.Fatalf("post-orchestrator-stale not fired; saw %v", spy.events)
+	}
+}
+
+func TestReconcile_FiresFeatureStaleHook(t *testing.T) {
+	home := t.TempDir()
+	d, err := db.Open(filepath.Join(home, "coda.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	spy := &spyDispatcher{}
+	m := New(d, spy)
+
+	ctx := context.Background()
+	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
+		t.Fatal(err)
+	}
+	f, err := m.SpawnFeature(ctx, SpawnFeatureInput{
+		OrchestratorName: "ash",
+		Project:          "coda",
+		Branch:           "feat-x",
+		WorktreeDir:      "/tmp/x",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.DB.Exec(`UPDATE features SET tmux_session=? WHERE id=?`, "coda-feat-x", f.ID); err != nil {
+		t.Fatal(err)
+	}
+	backdateFeature(t, m, f.ID, 60)
+
+	m.SetProber(&stubProber{
+		tmuxAlive: map[string]bool{"coda-feat-x": false},
+	})
+	if _, err := m.Reconcile(ctx, ""); err != nil {
+		t.Fatal(err)
+	}
+	if !spy.sawEvent(hooks.EventPostFeatureStale) {
+		t.Fatalf("post-feature-stale not fired; saw %v", spy.events)
+	}
+}
+
+// failingHookDispatcher returns an error for the first EventPostOrchestratorStale
+// call, and records every event seen.
+type failingHookDispatcher struct {
+	events   []hooks.Event
+	failOnce atomic.Bool
+}
+
+func (f *failingHookDispatcher) Fire(ctx context.Context, event hooks.Event, payload map[string]any) error {
+	f.events = append(f.events, event)
+	if event == hooks.EventPostOrchestratorStale && f.failOnce.CompareAndSwap(false, true) {
+		return errors.New("injected hook failure")
+	}
+	return nil
+}
+
+func TestReconcile_HookFailureDoesNotAbortLoop(t *testing.T) {
+	home := t.TempDir()
+	d, err := db.Open(filepath.Join(home, "coda.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	disp := &failingHookDispatcher{}
+	m := New(d, disp)
+
+	ctx := context.Background()
+	for _, n := range []string{"ash", "beth"} {
+		if _, err := m.CreateOrchestrator(ctx, n, "/tmp/"+n); err != nil {
+			t.Fatal(err)
 		}
 	}
-	if !found {
-		t.Fatalf("post-orchestrator-stale not fired; saw %v", spy.events)
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 1111); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.StartOrchestrator(ctx, "beth", "tmux-beth", 4097, 2222); err != nil {
+		t.Fatal(err)
+	}
+	backdateOrchestrator(t, m, "ash", 60)
+	backdateOrchestrator(t, m, "beth", 60)
+
+	m.SetProber(&stubProber{
+		tmuxAlive: map[string]bool{"tmux-ash": false, "tmux-beth": false},
+		pidAlive:  map[int]bool{1111: false, 2222: false},
+	})
+
+	results, err := m.Reconcile(ctx, "")
+	if err != nil {
+		t.Fatalf("reconcile must not surface hook failures: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("hook failure on first orch must not abort loop; got %d results", len(results))
+	}
+	for _, n := range []string{"ash", "beth"} {
+		o, _ := m.GetOrchestrator(ctx, n)
+		if o.State != StateStale {
+			t.Fatalf("%s state=%s, want stale", n, o.State)
+		}
 	}
 }
 
@@ -319,6 +651,7 @@ func TestStartOrchestrator_FromStale(t *testing.T) {
 
 	m.SetProber(&stubProber{
 		tmuxAlive: map[string]bool{"tmux-ash": false},
+		pidAlive:  map[int]bool{7777: false},
 	})
 	if _, err := m.Reconcile(ctx, ""); err != nil {
 		t.Fatal(err)

--- a/internal/lifecycle/reconciler_test.go
+++ b/internal/lifecycle/reconciler_test.go
@@ -1,0 +1,342 @@
+package lifecycle
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/evanstern/coda/internal/db"
+	"github.com/evanstern/coda/internal/hooks"
+)
+
+type stubProber struct {
+	tmuxAlive map[string]bool
+	pidAlive  map[int]bool
+	tmuxErr   error
+	pidErr    error
+}
+
+func (s *stubProber) TmuxSessionExists(name string) (bool, error) {
+	if s.tmuxErr != nil {
+		return false, s.tmuxErr
+	}
+	if v, ok := s.tmuxAlive[name]; ok {
+		return v, nil
+	}
+	return false, nil
+}
+
+func (s *stubProber) PidAlive(pid int) (bool, error) {
+	if s.pidErr != nil {
+		return false, s.pidErr
+	}
+	if v, ok := s.pidAlive[pid]; ok {
+		return v, nil
+	}
+	return false, nil
+}
+
+func newReconcileManager(t *testing.T) (*Manager, *hooks.Dispatcher) {
+	t.Helper()
+	home := t.TempDir()
+	d, err := db.Open(filepath.Join(home, "coda.db"))
+	if err != nil {
+		t.Fatalf("db open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	disp := hooks.New(d, home)
+	return New(d, disp), disp
+}
+
+func backdateOrchestrator(t *testing.T, m *Manager, name string, seconds int64) {
+	t.Helper()
+	newTs := m.Now().Add(-time.Duration(seconds) * time.Second).Unix()
+	if _, err := m.DB.Exec(`UPDATE orchestrators SET updated_at=? WHERE name=?`, newTs, name); err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+}
+
+func backdateFeature(t *testing.T, m *Manager, id int64, seconds int64) {
+	t.Helper()
+	newTs := m.Now().Add(-time.Duration(seconds) * time.Second).Unix()
+	if _, err := m.DB.Exec(`UPDATE features SET updated_at=? WHERE id=?`, newTs, id); err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+}
+
+func TestReconcile_TmuxGoneMarksStale(t *testing.T) {
+	m, _ := newReconcileManager(t)
+	ctx := context.Background()
+
+	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 1111); err != nil {
+		t.Fatal(err)
+	}
+	backdateOrchestrator(t, m, "ash", 60)
+
+	m.SetProber(&stubProber{
+		tmuxAlive: map[string]bool{"tmux-ash": false},
+		pidAlive:  map[int]bool{1111: true},
+	})
+
+	results, err := m.Reconcile(ctx, "")
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(results) != 1 || results[0].NewState != StateStale {
+		t.Fatalf("results=%+v, want one stale", results)
+	}
+
+	o, _ := m.GetOrchestrator(ctx, "ash")
+	if o.State != StateStale {
+		t.Fatalf("state=%s, want stale", o.State)
+	}
+	if !o.StaleReason.Valid || !strings.Contains(o.StaleReason.String, "tmux session") {
+		t.Fatalf("stale_reason=%+v, want 'tmux session...'", o.StaleReason)
+	}
+	if !strings.Contains(o.StaleReason.String, "tmux-ash") {
+		t.Fatalf("stale_reason=%q missing session name", o.StaleReason.String)
+	}
+}
+
+func TestReconcile_PidGoneMarksStale(t *testing.T) {
+	m, _ := newReconcileManager(t)
+	ctx := context.Background()
+
+	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.StartOrchestrator(ctx, "ash", "", 4096, 2222); err != nil {
+		t.Fatal(err)
+	}
+	backdateOrchestrator(t, m, "ash", 60)
+
+	m.SetProber(&stubProber{
+		pidAlive: map[int]bool{2222: false},
+	})
+
+	results, err := m.Reconcile(ctx, "")
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results=%+v, want 1", results)
+	}
+
+	o, _ := m.GetOrchestrator(ctx, "ash")
+	if o.State != StateStale {
+		t.Fatalf("state=%s, want stale", o.State)
+	}
+	if !strings.Contains(o.StaleReason.String, "pid 2222") {
+		t.Fatalf("stale_reason=%q missing pid", o.StaleReason.String)
+	}
+}
+
+func TestReconcile_BothAliveNoOp(t *testing.T) {
+	m, _ := newReconcileManager(t)
+	ctx := context.Background()
+
+	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 3333); err != nil {
+		t.Fatal(err)
+	}
+	backdateOrchestrator(t, m, "ash", 60)
+
+	m.SetProber(&stubProber{
+		tmuxAlive: map[string]bool{"tmux-ash": true},
+		pidAlive:  map[int]bool{3333: true},
+	})
+
+	results, err := m.Reconcile(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("results=%+v, want none", results)
+	}
+	o, _ := m.GetOrchestrator(ctx, "ash")
+	if o.State != StateRunning {
+		t.Fatalf("state=%s, want running", o.State)
+	}
+}
+
+func TestReconcile_RespectsFreshnessWindow(t *testing.T) {
+	m, _ := newReconcileManager(t)
+	ctx := context.Background()
+
+	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 4444); err != nil {
+		t.Fatal(err)
+	}
+
+	m.SetProber(&stubProber{
+		tmuxAlive: map[string]bool{"tmux-ash": false},
+		pidAlive:  map[int]bool{4444: false},
+	})
+
+	results, err := m.Reconcile(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("fresh row was reconciled: %+v", results)
+	}
+	o, _ := m.GetOrchestrator(ctx, "ash")
+	if o.State != StateRunning {
+		t.Fatalf("state=%s, want running (inside freshness window)", o.State)
+	}
+}
+
+func TestReconcile_StaleRowIsIdempotent(t *testing.T) {
+	m, _ := newReconcileManager(t)
+	ctx := context.Background()
+
+	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 5555); err != nil {
+		t.Fatal(err)
+	}
+	backdateOrchestrator(t, m, "ash", 60)
+
+	m.SetProber(&stubProber{
+		tmuxAlive: map[string]bool{"tmux-ash": false},
+	})
+	if _, err := m.Reconcile(ctx, ""); err != nil {
+		t.Fatal(err)
+	}
+	backdateOrchestrator(t, m, "ash", 60)
+
+	results, err := m.Reconcile(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("second reconcile produced results: %+v", results)
+	}
+}
+
+func TestReconcile_FeatureMarkedFailed(t *testing.T) {
+	m, _ := newReconcileManager(t)
+	ctx := context.Background()
+
+	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
+		t.Fatal(err)
+	}
+	f, err := m.SpawnFeature(ctx, SpawnFeatureInput{
+		OrchestratorName: "ash",
+		Project:          "coda",
+		Branch:           "feat-x",
+		WorktreeDir:      "/tmp/x",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.DB.Exec(`UPDATE features SET tmux_session=? WHERE id=?`, "coda-feat-x", f.ID); err != nil {
+		t.Fatal(err)
+	}
+	backdateFeature(t, m, f.ID, 60)
+
+	m.SetProber(&stubProber{
+		tmuxAlive: map[string]bool{"coda-feat-x": false},
+	})
+
+	results, err := m.Reconcile(ctx, "")
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(results) != 1 || results[0].Kind != "feature" || results[0].NewState != StateFailed {
+		t.Fatalf("results=%+v, want one failed feature", results)
+	}
+
+	f2, _ := m.GetFeature(ctx, "ash", "feat-x")
+	if f2.State != StateFailed {
+		t.Fatalf("state=%s, want failed", f2.State)
+	}
+	if !f2.StaleReason.Valid || !strings.Contains(f2.StaleReason.String, "tmux session") {
+		t.Fatalf("stale_reason=%+v", f2.StaleReason)
+	}
+}
+
+func TestReconcile_FiresHook(t *testing.T) {
+	home := t.TempDir()
+	d, err := db.Open(filepath.Join(home, "coda.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	spy := &spyDispatcher{}
+	m := New(d, spy)
+
+	ctx := context.Background()
+	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 6666); err != nil {
+		t.Fatal(err)
+	}
+	backdateOrchestrator(t, m, "ash", 60)
+
+	m.SetProber(&stubProber{
+		tmuxAlive: map[string]bool{"tmux-ash": false},
+	})
+	if _, err := m.Reconcile(ctx, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, e := range spy.events {
+		if e == hooks.EventPostOrchestratorStale {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("post-orchestrator-stale not fired; saw %v", spy.events)
+	}
+}
+
+func TestStartOrchestrator_FromStale(t *testing.T) {
+	m, _ := newReconcileManager(t)
+	ctx := context.Background()
+
+	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 7777); err != nil {
+		t.Fatal(err)
+	}
+	backdateOrchestrator(t, m, "ash", 60)
+
+	m.SetProber(&stubProber{
+		tmuxAlive: map[string]bool{"tmux-ash": false},
+	})
+	if _, err := m.Reconcile(ctx, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	o, _ := m.GetOrchestrator(ctx, "ash")
+	if o.State != StateStale {
+		t.Fatalf("precondition: state=%s, want stale", o.State)
+	}
+
+	o2, err := m.StartOrchestrator(ctx, "ash", "tmux-ash-2", 4097, 8888)
+	if err != nil {
+		t.Fatalf("start from stale: %v", err)
+	}
+	if o2.State != StateRunning {
+		t.Fatalf("state=%s, want running", o2.State)
+	}
+	if o2.StaleReason.Valid {
+		t.Fatalf("stale_reason not cleared: %+v", o2.StaleReason)
+	}
+}

--- a/test/v2-lifecycle.bats
+++ b/test/v2-lifecycle.bats
@@ -155,6 +155,60 @@ SENTINEL
     [[ "$output" != *"UNEXPECTED_CODA_CORE_INVOCATION"* ]]
 }
 
+@test "v2: orchestrator reconcile on empty DB prints 'no rows'" {
+    run "$CODA_CORE_BIN" orchestrator reconcile
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no rows transitioned"* ]]
+}
+
+backdate_orch() {
+    command -v sqlite3 >/dev/null || skip "sqlite3 CLI not installed"
+    sqlite3 "$CODA_HOME/coda.db" "UPDATE orchestrators SET updated_at = updated_at - 120 WHERE name='$1';"
+}
+
+@test "v2: reconcile flips a running row to stale when tmux session gone" {
+    "$CODA_CORE_BIN" orchestrator new zeta --config-dir /tmp/zeta
+    "$CODA_CORE_BIN" orchestrator start zeta --tmux-session coda-orch--zeta-ghost --pid 999999
+    backdate_orch zeta
+
+    run "$CODA_CORE_BIN" orchestrator reconcile
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]]
+
+    run "$CODA_CORE_BIN" orchestrator ls
+    [[ "$output" == *"stale"* ]]
+}
+
+@test "v2: CODA_NO_AUTO_RECONCILE=1 disables lazy reconcile on ls" {
+    "$CODA_CORE_BIN" orchestrator new lazy --config-dir /tmp/lazy
+    "$CODA_CORE_BIN" orchestrator start lazy --tmux-session coda-orch--lazy-ghost --pid 999998
+    backdate_orch lazy
+
+    CODA_NO_AUTO_RECONCILE=1 run "$CODA_CORE_BIN" orchestrator ls
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"running"* ]]
+    [[ "$output" != *"stale"* ]]
+
+    run "$CODA_CORE_BIN" orchestrator ls
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]]
+}
+
+@test "v2: start from stale succeeds and clears stale_reason" {
+    "$CODA_CORE_BIN" orchestrator new restart --config-dir /tmp/restart
+    "$CODA_CORE_BIN" orchestrator start restart --tmux-session coda-orch--restart-ghost --pid 999997
+    backdate_orch restart
+    "$CODA_CORE_BIN" orchestrator reconcile >/dev/null
+
+    run "$CODA_CORE_BIN" orchestrator start restart --tmux-session coda-orch--restart --pid 1234
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"running"* ]]
+
+    run "$CODA_CORE_BIN" orchestrator ls --json
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"stale_reason"* ]]
+}
+
 @test "v2 routing: bash coda feature spawn routes to coda-core" {
     "$CODA_CORE_BIN" orchestrator new spawner --config-dir /tmp/x
 


### PR DESCRIPTION
## Summary

Adds the reconciler layer that detects stale lifecycle rows and transitions them to a terminal state before downstream consumers (e.g. #149's message bus) read from the state store. Closes #155.

Before this card, #148's lifecycle writes \`state=running\` with a pid and tmux_session but nothing verifies those processes still exist. If a user \`tmux kill-session\`s the orchestrator or opencode crashes, the row stays \`running\` forever, and #149's message bus would queue messages against tombstoned rows with no observable failure. The reconciler closes that gap.

## What's in the box

- **Schema migration \`002_reconciler.sql\`** — extends \`orchestrators.state\` CHECK to include \`stale\` via the table-swap pattern (SQLite can't alter CHECK constraints in place) and adds \`stale_reason TEXT\` to both \`orchestrators\` and \`features\`. Second exercise of the #156 migration infrastructure. Schema version bumps from 1 to 2.
- **\`internal/lifecycle/reconciler.go\`** — \`Manager.Reconcile(ctx, name)\`, a public \`Prober\` interface, and a default tmux/pid prober. Orchestrators in \`starting|running|stopping\` are probed against \`tmux has-session\` and pid liveness (Linux \`/proc\` with signal-0 fallback, zombie-aware). Features in \`spawning|running|reporting\` are probed against their tmux session only (session_id liveness is deferred to #149 per brief §5.1). A 30-second freshness window protects in-flight \`StartOrchestrator\` from being false-marked.
- **\`StartOrchestrator\` guard widened** — now accepts \`state IN ('stopped','stale')\` and clears \`stale_reason\` on forward transition, so operators restart a stale orch without hand-editing the DB.
- **Hook event \`post-orchestrator-stale\`** — fires after each orchestrator → stale transition, payload follows existing orchestrator hook schema with \`stale_reason\` included.
- **CLI: \`coda-core orchestrator reconcile [<name>] [--json]\`** — explicit reconcile command. Exit codes 0/1/2; reconcile never emits exit 3 (not a lifecycle-blocked event, per brief §3.6).
- **Lazy reconcile** on \`orchestrator ls\` and \`status\` unless \`CODA_NO_AUTO_RECONCILE=1\`. Silent on this path — no stderr noise per brief §5.8.
- **Tests** — \`internal/lifecycle/reconciler_test.go\` covers tmux-dead, pid-dead, both-alive, freshness-window, idempotent-stale, feature-failed, hook-fires (spy dispatcher pattern from \`ordering_test.go\`), and start-from-stale using a stub \`Prober\`. \`test/v2-lifecycle.bats\` extended with reconcile CLI, \`CODA_NO_AUTO_RECONCILE\`, and start-from-stale integration tests (backdate via \`sqlite3\` CLI with auto-skip when not installed).
- **Docs** — \`docs/v2-lifecycle.md\` gains a Reconciliation section; \`.env.example\` documents \`CODA_NO_AUTO_RECONCILE\`.

## Test results

- \`go test ./...\` — all green (6 packages).
- \`bash tests/run.sh\` — all green.
- \`bats test/\` — 17/17 green in \`v2-lifecycle.bats\`. 3 pre-existing failures on \`main\` (\`tmux-integration.bats\` env-dependent plus card120 edge case) are unrelated to this card; verified they fail identically on \`origin/main\` before any change.

## Brief-vs-reality gaps

- The brief §3.3 specified \`Reconcile\` returning \`(int, error)\` but §3.6 specified the CLI emitting \`[]ReconcileResult\` JSON. Those are incompatible; I chose \`([]ReconcileResult, error)\` so the CLI can forward structured results without a second DB query. The int count is recoverable as \`len(results)\`.
- The brief §8 called the schema bump \"v3\" in prose but the SQL in §3.1 inserts \`schema_version = 2\`. I followed the SQL (migration file \`002\` → version 2), which is also what \`internal/db/migrations\` expects (numbered files must be contiguous starting at 1).
- The brief §3.1's \`INSERT … SELECT\` column list did not exactly match the #156-shipped \`001_init.sql\` order (it listed \`session_id\` before \`tmux_session\`; the actual schema is the reverse). Migration uses the real column order.

## Scope discipline

Nothing touched outside \`internal/db/\`, \`internal/lifecycle/\`, \`internal/hooks/\`, \`cmd/coda-core/\`, \`docs/\`, \`.env.example\`, \`test/v2-lifecycle.bats\`. No new features beyond brief §3.

Closes #155.