### PR TITLE
feat(#149): v2 typed message bus

### DIFF
--- a/cmd/coda-core/lifecycle_cmd.go
+++ b/cmd/coda-core/lifecycle_cmd.go
@@ -18,6 +18,7 @@ import (
 	"github.com/evanstern/coda/internal/db"
 	"github.com/evanstern/coda/internal/hooks"
 	"github.com/evanstern/coda/internal/lifecycle"
+	"github.com/evanstern/coda/internal/messages"
 )
 
 const defaultLazyReconcileIntervalSecs = 10
@@ -131,11 +132,26 @@ func runStatus(args []string) error {
 	if err != nil {
 		return dbError(err)
 	}
+	msgMgr := messages.New(d, nil, nil)
+	unacked, err := msgMgr.UnackedCounts(ctx)
+	if err != nil {
+		return dbError(err)
+	}
+
+	orchNames := make([]string, 0, len(orchs))
+	for _, o := range orchs {
+		orchNames = append(orchNames, o.Name)
+	}
 
 	if *asJSON {
+		unackedJSON := make(map[string]int, len(orchNames))
+		for _, name := range orchNames {
+			unackedJSON[name] = unacked[name]
+		}
 		out := map[string]any{
 			"orchestrators": orchsToJSON(orchs),
 			"features":      featuresToJSON(feats),
+			"unacked":       unackedJSON,
 		}
 		return writeJSON(os.Stdout, out)
 	}
@@ -143,6 +159,8 @@ func runStatus(args []string) error {
 	printOrchTable(os.Stdout, orchs)
 	fmt.Fprintln(os.Stdout)
 	printFeatureTable(os.Stdout, feats)
+	fmt.Fprintln(os.Stdout)
+	printUnackedTable(os.Stdout, orchNames, unacked)
 	return nil
 }
 

--- a/cmd/coda-core/lifecycle_cmd.go
+++ b/cmd/coda-core/lifecycle_cmd.go
@@ -159,8 +159,17 @@ func runStatus(args []string) error {
 	printOrchTable(os.Stdout, orchs)
 	fmt.Fprintln(os.Stdout)
 	printFeatureTable(os.Stdout, feats)
-	fmt.Fprintln(os.Stdout)
-	printUnackedTable(os.Stdout, orchNames, unacked)
+	hasUnacked := false
+	for _, o := range orchs {
+		if unacked[o.Name] > 0 {
+			hasUnacked = true
+			break
+		}
+	}
+	if hasUnacked {
+		fmt.Fprintln(os.Stdout)
+		printUnackedTable(os.Stdout, orchNames, unacked)
+	}
 	return nil
 }
 

--- a/cmd/coda-core/main.go
+++ b/cmd/coda-core/main.go
@@ -28,6 +28,14 @@ func main() {
 		err = runFeature(os.Args[2:])
 	case "status":
 		err = runStatus(os.Args[2:])
+	case "send":
+		err = runSend(os.Args[2:])
+	case "recv":
+		err = runRecv(os.Args[2:])
+	case "ack":
+		err = runAck(os.Args[2:])
+	case "drain":
+		err = runDrain(os.Args[2:])
 	case "version", "--version", "-V":
 		err = runVersion(os.Args[2:])
 	case "help", "--help", "-h":
@@ -74,5 +82,11 @@ v2 lifecycle (SQLite-backed):
   feature attach       Mark feature running
   feature finish       Mark feature done (fires pre-feature-teardown)
   status               Combined orchestrator + feature status
-  version              Print version + resolved CODA_HOME / DB`)
+  version              Print version + resolved CODA_HOME / DB
+
+Messages:
+  send     Send a typed message (writes row, attempts delivery)
+  recv     List messages for a recipient
+  ack      Mark a message as acted-upon
+  drain    Flush undelivered messages for a recipient`)
 }

--- a/cmd/coda-core/messages_cmd.go
+++ b/cmd/coda-core/messages_cmd.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/evanstern/coda/internal/db"
+	"github.com/evanstern/coda/internal/messages"
+)
+
+func openMessages() (*sql.DB, *messages.Manager, error) {
+	path, err := db.DefaultPath()
+	if err != nil {
+		return nil, nil, err
+	}
+	d, err := db.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	m := messages.New(d, messages.NewHTTPTransport(), &messages.DBOrchLookup{DB: d})
+	return d, m, nil
+}
+
+func runSend(args []string) error {
+	fs := flag.NewFlagSet("send", flag.ContinueOnError)
+	from := fs.String("from", os.Getenv("USER"), "sender name")
+	to := fs.String("to", "", "recipient orchestrator name (required)")
+	typ := fs.String("type", "", "message type (required)")
+	body := fs.String("body", "", "inline JSON body")
+	bodyFile := fs.String("body-file", "", "read JSON body from file")
+	parentID := fs.Int64("parent-id", 0, "thread reply target (optional)")
+	if err := parseInterleaved(fs, args); err != nil {
+		return userError("%v", err)
+	}
+	if *to == "" || *typ == "" {
+		return userError("usage: coda-core send --from <name> --to <name> --type <type> --body <json>")
+	}
+	if *body == "" && *bodyFile == "" {
+		return userError("either --body or --body-file is required")
+	}
+	if *body != "" && *bodyFile != "" {
+		return userError("--body and --body-file are mutually exclusive")
+	}
+	bodyText := *body
+	if *bodyFile != "" {
+		b, err := os.ReadFile(*bodyFile)
+		if err != nil {
+			return userError("read body file: %v", err)
+		}
+		bodyText = string(b)
+	}
+
+	d, mgr, err := openMessages()
+	if err != nil {
+		return dbError(err)
+	}
+	defer d.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	msg, err := mgr.Send(ctx, *from, *to, messages.Type(*typ), bodyText, *parentID)
+	if err != nil {
+		if errors.Is(err, messages.ErrInvalidType) ||
+			errors.Is(err, messages.ErrInvalidBody) ||
+			errors.Is(err, messages.ErrNotFound) {
+			return userError("%v", err)
+		}
+		return dbError(err)
+	}
+	fmt.Printf("sent message id=%d delivered=%v\n", msg.ID, msg.DeliveredAt.Valid)
+	return nil
+}
+
+func runRecv(args []string) error {
+	fs := flag.NewFlagSet("recv", flag.ContinueOnError)
+	recipient := fs.String("recipient", "", "recipient name (required)")
+	unacked := fs.Bool("unacked", false, "only show unacked")
+	sinceID := fs.Int64("since-id", 0, "only show id > since-id")
+	limit := fs.Int("limit", 0, "max rows (default 50)")
+	asJSON := fs.Bool("json", false, "emit JSON")
+	if err := parseInterleaved(fs, args); err != nil {
+		return userError("%v", err)
+	}
+	if *recipient == "" {
+		return userError("usage: coda-core recv --recipient <name> [--unacked] [--since-id N] [--limit N] [--json]")
+	}
+	d, mgr, err := openMessages()
+	if err != nil {
+		return dbError(err)
+	}
+	defer d.Close()
+
+	msgs, err := mgr.Recv(context.Background(), *recipient, *unacked, *sinceID, *limit)
+	if err != nil {
+		return dbError(err)
+	}
+	if *asJSON {
+		return writeJSON(os.Stdout, messagesToJSON(msgs))
+	}
+	printMessagesTable(os.Stdout, msgs)
+	return nil
+}
+
+func runAck(args []string) error {
+	if len(args) != 1 {
+		return userError("usage: coda-core ack <id>")
+	}
+	id, err := strconv.ParseInt(args[0], 10, 64)
+	if err != nil {
+		return userError("invalid id %q: %v", args[0], err)
+	}
+	d, mgr, err := openMessages()
+	if err != nil {
+		return dbError(err)
+	}
+	defer d.Close()
+
+	if err := mgr.Ack(context.Background(), id); err != nil {
+		if errors.Is(err, messages.ErrNotFound) {
+			return userError("%v", err)
+		}
+		return dbError(err)
+	}
+	fmt.Printf("acked %d\n", id)
+	return nil
+}
+
+func runDrain(args []string) error {
+	fs := flag.NewFlagSet("drain", flag.ContinueOnError)
+	recipient := fs.String("recipient", "", "recipient name (required)")
+	if err := parseInterleaved(fs, args); err != nil {
+		return userError("%v", err)
+	}
+	if *recipient == "" {
+		return userError("usage: coda-core drain --recipient <name>")
+	}
+
+	d, mgr, err := openMessages()
+	if err != nil {
+		return dbError(err)
+	}
+	defer d.Close()
+
+	var pending int
+	if err := d.QueryRow(
+		`SELECT COUNT(*) FROM messages WHERE recipient=? AND delivered_at IS NULL`,
+		*recipient).Scan(&pending); err != nil {
+		return dbError(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	n, err := mgr.Drain(ctx, *recipient)
+	if err != nil {
+		return dbError(err)
+	}
+	fmt.Printf("drained %d of %d messages\n", n, pending)
+	return nil
+}
+
+func messagesToJSON(msgs []*messages.Message) []map[string]any {
+	out := make([]map[string]any, 0, len(msgs))
+	for _, msg := range msgs {
+		m := map[string]any{
+			"id":         msg.ID,
+			"sender":     msg.Sender,
+			"recipient":  msg.Recipient,
+			"type":       string(msg.Type),
+			"body":       json.RawMessage(msg.Body),
+			"created_at": msg.CreatedAt,
+		}
+		if msg.ParentID.Valid {
+			m["parent_id"] = msg.ParentID.Int64
+		}
+		if msg.DeliveredAt.Valid {
+			m["delivered_at"] = msg.DeliveredAt.Int64
+		}
+		if msg.AckedAt.Valid {
+			m["acked_at"] = msg.AckedAt.Int64
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func printMessagesTable(w io.Writer, msgs []*messages.Message) {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tFROM\tTYPE\tCREATED\tDELIVERED\tACKED\tPREVIEW")
+	for _, msg := range msgs {
+		fmt.Fprintf(tw, "%d\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			msg.ID, msg.Sender, msg.Type,
+			time.Unix(msg.CreatedAt, 0).UTC().Format(time.RFC3339),
+			yesNo(msg.DeliveredAt.Valid), yesNo(msg.AckedAt.Valid),
+			previewBody(msg.Body))
+	}
+	if len(msgs) == 0 {
+		fmt.Fprintln(tw, "(no messages)")
+	}
+	tw.Flush()
+}
+
+func yesNo(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}
+
+func previewBody(body string) string {
+	flat := strings.ReplaceAll(body, "\n", " ")
+	flat = strings.ReplaceAll(flat, "\t", " ")
+	const max = 60
+	if len(flat) > max {
+		return flat[:max] + "…"
+	}
+	return flat
+}
+
+func printUnackedTable(w io.Writer, orchs []string, unacked map[string]int) {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "RECIPIENT\tUNACKED")
+	for _, name := range orchs {
+		fmt.Fprintf(tw, "%s\t%d\n", name, unacked[name])
+	}
+	if len(orchs) == 0 {
+		fmt.Fprintln(tw, "(no orchestrators)")
+	}
+	tw.Flush()
+}

--- a/cmd/coda-core/messages_cmd.go
+++ b/cmd/coda-core/messages_cmd.go
@@ -152,20 +152,13 @@ func runDrain(args []string) error {
 	}
 	defer d.Close()
 
-	var pending int
-	if err := d.QueryRow(
-		`SELECT COUNT(*) FROM messages WHERE recipient=? AND delivered_at IS NULL`,
-		*recipient).Scan(&pending); err != nil {
-		return dbError(err)
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	n, err := mgr.Drain(ctx, *recipient)
 	if err != nil {
 		return dbError(err)
 	}
-	fmt.Printf("drained %d of %d messages\n", n, pending)
+	fmt.Printf("drained %d messages\n", n)
 	return nil
 }
 
@@ -227,14 +220,26 @@ func previewBody(body string) string {
 	return flat
 }
 
+// printUnackedTable renders unacked message counts for the live
+// orchestrators in orchs. Only orchestrators with count > 0 are
+// shown; zero rows are noise. Messages addressed to recipients not
+// in orchs (deleted or unknown orchestrators) are intentionally not
+// surfaced here — they remain readable via
+// `coda-core recv --recipient <name>`.
 func printUnackedTable(w io.Writer, orchs []string, unacked map[string]int) {
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(tw, "RECIPIENT\tUNACKED")
+	any := false
 	for _, name := range orchs {
-		fmt.Fprintf(tw, "%s\t%d\n", name, unacked[name])
+		n := unacked[name]
+		if n == 0 {
+			continue
+		}
+		fmt.Fprintf(tw, "%s\t%d\n", name, n)
+		any = true
 	}
-	if len(orchs) == 0 {
-		fmt.Fprintln(tw, "(no orchestrators)")
+	if !any {
+		return
 	}
 	tw.Flush()
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -35,7 +35,7 @@ func TestOpen_CreatesSchemaIdempotently(t *testing.T) {
 	}
 	defer d2.Close()
 
-	for _, table := range []string{"orchestrators", "features", "hook_events"} {
+	for _, table := range []string{"orchestrators", "features", "hook_events", "messages"} {
 		var name string
 		err := d2.QueryRow(
 			"SELECT name FROM sqlite_master WHERE type='table' AND name=?",

--- a/internal/db/migrations/003_messages.sql
+++ b/internal/db/migrations/003_messages.sql
@@ -1,0 +1,33 @@
+-- Typed message bus: durability layer for coda send/recv/ack.
+-- Recipient may be an orchestrator name or the literal 'broadcast'
+-- (broadcast semantics parked per design doc §Open questions §1).
+-- parent_id enables threading (e.g. note replying to an escalation).
+CREATE TABLE IF NOT EXISTS messages (
+  id            INTEGER PRIMARY KEY,
+  sender        TEXT NOT NULL,
+  recipient     TEXT NOT NULL,
+  type          TEXT NOT NULL
+                CHECK (type IN ('brief','status','completion','escalation','note')),
+  body          TEXT NOT NULL,
+  parent_id     INTEGER REFERENCES messages(id) ON DELETE SET NULL,
+  created_at    INTEGER NOT NULL,
+  delivered_at  INTEGER,
+  acked_at      INTEGER
+);
+
+-- Undelivered queue lookup (coda drain).
+CREATE INDEX IF NOT EXISTS idx_messages_undelivered
+  ON messages(recipient, created_at)
+  WHERE delivered_at IS NULL;
+
+-- Unacked inbox lookup (coda recv --unacked, coda status).
+CREATE INDEX IF NOT EXISTS idx_messages_unacked
+  ON messages(recipient, created_at)
+  WHERE acked_at IS NULL;
+
+-- Thread lookup.
+CREATE INDEX IF NOT EXISTS idx_messages_parent
+  ON messages(parent_id)
+  WHERE parent_id IS NOT NULL;
+
+INSERT INTO schema_version (version, applied_at) VALUES (3, unixepoch());

--- a/internal/db/migrations/migrations_test.go
+++ b/internal/db/migrations/migrations_test.go
@@ -27,6 +27,29 @@ func TestAll_ParsesAndOrders(t *testing.T) {
 	}
 }
 
+func TestAll_IncludesMessagesMigration(t *testing.T) {
+	ms, err := All()
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	var found *Migration
+	for i := range ms {
+		if ms[i].Version == 3 {
+			found = &ms[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("migration 003 not present in embed (got %d migrations)", len(ms))
+	}
+	if found.Name != "messages" {
+		t.Fatalf("migration 003 name = %q, want %q", found.Name, "messages")
+	}
+	if !strings.Contains(found.SQL, "CREATE TABLE IF NOT EXISTS messages") {
+		t.Fatalf("migration 003 SQL missing messages table")
+	}
+}
+
 func TestLatest_MatchesLastMigration(t *testing.T) {
 	ms, err := All()
 	if err != nil {

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -29,6 +29,10 @@ const (
 // BroadcastRecipient is the sentinel recipient value that stores the
 // message but skips the delivery attempt. Real broadcast fan-out is
 // parked (design doc §Open questions §1).
+//
+// Reserved: do NOT register an orchestrator with this name. An
+// orchestrator named "broadcast" would have messages stored but
+// never delivered, because Send short-circuits on this literal.
 const BroadcastRecipient = "broadcast"
 
 // MaxBodyBytes caps the stored body size per design doc §Open
@@ -182,19 +186,33 @@ func (m *Manager) Send(ctx context.Context, sender, recipient string, t Type, bo
 		return msg, nil
 	}
 
+	deliveredAt := m.now()
 	if _, err := m.DB.ExecContext(ctx,
-		`UPDATE messages SET delivered_at=? WHERE id=?`, now, id); err != nil {
+		`UPDATE messages SET delivered_at=? WHERE id=?`, deliveredAt, id); err != nil {
 		return nil, err
 	}
-	msg.DeliveredAt = sql.NullInt64{Int64: now, Valid: true}
+	msg.DeliveredAt = sql.NullInt64{Int64: deliveredAt, Valid: true}
 	return msg, nil
 }
 
 // Drain delivers all undelivered messages for recipient in created_at
 // order. It stops at the first delivery failure so ordering is
-// preserved across restarts. Returns (delivered_count, error). A
-// transport failure is NOT propagated as an error — the caller logs
-// and moves on.
+// preserved across restarts. Returns (delivered_count, error).
+//
+// Semantics:
+//   - (0, nil)        nothing pending, OR first message failed delivery
+//     (indistinguishable in the return value; check stderr
+//     for the failure log, or observe delivered_at in the
+//     DB to tell them apart)
+//   - (n>0, nil)      n messages delivered; may have stopped early on a
+//     later failure
+//   - (n, err)        DB error during scan or UPDATE; n messages up to
+//     that point were delivered
+//
+// A transport-level delivery failure is NOT propagated as an error
+// (the design calls for fire-and-forget; Drain logs to stderr and
+// returns the count of successes). A future DrainResult struct may
+// make this distinguishable if callers need it.
 func (m *Manager) Drain(ctx context.Context, recipient string) (int, error) {
 	if m.Orchs == nil || m.Transport == nil {
 		return 0, nil
@@ -210,44 +228,68 @@ func (m *Manager) Drain(ctx context.Context, recipient string) (int, error) {
 		return 0, nil
 	}
 
+	const chunk = 64
+	delivered := 0
+	var lastID int64 = 0
+
+	for {
+		batch, err := m.fetchPendingBatch(ctx, recipient, lastID, chunk)
+		if err != nil {
+			return delivered, err
+		}
+		if len(batch) == 0 {
+			return delivered, nil
+		}
+		for _, msg := range batch {
+			if err := m.Transport.Deliver(ctx, port, sessionID, renderDelivery(msg)); err != nil {
+				fmt.Fprintf(os.Stderr, "messages: drain id=%d to %q failed: %v\n", msg.ID, recipient, err)
+				return delivered, nil
+			}
+			deliveredAt := m.now()
+			if _, err := m.DB.ExecContext(ctx,
+				`UPDATE messages SET delivered_at=? WHERE id=?`, deliveredAt, msg.ID); err != nil {
+				return delivered, err
+			}
+			msg.DeliveredAt = sql.NullInt64{Int64: deliveredAt, Valid: true}
+			delivered++
+			lastID = msg.ID
+		}
+		if len(batch) < chunk {
+			return delivered, nil
+		}
+	}
+}
+
+// fetchPendingBatch returns up to limit undelivered messages for
+// recipient with id > afterID, ordered by (created_at, id). Rows
+// are fully drained and closed before returning, so the caller
+// can safely run ExecContext afterward on the same connection.
+func (m *Manager) fetchPendingBatch(ctx context.Context, recipient string, afterID int64, limit int) ([]*Message, error) {
 	rows, err := m.DB.QueryContext(ctx,
 		`SELECT id, sender, recipient, type, body, parent_id, created_at, delivered_at, acked_at
 		 FROM messages
-		 WHERE recipient=? AND delivered_at IS NULL
-		 ORDER BY created_at ASC, id ASC`, recipient)
+		 WHERE recipient=? AND delivered_at IS NULL AND id > ?
+		 ORDER BY created_at ASC, id ASC
+		 LIMIT ?`, recipient, afterID, limit)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	var pending []*Message
+	defer rows.Close()
+	var out []*Message
 	for rows.Next() {
 		msg := &Message{}
 		var typ string
 		if err := rows.Scan(&msg.ID, &msg.Sender, &msg.Recipient, &typ, &msg.Body,
 			&msg.ParentID, &msg.CreatedAt, &msg.DeliveredAt, &msg.AckedAt); err != nil {
-			rows.Close()
-			return 0, err
+			return nil, err
 		}
 		msg.Type = Type(typ)
-		pending = append(pending, msg)
+		out = append(out, msg)
 	}
-	if err := rows.Close(); err != nil {
-		return 0, err
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
-
-	delivered := 0
-	for _, msg := range pending {
-		if err := m.Transport.Deliver(ctx, port, sessionID, renderDelivery(msg)); err != nil {
-			fmt.Fprintf(os.Stderr, "messages: drain id=%d to %q failed: %v\n", msg.ID, recipient, err)
-			return delivered, nil
-		}
-		now := m.now()
-		if _, err := m.DB.ExecContext(ctx,
-			`UPDATE messages SET delivered_at=? WHERE id=?`, now, msg.ID); err != nil {
-			return delivered, err
-		}
-		delivered++
-	}
-	return delivered, nil
+	return out, nil
 }
 
 // Recv returns messages for recipient, newest first, limited to limit
@@ -330,9 +372,21 @@ func (m *Manager) UnackedCounts(ctx context.Context) (map[string]int, error) {
 	return out, rows.Err()
 }
 
-// renderDelivery formats a message for HTTP delivery: a one-line
-// header ([message type=... id=... from=...]) followed by the raw
-// JSON body on line 2. Shared by Send and Drain.
+// renderDelivery formats a message for HTTP delivery. The receiving
+// opencode session HTTP endpoint accepts {"text": "<string>"} and
+// renders that string verbatim into the agent's conversation on the
+// next turn.
+//
+// Wire format:
+//
+//	[message type=<type> id=<N> from=<sender>]\n<body-json-one-line>
+//
+// The single-line header lets the receiving agent detect bus messages
+// structurally. Internal newlines in the body are replaced with spaces
+// so the header stays on line 1; the body is otherwise passed through
+// as raw JSON. This is the v1 compatibility wire format — a structured
+// message type (opencode side) is a #149 follow-up. If opencode ever
+// changes how the text field is rendered, adjust here.
 func renderDelivery(msg *Message) string {
 	body := strings.ReplaceAll(msg.Body, "\n", " ")
 	return fmt.Sprintf("[message type=%s id=%d from=%s]\n%s",

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -1,0 +1,371 @@
+// Package messages implements the v2 typed message bus: a persistent
+// SQLite-backed store with optional HTTP delivery. It replaces the
+// inbox.md + coda orch send + 50-orch-notify hook plumbing with a
+// single surface: Send, Recv, Ack, Drain.
+package messages
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// Type is the validated message type.
+type Type string
+
+const (
+	TypeBrief      Type = "brief"
+	TypeStatus     Type = "status"
+	TypeCompletion Type = "completion"
+	TypeEscalation Type = "escalation"
+	TypeNote       Type = "note"
+)
+
+// BroadcastRecipient is the sentinel recipient value that stores the
+// message but skips the delivery attempt. Real broadcast fan-out is
+// parked (design doc §Open questions §1).
+const BroadcastRecipient = "broadcast"
+
+// MaxBodyBytes caps the stored body size per design doc §Open
+// questions §2.
+const MaxBodyBytes = 65536
+
+// Message is one row of the messages table.
+type Message struct {
+	ID          int64
+	Sender      string
+	Recipient   string
+	Type        Type
+	Body        string
+	ParentID    sql.NullInt64
+	CreatedAt   int64
+	DeliveredAt sql.NullInt64
+	AckedAt     sql.NullInt64
+}
+
+// Transport abstracts HTTP delivery. A nil Transport on the Manager
+// disables delivery attempts; the row is still stored durably.
+type Transport interface {
+	Deliver(ctx context.Context, port int, sessionID, text string) error
+}
+
+// OrchLookup fetches delivery coordinates for a recipient name.
+// running=false means the orchestrator exists but is not in
+// state=running (message queues). err=ErrNotFound means no such
+// orchestrator.
+type OrchLookup interface {
+	Lookup(ctx context.Context, name string) (port int, sessionID string, running bool, err error)
+}
+
+var (
+	ErrNotFound    = errors.New("not found")
+	ErrInvalidBody = errors.New("invalid body for message type")
+	ErrInvalidType = errors.New("invalid message type")
+)
+
+// Manager is the state + delivery surface.
+type Manager struct {
+	DB        *sql.DB
+	Transport Transport
+	Orchs     OrchLookup
+	Now       func() time.Time
+}
+
+// New constructs a Manager. Either Transport or Orchs may be nil —
+// Send will just skip the delivery attempt and leave delivered_at
+// NULL for a later Drain.
+func New(db *sql.DB, t Transport, o OrchLookup) *Manager {
+	return &Manager{DB: db, Transport: t, Orchs: o, Now: time.Now}
+}
+
+func (m *Manager) now() int64 { return m.Now().Unix() }
+
+var requiredFields = map[Type][]string{
+	TypeBrief:      {"card_id", "card_title", "project", "branch", "brief_path"},
+	TypeStatus:     {"feature", "progress"},
+	TypeCompletion: {"feature", "status"},
+	TypeEscalation: {"from_feature", "blocker", "blocking"},
+	TypeNote:       {"text"},
+}
+
+var completionStatuses = map[string]bool{
+	"done": true, "failed": true, "partial": true, "blocked": true,
+}
+
+// Send writes a message row and, if the recipient is running, attempts
+// delivery. Delivery failure does NOT return an error; the message is
+// durably stored and will be drained on recipient restart.
+// parentID=0 means no parent; nonzero must reference an existing row.
+func (m *Manager) Send(ctx context.Context, sender, recipient string, t Type, body string, parentID int64) (*Message, error) {
+	if _, ok := requiredFields[t]; !ok {
+		return nil, fmt.Errorf("%w: %q", ErrInvalidType, t)
+	}
+	if len(body) > MaxBodyBytes {
+		return nil, fmt.Errorf("%w: body exceeds 64KB (%d bytes)", ErrInvalidBody, len(body))
+	}
+	if !json.Valid([]byte(body)) {
+		return nil, fmt.Errorf("%w: not valid JSON", ErrInvalidBody)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidBody, err)
+	}
+	for _, field := range requiredFields[t] {
+		if _, present := parsed[field]; !present {
+			return nil, fmt.Errorf("%w: missing %q", ErrInvalidBody, field)
+		}
+	}
+	if t == TypeCompletion {
+		s, _ := parsed["status"].(string)
+		if !completionStatuses[s] {
+			return nil, fmt.Errorf("%w: completion.status must be one of done|failed|partial|blocked", ErrInvalidBody)
+		}
+	}
+
+	if parentID != 0 {
+		var exists int
+		err := m.DB.QueryRowContext(ctx, `SELECT 1 FROM messages WHERE id=?`, parentID).Scan(&exists)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("%w: parent message %d", ErrNotFound, parentID)
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	now := m.now()
+	var parentArg any
+	if parentID != 0 {
+		parentArg = parentID
+	}
+	res, err := m.DB.ExecContext(ctx,
+		`INSERT INTO messages (sender, recipient, type, body, parent_id, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		sender, recipient, string(t), body, parentArg, now)
+	if err != nil {
+		return nil, err
+	}
+	id, _ := res.LastInsertId()
+	msg := &Message{
+		ID: id, Sender: sender, Recipient: recipient, Type: t,
+		Body: body, CreatedAt: now,
+	}
+	if parentID != 0 {
+		msg.ParentID = sql.NullInt64{Int64: parentID, Valid: true}
+	}
+
+	if recipient == BroadcastRecipient {
+		return msg, nil
+	}
+	if m.Orchs == nil || m.Transport == nil {
+		return msg, nil
+	}
+
+	port, sessionID, running, err := m.Orchs.Lookup(ctx, recipient)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return msg, nil
+		}
+		return nil, err
+	}
+	if !running {
+		return msg, nil
+	}
+
+	if derr := m.Transport.Deliver(ctx, port, sessionID, renderDelivery(msg)); derr != nil {
+		fmt.Fprintf(os.Stderr, "messages: deliver id=%d to %q failed: %v\n", id, recipient, derr)
+		return msg, nil
+	}
+
+	if _, err := m.DB.ExecContext(ctx,
+		`UPDATE messages SET delivered_at=? WHERE id=?`, now, id); err != nil {
+		return nil, err
+	}
+	msg.DeliveredAt = sql.NullInt64{Int64: now, Valid: true}
+	return msg, nil
+}
+
+// Drain delivers all undelivered messages for recipient in created_at
+// order. It stops at the first delivery failure so ordering is
+// preserved across restarts. Returns (delivered_count, error). A
+// transport failure is NOT propagated as an error — the caller logs
+// and moves on.
+func (m *Manager) Drain(ctx context.Context, recipient string) (int, error) {
+	if m.Orchs == nil || m.Transport == nil {
+		return 0, nil
+	}
+	port, sessionID, running, err := m.Orchs.Lookup(ctx, recipient)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	if !running {
+		return 0, nil
+	}
+
+	rows, err := m.DB.QueryContext(ctx,
+		`SELECT id, sender, recipient, type, body, parent_id, created_at, delivered_at, acked_at
+		 FROM messages
+		 WHERE recipient=? AND delivered_at IS NULL
+		 ORDER BY created_at ASC, id ASC`, recipient)
+	if err != nil {
+		return 0, err
+	}
+	var pending []*Message
+	for rows.Next() {
+		msg := &Message{}
+		var typ string
+		if err := rows.Scan(&msg.ID, &msg.Sender, &msg.Recipient, &typ, &msg.Body,
+			&msg.ParentID, &msg.CreatedAt, &msg.DeliveredAt, &msg.AckedAt); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		msg.Type = Type(typ)
+		pending = append(pending, msg)
+	}
+	if err := rows.Close(); err != nil {
+		return 0, err
+	}
+
+	delivered := 0
+	for _, msg := range pending {
+		if err := m.Transport.Deliver(ctx, port, sessionID, renderDelivery(msg)); err != nil {
+			fmt.Fprintf(os.Stderr, "messages: drain id=%d to %q failed: %v\n", msg.ID, recipient, err)
+			return delivered, nil
+		}
+		now := m.now()
+		if _, err := m.DB.ExecContext(ctx,
+			`UPDATE messages SET delivered_at=? WHERE id=?`, now, msg.ID); err != nil {
+			return delivered, err
+		}
+		delivered++
+	}
+	return delivered, nil
+}
+
+// Recv returns messages for recipient, newest first, limited to limit
+// rows (0 = default 50). If unackedOnly, filters acked_at IS NULL. If
+// sinceID > 0, filters id > sinceID.
+func (m *Manager) Recv(ctx context.Context, recipient string, unackedOnly bool, sinceID int64, limit int) ([]*Message, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	q := `SELECT id, sender, recipient, type, body, parent_id, created_at, delivered_at, acked_at
+	      FROM messages WHERE recipient=?`
+	args := []any{recipient}
+	if unackedOnly {
+		q += ` AND acked_at IS NULL`
+	}
+	if sinceID > 0 {
+		q += ` AND id > ?`
+		args = append(args, sinceID)
+	}
+	q += ` ORDER BY created_at DESC, id DESC LIMIT ?`
+	args = append(args, limit)
+
+	rows, err := m.DB.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*Message
+	for rows.Next() {
+		msg := &Message{}
+		var typ string
+		if err := rows.Scan(&msg.ID, &msg.Sender, &msg.Recipient, &typ, &msg.Body,
+			&msg.ParentID, &msg.CreatedAt, &msg.DeliveredAt, &msg.AckedAt); err != nil {
+			return nil, err
+		}
+		msg.Type = Type(typ)
+		out = append(out, msg)
+	}
+	return out, rows.Err()
+}
+
+// Ack sets acked_at on the given message id. Idempotent — re-acking
+// is a no-op success. Returns ErrNotFound if no row matches.
+func (m *Manager) Ack(ctx context.Context, id int64) error {
+	var existingAck sql.NullInt64
+	err := m.DB.QueryRowContext(ctx,
+		`SELECT acked_at FROM messages WHERE id=?`, id).Scan(&existingAck)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("%w: message %d", ErrNotFound, id)
+	}
+	if err != nil {
+		return err
+	}
+	if existingAck.Valid {
+		return nil
+	}
+	_, err = m.DB.ExecContext(ctx,
+		`UPDATE messages SET acked_at=? WHERE id=?`, m.now(), id)
+	return err
+}
+
+// UnackedCounts returns a map of recipient -> count of unacked
+// messages, used by coda-core status.
+func (m *Manager) UnackedCounts(ctx context.Context) (map[string]int, error) {
+	rows, err := m.DB.QueryContext(ctx,
+		`SELECT recipient, COUNT(*) FROM messages WHERE acked_at IS NULL GROUP BY recipient`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string]int{}
+	for rows.Next() {
+		var name string
+		var n int
+		if err := rows.Scan(&name, &n); err != nil {
+			return nil, err
+		}
+		out[name] = n
+	}
+	return out, rows.Err()
+}
+
+// renderDelivery formats a message for HTTP delivery: a one-line
+// header ([message type=... id=... from=...]) followed by the raw
+// JSON body on line 2. Shared by Send and Drain.
+func renderDelivery(msg *Message) string {
+	body := strings.ReplaceAll(msg.Body, "\n", " ")
+	return fmt.Sprintf("[message type=%s id=%d from=%s]\n%s",
+		msg.Type, msg.ID, msg.Sender, body)
+}
+
+// DBOrchLookup resolves recipient names via the orchestrators table.
+type DBOrchLookup struct {
+	DB *sql.DB
+}
+
+// Lookup implements OrchLookup by querying the orchestrators row.
+func (l *DBOrchLookup) Lookup(ctx context.Context, name string) (int, string, bool, error) {
+	var port sql.NullInt64
+	var sessionID sql.NullString
+	var state string
+	err := l.DB.QueryRowContext(ctx,
+		`SELECT port, session_id, state FROM orchestrators WHERE name=?`,
+		name).Scan(&port, &sessionID, &state)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, "", false, ErrNotFound
+	}
+	if err != nil {
+		return 0, "", false, err
+	}
+	running := state == "running" && port.Valid && sessionID.Valid
+	p := 0
+	if port.Valid {
+		p = int(port.Int64)
+	}
+	s := ""
+	if sessionID.Valid {
+		s = sessionID.String
+	}
+	return p, s, running, nil
+}

--- a/internal/messages/messages_test.go
+++ b/internal/messages/messages_test.go
@@ -361,6 +361,61 @@ func TestDrain_StopsAtFirstFailure(t *testing.T) {
 	}
 }
 
+func TestDrain_StreamsLargeBacklog(t *testing.T) {
+	tr := &stubTransport{}
+	orchs := &stubOrchs{port: 4096, sessionID: "ses1", running: true}
+	m, d := newTestManager(t, tr, orchs)
+
+	const total = 130
+	ids := make([]int64, 0, total)
+	for i := 0; i < total; i++ {
+		id := seedMessage(t, d, "ash", "zach", int64(1000+i), false)
+		ids = append(ids, id)
+	}
+
+	n, err := m.Drain(context.Background(), "zach")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != total {
+		t.Fatalf("drained %d, want %d", n, total)
+	}
+	if len(tr.calls) != total {
+		t.Fatalf("transport calls = %d, want %d", len(tr.calls), total)
+	}
+
+	var got []int64
+	for _, call := range tr.calls {
+		for _, token := range strings.Split(call.Text, " ") {
+			if strings.HasPrefix(token, "id=") {
+				var n int64
+				if _, err := fmt.Sscanf(token, "id=%d", &n); err != nil {
+					t.Fatal(err)
+				}
+				got = append(got, n)
+			}
+		}
+	}
+	if len(got) != total {
+		t.Fatalf("parsed ids = %d, want %d", len(got), total)
+	}
+	for i, id := range got {
+		if id != ids[i] {
+			t.Fatalf("drain order[%d] = %d, want %d", i, id, ids[i])
+		}
+	}
+
+	var remaining int
+	if err := d.QueryRow(
+		`SELECT COUNT(*) FROM messages WHERE recipient='zach' AND delivered_at IS NULL`,
+	).Scan(&remaining); err != nil {
+		t.Fatal(err)
+	}
+	if remaining != 0 {
+		t.Fatalf("remaining undelivered = %d, want 0", remaining)
+	}
+}
+
 func TestDrain_NoopWhenOrchNotRunning(t *testing.T) {
 	tr := &stubTransport{}
 	orchs := &stubOrchs{running: false}

--- a/internal/messages/messages_test.go
+++ b/internal/messages/messages_test.go
@@ -1,0 +1,551 @@
+package messages
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/evanstern/coda/internal/db"
+)
+
+type stubTransport struct {
+	calls    []stubCall
+	fail     bool
+	failOnID int64
+	failErr  error
+}
+
+type stubCall struct {
+	Port      int
+	SessionID string
+	Text      string
+}
+
+func (s *stubTransport) Deliver(ctx context.Context, port int, sessionID, text string) error {
+	s.calls = append(s.calls, stubCall{Port: port, SessionID: sessionID, Text: text})
+	if s.failErr != nil {
+		return s.failErr
+	}
+	if s.fail {
+		return errors.New("stub deliver fail")
+	}
+	if s.failOnID > 0 {
+		idx := int64(len(s.calls))
+		if idx == s.failOnID {
+			return errors.New("stub deliver fail on nth call")
+		}
+	}
+	return nil
+}
+
+type stubOrchs struct {
+	port      int
+	sessionID string
+	running   bool
+	err       error
+}
+
+func (s *stubOrchs) Lookup(ctx context.Context, name string) (int, string, bool, error) {
+	if s.err != nil {
+		return 0, "", false, s.err
+	}
+	return s.port, s.sessionID, s.running, nil
+}
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	d, err := db.Open(filepath.Join(t.TempDir(), "coda.db"))
+	if err != nil {
+		t.Fatalf("db open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+func newTestManager(t *testing.T, transport Transport, orchs OrchLookup) (*Manager, *sql.DB) {
+	t.Helper()
+	d := openTestDB(t)
+	m := New(d, transport, orchs)
+	m.Now = func() time.Time { return time.Unix(1000, 0) }
+	return m, d
+}
+
+func validBody(t Type) string {
+	switch t {
+	case TypeBrief:
+		return `{"card_id":"149","card_title":"msg bus","project":"coda","branch":"149","brief_path":"/tmp/x"}`
+	case TypeStatus:
+		return `{"feature":"msgs","progress":"halfway"}`
+	case TypeCompletion:
+		return `{"feature":"msgs","status":"done"}`
+	case TypeEscalation:
+		return `{"from_feature":"msgs","blocker":"x","blocking":"y"}`
+	case TypeNote:
+		return `{"text":"hello"}`
+	}
+	return `{}`
+}
+
+func TestSend_ValidatesType(t *testing.T) {
+	m, _ := newTestManager(t, nil, nil)
+	_, err := m.Send(context.Background(), "ash", "zach", Type("nope"), `{"text":"x"}`, 0)
+	if !errors.Is(err, ErrInvalidType) {
+		t.Fatalf("want ErrInvalidType, got %v", err)
+	}
+}
+
+func TestSend_ValidatesBodyJSON(t *testing.T) {
+	m, _ := newTestManager(t, nil, nil)
+	_, err := m.Send(context.Background(), "ash", "zach", TypeNote, `not json`, 0)
+	if !errors.Is(err, ErrInvalidBody) {
+		t.Fatalf("want ErrInvalidBody, got %v", err)
+	}
+}
+
+func TestSend_RequiresTypeSpecificFields(t *testing.T) {
+	cases := []struct {
+		name string
+		t    Type
+		body string
+	}{
+		{"brief missing card_id", TypeBrief, `{"card_title":"t","project":"p","branch":"b","brief_path":"/x"}`},
+		{"status missing progress", TypeStatus, `{"feature":"f"}`},
+		{"completion missing status", TypeCompletion, `{"feature":"f"}`},
+		{"escalation missing blocking", TypeEscalation, `{"from_feature":"f","blocker":"x"}`},
+		{"note missing text", TypeNote, `{}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m, _ := newTestManager(t, nil, nil)
+			_, err := m.Send(context.Background(), "ash", "zach", c.t, c.body, 0)
+			if !errors.Is(err, ErrInvalidBody) {
+				t.Fatalf("want ErrInvalidBody, got %v", err)
+			}
+		})
+	}
+}
+
+func TestSend_RejectsBadCompletionStatus(t *testing.T) {
+	m, _ := newTestManager(t, nil, nil)
+	_, err := m.Send(context.Background(), "ash", "zach", TypeCompletion,
+		`{"feature":"f","status":"maybe"}`, 0)
+	if !errors.Is(err, ErrInvalidBody) {
+		t.Fatalf("want ErrInvalidBody, got %v", err)
+	}
+}
+
+func TestSend_RejectsOversizeBody(t *testing.T) {
+	m, _ := newTestManager(t, nil, nil)
+	big := `{"text":"` + strings.Repeat("a", MaxBodyBytes) + `"}`
+	_, err := m.Send(context.Background(), "ash", "zach", TypeNote, big, 0)
+	if !errors.Is(err, ErrInvalidBody) {
+		t.Fatalf("want ErrInvalidBody, got %v", err)
+	}
+}
+
+func TestSend_StoresRowWithNullDeliveredWhenNoTransport(t *testing.T) {
+	m, d := newTestManager(t, nil, nil)
+	msg, err := m.Send(context.Background(), "ash", "zach", TypeNote, `{"text":"hi"}`, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var delivered sql.NullInt64
+	if err := d.QueryRow(`SELECT delivered_at FROM messages WHERE id=?`, msg.ID).Scan(&delivered); err != nil {
+		t.Fatal(err)
+	}
+	if delivered.Valid {
+		t.Fatalf("delivered_at = %v, want NULL", delivered)
+	}
+}
+
+func TestSend_SetsDeliveredOnSuccess(t *testing.T) {
+	tr := &stubTransport{}
+	orchs := &stubOrchs{port: 4096, sessionID: "ses1", running: true}
+	m, d := newTestManager(t, tr, orchs)
+
+	msg, err := m.Send(context.Background(), "ash", "zach", TypeNote, `{"text":"hi"}`, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !msg.DeliveredAt.Valid {
+		t.Fatalf("delivered_at not set in returned struct")
+	}
+	var delivered sql.NullInt64
+	if err := d.QueryRow(`SELECT delivered_at FROM messages WHERE id=?`, msg.ID).Scan(&delivered); err != nil {
+		t.Fatal(err)
+	}
+	if !delivered.Valid {
+		t.Fatalf("delivered_at not persisted")
+	}
+	if len(tr.calls) != 1 {
+		t.Fatalf("want 1 deliver call, got %d", len(tr.calls))
+	}
+}
+
+func TestSend_LeavesUndeliveredOnTransportFailure(t *testing.T) {
+	tr := &stubTransport{fail: true}
+	orchs := &stubOrchs{port: 4096, sessionID: "ses1", running: true}
+	m, d := newTestManager(t, tr, orchs)
+
+	msg, err := m.Send(context.Background(), "ash", "zach", TypeNote, `{"text":"hi"}`, 0)
+	if err != nil {
+		t.Fatalf("transport failure must not propagate, got %v", err)
+	}
+	if msg.DeliveredAt.Valid {
+		t.Fatalf("delivered_at should be NULL on transport failure")
+	}
+	var delivered sql.NullInt64
+	if err := d.QueryRow(`SELECT delivered_at FROM messages WHERE id=?`, msg.ID).Scan(&delivered); err != nil {
+		t.Fatal(err)
+	}
+	if delivered.Valid {
+		t.Fatalf("persisted delivered_at should be NULL")
+	}
+}
+
+func TestSend_QueuesWhenRecipientNotRunning(t *testing.T) {
+	tr := &stubTransport{}
+	orchs := &stubOrchs{running: false}
+	m, _ := newTestManager(t, tr, orchs)
+
+	msg, err := m.Send(context.Background(), "ash", "zach", TypeNote, `{"text":"hi"}`, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.DeliveredAt.Valid {
+		t.Fatalf("should not be delivered when recipient not running")
+	}
+	if len(tr.calls) != 0 {
+		t.Fatalf("transport should not be invoked when not running")
+	}
+}
+
+func TestSend_QueuesWhenRecipientUnknown(t *testing.T) {
+	tr := &stubTransport{}
+	orchs := &stubOrchs{err: ErrNotFound}
+	m, _ := newTestManager(t, tr, orchs)
+
+	msg, err := m.Send(context.Background(), "ash", "ghost", TypeNote, `{"text":"hi"}`, 0)
+	if err != nil {
+		t.Fatalf("unknown recipient should not error, got %v", err)
+	}
+	if msg.DeliveredAt.Valid {
+		t.Fatalf("should be queued")
+	}
+}
+
+func TestSend_ValidatesParentIDExists(t *testing.T) {
+	m, _ := newTestManager(t, nil, nil)
+	_, err := m.Send(context.Background(), "ash", "zach", TypeNote, `{"text":"hi"}`, 999)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+}
+
+func TestSend_AcceptsParentIDWhenExists(t *testing.T) {
+	m, _ := newTestManager(t, nil, nil)
+	ctx := context.Background()
+	parent, err := m.Send(ctx, "ash", "zach", TypeNote, `{"text":"hi"}`, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := m.Send(ctx, "zach", "ash", TypeNote, `{"text":"back"}`, parent.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !child.ParentID.Valid || child.ParentID.Int64 != parent.ID {
+		t.Fatalf("child ParentID = %v, want %d", child.ParentID, parent.ID)
+	}
+}
+
+func TestSend_AcceptsBroadcastRecipient(t *testing.T) {
+	tr := &stubTransport{}
+	orchs := &stubOrchs{port: 4096, sessionID: "ses", running: true}
+	m, _ := newTestManager(t, tr, orchs)
+
+	msg, err := m.Send(context.Background(), "ash", BroadcastRecipient, TypeNote, `{"text":"hi"}`, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.DeliveredAt.Valid {
+		t.Fatalf("broadcast should not deliver")
+	}
+	if len(tr.calls) != 0 {
+		t.Fatalf("broadcast should not invoke transport")
+	}
+}
+
+func seedMessage(t *testing.T, d *sql.DB, sender, recipient string, createdAt int64, acked bool) int64 {
+	t.Helper()
+	var ackedArg any
+	if acked {
+		ackedArg = createdAt + 1
+	}
+	res, err := d.Exec(
+		`INSERT INTO messages (sender, recipient, type, body, created_at, acked_at)
+		 VALUES (?, ?, 'note', '{"text":"x"}', ?, ?)`,
+		sender, recipient, createdAt, ackedArg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, _ := res.LastInsertId()
+	return id
+}
+
+func TestDrain_DeliversInOrder(t *testing.T) {
+	tr := &stubTransport{}
+	orchs := &stubOrchs{port: 4096, sessionID: "ses1", running: true}
+	m, d := newTestManager(t, tr, orchs)
+
+	id1 := seedMessage(t, d, "ash", "zach", 100, false)
+	id2 := seedMessage(t, d, "ash", "zach", 200, false)
+	id3 := seedMessage(t, d, "ash", "zach", 300, false)
+
+	n, err := m.Drain(context.Background(), "zach")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 3 {
+		t.Fatalf("drained %d, want 3", n)
+	}
+	if len(tr.calls) != 3 {
+		t.Fatalf("want 3 transport calls, got %d", len(tr.calls))
+	}
+	var ids []int64
+	for _, call := range tr.calls {
+		for _, token := range strings.Split(call.Text, " ") {
+			if strings.HasPrefix(token, "id=") {
+				var n int64
+				if _, err := fmt.Sscanf(token, "id=%d", &n); err != nil {
+					t.Fatal(err)
+				}
+				ids = append(ids, n)
+			}
+		}
+	}
+	want := []int64{id1, id2, id3}
+	for i, id := range ids {
+		if id != want[i] {
+			t.Fatalf("drain order[%d] = %d, want %d", i, id, want[i])
+		}
+	}
+}
+
+func TestDrain_StopsAtFirstFailure(t *testing.T) {
+	tr := &stubTransport{failOnID: 2}
+	orchs := &stubOrchs{port: 4096, sessionID: "ses1", running: true}
+	m, d := newTestManager(t, tr, orchs)
+
+	id1 := seedMessage(t, d, "ash", "zach", 100, false)
+	_ = seedMessage(t, d, "ash", "zach", 200, false)
+	_ = seedMessage(t, d, "ash", "zach", 300, false)
+
+	n, err := m.Drain(context.Background(), "zach")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("drained %d, want 1", n)
+	}
+	var del sql.NullInt64
+	if err := d.QueryRow(`SELECT delivered_at FROM messages WHERE id=?`, id1).Scan(&del); err != nil {
+		t.Fatal(err)
+	}
+	if !del.Valid {
+		t.Fatalf("msg 1 should be delivered")
+	}
+}
+
+func TestDrain_NoopWhenOrchNotRunning(t *testing.T) {
+	tr := &stubTransport{}
+	orchs := &stubOrchs{running: false}
+	m, d := newTestManager(t, tr, orchs)
+	seedMessage(t, d, "ash", "zach", 100, false)
+
+	n, err := m.Drain(context.Background(), "zach")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("drained %d, want 0", n)
+	}
+	if len(tr.calls) != 0 {
+		t.Fatalf("transport should not be called")
+	}
+}
+
+func TestRecv_ReturnsNewestFirst(t *testing.T) {
+	m, d := newTestManager(t, nil, nil)
+	seedMessage(t, d, "ash", "zach", 100, false)
+	seedMessage(t, d, "ash", "zach", 200, false)
+	id3 := seedMessage(t, d, "ash", "zach", 300, false)
+
+	msgs, err := m.Recv(context.Background(), "zach", false, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("got %d, want 3", len(msgs))
+	}
+	if msgs[0].ID != id3 {
+		t.Fatalf("first = %d, want %d (newest)", msgs[0].ID, id3)
+	}
+}
+
+func TestRecv_UnackedOnly(t *testing.T) {
+	m, d := newTestManager(t, nil, nil)
+	ackedID := seedMessage(t, d, "ash", "zach", 100, true)
+	unackedID := seedMessage(t, d, "ash", "zach", 200, false)
+
+	msgs, err := m.Recv(context.Background(), "zach", true, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 1 || msgs[0].ID != unackedID {
+		t.Fatalf("unacked filter got %d msgs, first=%d, want 1 msg id=%d",
+			len(msgs), func() int64 {
+				if len(msgs) > 0 {
+					return msgs[0].ID
+				}
+				return 0
+			}(), unackedID)
+	}
+	_ = ackedID
+}
+
+func TestRecv_SinceID(t *testing.T) {
+	m, d := newTestManager(t, nil, nil)
+	id1 := seedMessage(t, d, "ash", "zach", 100, false)
+	seedMessage(t, d, "ash", "zach", 200, false)
+	seedMessage(t, d, "ash", "zach", 300, false)
+
+	msgs, err := m.Recv(context.Background(), "zach", false, id1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("got %d, want 2", len(msgs))
+	}
+	for _, msg := range msgs {
+		if msg.ID <= id1 {
+			t.Fatalf("msg id %d not > %d", msg.ID, id1)
+		}
+	}
+}
+
+func TestRecv_LimitDefaults(t *testing.T) {
+	m, d := newTestManager(t, nil, nil)
+	for i := int64(0); i < 60; i++ {
+		seedMessage(t, d, "ash", "zach", 1000+i, false)
+	}
+	msgs, err := m.Recv(context.Background(), "zach", false, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 50 {
+		t.Fatalf("got %d, want 50 (default limit)", len(msgs))
+	}
+}
+
+func TestAck_SetsAckedAt(t *testing.T) {
+	m, d := newTestManager(t, nil, nil)
+	id := seedMessage(t, d, "ash", "zach", 100, false)
+	if err := m.Ack(context.Background(), id); err != nil {
+		t.Fatal(err)
+	}
+	var acked sql.NullInt64
+	if err := d.QueryRow(`SELECT acked_at FROM messages WHERE id=?`, id).Scan(&acked); err != nil {
+		t.Fatal(err)
+	}
+	if !acked.Valid {
+		t.Fatalf("acked_at not set")
+	}
+}
+
+func TestAck_Idempotent(t *testing.T) {
+	m, d := newTestManager(t, nil, nil)
+	id := seedMessage(t, d, "ash", "zach", 100, false)
+	if err := m.Ack(context.Background(), id); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Ack(context.Background(), id); err != nil {
+		t.Fatalf("second ack should be no-op, got %v", err)
+	}
+}
+
+func TestAck_NotFound(t *testing.T) {
+	m, _ := newTestManager(t, nil, nil)
+	err := m.Ack(context.Background(), 999)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+}
+
+func TestUnackedCounts_AggregatesByRecipient(t *testing.T) {
+	m, d := newTestManager(t, nil, nil)
+	seedMessage(t, d, "ash", "zach", 100, false)
+	seedMessage(t, d, "ash", "zach", 101, false)
+	seedMessage(t, d, "ash", "riley", 102, false)
+	seedMessage(t, d, "ash", "riley", 103, true)
+
+	counts, err := m.UnackedCounts(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counts["zach"] != 2 {
+		t.Fatalf("zach = %d, want 2", counts["zach"])
+	}
+	if counts["riley"] != 1 {
+		t.Fatalf("riley = %d, want 1 (acked one excluded)", counts["riley"])
+	}
+}
+
+func TestDBOrchLookup_NotFound(t *testing.T) {
+	d := openTestDB(t)
+	l := &DBOrchLookup{DB: d}
+	_, _, _, err := l.Lookup(context.Background(), "ghost")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+}
+
+func TestDBOrchLookup_RunningRequiresCoords(t *testing.T) {
+	d := openTestDB(t)
+	if _, err := d.Exec(
+		`INSERT INTO orchestrators (name, config_dir, state, created_at, updated_at)
+		 VALUES ('zach', '/tmp/z', 'running', 0, 0)`,
+	); err != nil {
+		t.Fatal(err)
+	}
+	l := &DBOrchLookup{DB: d}
+	_, _, running, err := l.Lookup(context.Background(), "zach")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if running {
+		t.Fatalf("running should be false when port/session_id missing")
+	}
+}
+
+func TestDBOrchLookup_ReturnsCoords(t *testing.T) {
+	d := openTestDB(t)
+	if _, err := d.Exec(
+		`INSERT INTO orchestrators (name, config_dir, state, port, session_id, created_at, updated_at)
+		 VALUES ('zach', '/tmp/z', 'running', 4096, 'ses1', 0, 0)`,
+	); err != nil {
+		t.Fatal(err)
+	}
+	l := &DBOrchLookup{DB: d}
+	port, session, running, err := l.Lookup(context.Background(), "zach")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if port != 4096 || session != "ses1" || !running {
+		t.Fatalf("Lookup = (%d, %q, %v), want (4096, ses1, true)", port, session, running)
+	}
+}

--- a/internal/messages/transport.go
+++ b/internal/messages/transport.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -22,14 +23,29 @@ func NewHTTPTransport() *HTTPTransport {
 
 // Deliver POSTs a text message to http://127.0.0.1:<port>/session/<id>/message
 // with body {"text":"<text>"}. Returns error on non-2xx, missing
-// coordinates, or transport failure.
+// coordinates, invalid port, or transport failure.
+//
+// Delivery is loopback-only by design: the v2 message bus is a
+// single-host system and only talks to orchestrator sessions on
+// 127.0.0.1. Cross-host delivery is explicitly out of scope for v2.
 func (h *HTTPTransport) Deliver(ctx context.Context, port int, sessionID, text string) error {
-	if port == 0 || sessionID == "" {
-		return fmt.Errorf("missing port or session_id")
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("invalid port %d", port)
 	}
-	url := fmt.Sprintf("http://127.0.0.1:%d/session/%s/message", port, sessionID)
-	payload, _ := json.Marshal(map[string]string{"text": text})
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(payload))
+	if sessionID == "" {
+		return fmt.Errorf("missing session_id")
+	}
+	u := &url.URL{
+		Scheme:  "http",
+		Host:    fmt.Sprintf("127.0.0.1:%d", port),
+		Path:    "/session/" + sessionID + "/message",
+		RawPath: "/session/" + url.PathEscape(sessionID) + "/message",
+	}
+	payload, err := json.Marshal(map[string]string{"text": text})
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, "POST", u.String(), bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}

--- a/internal/messages/transport.go
+++ b/internal/messages/transport.go
@@ -1,0 +1,46 @@
+package messages
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// HTTPTransport POSTs messages to an opencode session endpoint.
+type HTTPTransport struct {
+	Client *http.Client
+}
+
+// NewHTTPTransport returns a transport with a 3-second timeout,
+// matching the design doc's fire-and-forget semantics.
+func NewHTTPTransport() *HTTPTransport {
+	return &HTTPTransport{Client: &http.Client{Timeout: 3 * time.Second}}
+}
+
+// Deliver POSTs a text message to http://127.0.0.1:<port>/session/<id>/message
+// with body {"text":"<text>"}. Returns error on non-2xx, missing
+// coordinates, or transport failure.
+func (h *HTTPTransport) Deliver(ctx context.Context, port int, sessionID, text string) error {
+	if port == 0 || sessionID == "" {
+		return fmt.Errorf("missing port or session_id")
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%d/session/%s/message", port, sessionID)
+	payload, _ := json.Marshal(map[string]string{"text": text})
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := h.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("deliver: http %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/internal/messages/transport_test.go
+++ b/internal/messages/transport_test.go
@@ -1,0 +1,143 @@
+package messages
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestHTTPTransport(timeout time.Duration) *HTTPTransport {
+	return &HTTPTransport{Client: &http.Client{Timeout: timeout}}
+}
+
+func hostPort(t *testing.T, rawurl string) (string, int) {
+	t.Helper()
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := strings.Split(u.Host, ":")
+	if len(parts) != 2 {
+		t.Fatalf("unexpected host %q", u.Host)
+	}
+	p, err := strconv.Atoi(parts[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parts[0], p
+}
+
+func TestHTTPTransport_2xxIsSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	h, port := hostPort(t, srv.URL)
+	_ = h
+	tr := newTestHTTPTransport(2 * time.Second)
+	tr.Client.Transport = rewriteLoopback(t, srv.URL)
+
+	if err := tr.Deliver(context.Background(), port, "ses", "hi"); err != nil {
+		t.Fatalf("want nil err, got %v", err)
+	}
+}
+
+func TestHTTPTransport_500IsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer srv.Close()
+
+	_, port := hostPort(t, srv.URL)
+	tr := newTestHTTPTransport(2 * time.Second)
+	tr.Client.Transport = rewriteLoopback(t, srv.URL)
+
+	if err := tr.Deliver(context.Background(), port, "ses", "hi"); err == nil {
+		t.Fatal("want error on 500, got nil")
+	}
+}
+
+func TestHTTPTransport_TimeoutIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	_, port := hostPort(t, srv.URL)
+	tr := newTestHTTPTransport(20 * time.Millisecond)
+	tr.Client.Transport = rewriteLoopback(t, srv.URL)
+
+	if err := tr.Deliver(context.Background(), port, "ses", "hi"); err == nil {
+		t.Fatal("want timeout error, got nil")
+	}
+}
+
+func TestHTTPTransport_RejectsEmptyCoords(t *testing.T) {
+	tr := NewHTTPTransport()
+	if err := tr.Deliver(context.Background(), 0, "ses", "hi"); err == nil {
+		t.Fatal("want error for port=0")
+	}
+	if err := tr.Deliver(context.Background(), 4096, "", "hi"); err == nil {
+		t.Fatal("want error for empty sessionID")
+	}
+}
+
+func TestHTTPTransport_SendsCorrectBody(t *testing.T) {
+	var gotBody []byte
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		gotPath = r.URL.Path
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	_, port := hostPort(t, srv.URL)
+	tr := newTestHTTPTransport(2 * time.Second)
+	tr.Client.Transport = rewriteLoopback(t, srv.URL)
+
+	if err := tr.Deliver(context.Background(), port, "ses1", "hello"); err != nil {
+		t.Fatal(err)
+	}
+	var parsed map[string]string
+	if err := json.Unmarshal(gotBody, &parsed); err != nil {
+		t.Fatalf("body not JSON: %v", err)
+	}
+	if parsed["text"] != "hello" {
+		t.Fatalf("body text = %q, want %q", parsed["text"], "hello")
+	}
+	if gotPath != "/session/ses1/message" {
+		t.Fatalf("path = %q, want /session/ses1/message", gotPath)
+	}
+}
+
+// rewriteLoopback lets tests hit httptest.Server even though the
+// transport hardcodes 127.0.0.1. It rewrites the URL target host
+// to the httptest server host at the round-trip layer.
+func rewriteLoopback(t *testing.T, srvURL string) http.RoundTripper {
+	t.Helper()
+	target, err := url.Parse(srvURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &loopbackRewriter{host: target.Host}
+}
+
+type loopbackRewriter struct {
+	host string
+}
+
+func (l *loopbackRewriter) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Host = l.host
+	req.Host = l.host
+	return http.DefaultTransport.RoundTrip(req)
+}

--- a/internal/messages/transport_test.go
+++ b/internal/messages/transport_test.go
@@ -82,12 +82,44 @@ func TestHTTPTransport_TimeoutIsError(t *testing.T) {
 }
 
 func TestHTTPTransport_RejectsEmptyCoords(t *testing.T) {
-	tr := NewHTTPTransport()
-	if err := tr.Deliver(context.Background(), 0, "ses", "hi"); err == nil {
-		t.Fatal("want error for port=0")
+	cases := []struct {
+		name      string
+		port      int
+		sessionID string
+	}{
+		{"port=0", 0, "ses"},
+		{"port=-1", -1, "ses"},
+		{"port=99999", 99999, "ses"},
+		{"empty sessionID", 4096, ""},
 	}
-	if err := tr.Deliver(context.Background(), 4096, "", "hi"); err == nil {
-		t.Fatal("want error for empty sessionID")
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tr := NewHTTPTransport()
+			if err := tr.Deliver(context.Background(), c.port, c.sessionID, "hi"); err == nil {
+				t.Fatalf("want error for %s", c.name)
+			}
+		})
+	}
+}
+
+func TestHTTPTransport_PathEscapesSessionID(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	_, port := hostPort(t, srv.URL)
+	tr := newTestHTTPTransport(2 * time.Second)
+	tr.Client.Transport = rewriteLoopback(t, srv.URL)
+
+	if err := tr.Deliver(context.Background(), port, "abc/def", "hi"); err != nil {
+		t.Fatal(err)
+	}
+	want := "/session/abc%2Fdef/message"
+	if gotPath != want {
+		t.Fatalf("escaped path = %q, want %q", gotPath, want)
 	}
 }
 
@@ -120,9 +152,13 @@ func TestHTTPTransport_SendsCorrectBody(t *testing.T) {
 	}
 }
 
-// rewriteLoopback lets tests hit httptest.Server even though the
-// transport hardcodes 127.0.0.1. It rewrites the URL target host
-// to the httptest server host at the round-trip layer.
+// rewriteLoopback is a test-only RoundTripper that redirects
+// requests to 127.0.0.1:<any> over to the httptest.Server host.
+// HTTPTransport.Deliver hardcodes 127.0.0.1 because the v2 bus is
+// single-host by design (cross-host delivery is out of scope for
+// v2; see Deliver's doc comment). To exercise the real Deliver
+// codepath in tests without binding httptest.Server to the
+// hardcoded port, we swap the Host at the transport layer.
 func rewriteLoopback(t *testing.T, srvURL string) http.RoundTripper {
 	t.Helper()
 	target, err := url.Parse(srvURL)


### PR DESCRIPTION
Replace inbox.md + coda orch send + 50-orch-notify hook with a single
persistent typed message bus: SQLite for durability, HTTP POST for
delivery, agents interact via coda-core send/recv/ack/drain.

- migration 003_messages.sql: messages table + three partial indexes
  (undelivered, unacked, parent_id thread lookup)
- internal/messages/: Manager with Send/Recv/Ack/Drain/UnackedCounts,
  body validation (JSON, per-type required fields, 64KB cap, completion
  status enum), parent_id existence check, broadcast recipient sentinel
- transport.go: HTTPTransport (3s timeout, POST /session/<id>/message
  with {text}), transport_test.go covers 2xx/5xx/timeout/empty-coords/body
- DBOrchLookup resolves port/session_id from the orchestrators table
- coda-core send/recv/ack/drain subcommands with --json mode
- coda-core status grows a third section with unacked counts per orch

Delivery failure does not error: the row is durably stored and drained
on recipient restart. Drain stops at the first failure to preserve
ordering across restarts.

Scope locked to a single PR per Evan (2026-04-22). Shell-layer wiring,
inbox.md removal, auto-drain on start, broadcast fan-out, and prune
are explicit follow-ups.
