### PR TITLE
feat(#160): use prompt_async endpoint for fire-and-forget delivery

### DIFF
--- a/internal/messages/transport.go
+++ b/internal/messages/transport.go
@@ -21,13 +21,17 @@ func NewHTTPTransport() *HTTPTransport {
 	return &HTTPTransport{Client: &http.Client{Timeout: 3 * time.Second}}
 }
 
-// Deliver POSTs a text message to http://127.0.0.1:<port>/session/<id>/message
-// using the opencode session API shape:
+// Deliver POSTs a text message to
+// http://127.0.0.1:<port>/session/<id>/prompt_async using the opencode
+// session API shape:
 //
 //	{"parts":[{"type":"text","text":"<text>"}]}
 //
-// Returns error on non-2xx, missing coordinates, invalid port, or
-// transport failure.
+// The prompt_async endpoint returns 204 No Content immediately — true
+// fire-and-forget. The sibling /message endpoint holds the connection
+// open until the agent replies, which blows past the 3s client timeout
+// on any real message. Returns error on non-2xx, missing coordinates,
+// invalid port, or transport failure.
 //
 // Delivery is loopback-only by design: the v2 message bus is a
 // single-host system and only talks to orchestrator sessions on
@@ -42,8 +46,8 @@ func (h *HTTPTransport) Deliver(ctx context.Context, port int, sessionID, text s
 	u := &url.URL{
 		Scheme:  "http",
 		Host:    fmt.Sprintf("127.0.0.1:%d", port),
-		Path:    "/session/" + sessionID + "/message",
-		RawPath: "/session/" + url.PathEscape(sessionID) + "/message",
+		Path:    "/session/" + sessionID + "/prompt_async",
+		RawPath: "/session/" + url.PathEscape(sessionID) + "/prompt_async",
 	}
 	payload, err := json.Marshal(map[string]any{
 		"parts": []map[string]string{{"type": "text", "text": text}},

--- a/internal/messages/transport_test.go
+++ b/internal/messages/transport_test.go
@@ -117,7 +117,7 @@ func TestHTTPTransport_PathEscapesSessionID(t *testing.T) {
 	if err := tr.Deliver(context.Background(), port, "abc/def", "hi"); err != nil {
 		t.Fatal(err)
 	}
-	want := "/session/abc%2Fdef/message"
+	want := "/session/abc%2Fdef/prompt_async"
 	if gotPath != want {
 		t.Fatalf("escaped path = %q, want %q", gotPath, want)
 	}
@@ -158,8 +158,8 @@ func TestHTTPTransport_SendsCorrectBody(t *testing.T) {
 	if parsed.Parts[0].Text != "hello" {
 		t.Fatalf("parts[0].text = %q, want %q", parsed.Parts[0].Text, "hello")
 	}
-	if gotPath != "/session/ses1/message" {
-		t.Fatalf("path = %q, want /session/ses1/message", gotPath)
+	if gotPath != "/session/ses1/prompt_async" {
+		t.Fatalf("path = %q, want /session/ses1/prompt_async", gotPath)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `HTTPTransport.Deliver` now POSTs to `/session/<id>/prompt_async` instead of `/session/<id>/message`
- `prompt_async` returns 204 No Content immediately; `/message` holds the connection until the agent replies (blows past our 3s timeout on every real message)
- Test path assertions updated; godoc documents the rationale

## Why
Caught during #158 live shakedown: `coda-core send` reported `delivered=false` because the HTTP client timed out — but Zach actually received + processed + replied. Delivery succeeded; the wrong endpoint choice made it look like a failure.

## Verification
- `go test ./...` green
- `go vet ./...` clean, `gofmt -l .` clean
- Live end-to-end: rebuilt `coda-core`, sent note from ash to zach. Real wall clock: **20ms**. `delivered=true`. Zach received and replied (id=8 in the DB)

## Stack
- #158 (wire format) — merged
- #160 — this PR
- #159 (orchestrator start --session-id) — still open, separate fix