### PR TITLE
feat(#158): fix message bus HTTP wire format

### DIFF
--- a/internal/messages/transport.go
+++ b/internal/messages/transport.go
@@ -22,8 +22,12 @@ func NewHTTPTransport() *HTTPTransport {
 }
 
 // Deliver POSTs a text message to http://127.0.0.1:<port>/session/<id>/message
-// with body {"text":"<text>"}. Returns error on non-2xx, missing
-// coordinates, invalid port, or transport failure.
+// using the opencode session API shape:
+//
+//	{"parts":[{"type":"text","text":"<text>"}]}
+//
+// Returns error on non-2xx, missing coordinates, invalid port, or
+// transport failure.
 //
 // Delivery is loopback-only by design: the v2 message bus is a
 // single-host system and only talks to orchestrator sessions on
@@ -41,7 +45,9 @@ func (h *HTTPTransport) Deliver(ctx context.Context, port int, sessionID, text s
 		Path:    "/session/" + sessionID + "/message",
 		RawPath: "/session/" + url.PathEscape(sessionID) + "/message",
 	}
-	payload, err := json.Marshal(map[string]string{"text": text})
+	payload, err := json.Marshal(map[string]any{
+		"parts": []map[string]string{{"type": "text", "text": text}},
+	})
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
 	}

--- a/internal/messages/transport_test.go
+++ b/internal/messages/transport_test.go
@@ -140,12 +140,23 @@ func TestHTTPTransport_SendsCorrectBody(t *testing.T) {
 	if err := tr.Deliver(context.Background(), port, "ses1", "hello"); err != nil {
 		t.Fatal(err)
 	}
-	var parsed map[string]string
+	var parsed struct {
+		Parts []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"parts"`
+	}
 	if err := json.Unmarshal(gotBody, &parsed); err != nil {
 		t.Fatalf("body not JSON: %v", err)
 	}
-	if parsed["text"] != "hello" {
-		t.Fatalf("body text = %q, want %q", parsed["text"], "hello")
+	if len(parsed.Parts) != 1 {
+		t.Fatalf("parts len = %d, want 1", len(parsed.Parts))
+	}
+	if parsed.Parts[0].Type != "text" {
+		t.Fatalf("parts[0].type = %q, want %q", parsed.Parts[0].Type, "text")
+	}
+	if parsed.Parts[0].Text != "hello" {
+		t.Fatalf("parts[0].text = %q, want %q", parsed.Parts[0].Text, "hello")
 	}
 	if gotPath != "/session/ses1/message" {
 		t.Fatalf("path = %q, want /session/ses1/message", gotPath)


### PR DESCRIPTION
## Summary
- `HTTPTransport.Deliver` was posting `{"text":...}`; opencode's session endpoint requires `{"parts":[{"type":"text","text":...}]}`
- Every bus delivery was 400ing in production. Caught during #149 post-merge live shakedown (ash -> zach curl probe revealed the real shape)
- Fixed transport payload, updated `TestHTTPTransport_SendsCorrectBody`, godoc now documents the actual opencode API shape

## Verification
- `go test ./...` green
- `go vet ./...` clean, `gofmt -l .` clean
- Live end-to-end: rebuilt `coda-core`, sent note from ash orch to zach orch, Zach received and replied ("Got #158. Parts array format received cleanly.")

## Follow-ups (separate cards)
- #159: `orchestrator start` needs `--session-id` flag (still being worked around via manual SQL)
- New: 3s transport timeout races against opencode's synchronous agent response (opencode holds the connection until agent replies, which on a real note easily exceeds 3s). Current behavior: message delivered + acted on + reply queued, but `delivered_at` stays NULL due to timeout. Fire-and-forget semantics need a different primitive (e.g., `prompt_async`).