### PR TITLE
feat(#159): add --session-id flag to orchestrator start

### DIFF
--- a/cmd/coda-core/lifecycle_cmd.go
+++ b/cmd/coda-core/lifecycle_cmd.go
@@ -229,13 +229,14 @@ func orchNew(args []string) error {
 func orchStart(args []string) error {
 	fs := flag.NewFlagSet("orchestrator start", flag.ContinueOnError)
 	tmuxSession := fs.String("tmux-session", "", "tmux session name (optional)")
+	sessionID := fs.String("session-id", "", "opencode session id (optional)")
 	port := fs.Int("port", 0, "listener port (optional)")
 	pid := fs.Int("pid", 0, "process id (optional)")
 	if err := parseInterleaved(fs, args); err != nil {
 		return userError("%v", err)
 	}
 	if fs.NArg() != 1 {
-		return userError("usage: coda-core orchestrator start <name> [--tmux-session ...] [--port N] [--pid N]")
+		return userError("usage: coda-core orchestrator start <name> [--tmux-session ...] [--session-id ...] [--port N] [--pid N]")
 	}
 	name := fs.Arg(0)
 
@@ -245,7 +246,7 @@ func orchStart(args []string) error {
 	}
 	defer d.Close()
 
-	o, err := mgr.StartOrchestrator(context.Background(), name, *tmuxSession, *port, *pid)
+	o, err := mgr.StartOrchestrator(context.Background(), name, *tmuxSession, *sessionID, *port, *pid)
 	if err != nil {
 		if errors.Is(err, lifecycle.ErrNotFound) {
 			return userError("%v", err)

--- a/cmd/coda-core/lifecycle_cmd_test.go
+++ b/cmd/coda-core/lifecycle_cmd_test.go
@@ -42,7 +42,7 @@ func seedProbeCandidate(t *testing.T, mgr *lifecycle.Manager) {
 	if _, err := mgr.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := mgr.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 1111); err != nil {
+	if _, err := mgr.StartOrchestrator(ctx, "ash", "tmux-ash", "", 4096, 1111); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := mgr.DB.ExecContext(ctx,

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -2,6 +2,7 @@ package lifecycle
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"path/filepath"
 	"testing"
@@ -37,7 +38,7 @@ func TestOrchestratorCRUD(t *testing.T) {
 		t.Fatalf("duplicate create: err=%v, want ErrExists", err)
 	}
 
-	o2, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 12345)
+	o2, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", "", 4096, 12345)
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -129,5 +130,40 @@ func TestSpawnFeatureMissingOrchestrator(t *testing.T) {
 	})
 	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestStartOrchestrator_SetsSessionID(t *testing.T) {
+	m, _ := newTestManager(t)
+	ctx := context.Background()
+
+	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	o, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", "ses_abc123", 4096, 1111)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if !o.TmuxSession.Valid || o.TmuxSession.String != "tmux-ash" {
+		t.Fatalf("tmux_session not persisted: %+v", o.TmuxSession)
+	}
+	// Verify session_id persisted via GetOrchestrator (round-trip
+	// through the DB, not just the in-memory return value).
+	refetched, err := m.GetOrchestrator(ctx, "ash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if refetched.StaleReason.Valid {
+		t.Fatalf("stale_reason should be NULL after start: %+v", refetched.StaleReason)
+	}
+	// The Orchestrator struct does not currently expose SessionID;
+	// verify via direct SQL query against the test DB.
+	var sid sql.NullString
+	if err := m.DB.QueryRowContext(ctx,
+		`SELECT session_id FROM orchestrators WHERE name='ash'`).Scan(&sid); err != nil {
+		t.Fatal(err)
+	}
+	if !sid.Valid || sid.String != "ses_abc123" {
+		t.Fatalf("session_id = %+v, want ses_abc123", sid)
 	}
 }

--- a/internal/lifecycle/orchestrator.go
+++ b/internal/lifecycle/orchestrator.go
@@ -106,13 +106,13 @@ func (m *Manager) CreateOrchestrator(ctx context.Context, name, configDir string
 
 // StartOrchestrator records a start transition: state=running, stamps
 // tmux_session/port/pid/started_at. Fires post-orchestrator-start.
-func (m *Manager) StartOrchestrator(ctx context.Context, name string, tmuxSession string, port int, pid int) (*Orchestrator, error) {
+func (m *Manager) StartOrchestrator(ctx context.Context, name string, tmuxSession string, sessionID string, port int, pid int) (*Orchestrator, error) {
 	now := m.now()
 	res, err := m.DB.ExecContext(ctx,
 		`UPDATE orchestrators
-		 SET state=?, tmux_session=?, port=?, pid=?, started_at=?, stale_reason=NULL, updated_at=?
+		 SET state=?, tmux_session=?, session_id=?, port=?, pid=?, started_at=?, stale_reason=NULL, updated_at=?
 		 WHERE name=? AND state IN ('stopped','stale')`,
-		StateRunning, nullStr(tmuxSession), nullInt(int64(port)), nullInt(int64(pid)), now, now, name)
+		StateRunning, nullStr(tmuxSession), nullStr(sessionID), nullInt(int64(port)), nullInt(int64(pid)), now, now, name)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/lifecycle/reconciler_test.go
+++ b/internal/lifecycle/reconciler_test.go
@@ -136,7 +136,7 @@ func TestReconcile_TmuxGoneWithUnknownPidKeepsAlive(t *testing.T) {
 	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 1111); err != nil {
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", "", 4096, 1111); err != nil {
 		t.Fatal(err)
 	}
 	backdateOrchestrator(t, m, "ash", 60)
@@ -166,7 +166,7 @@ func TestReconcile_PidDeadButTmuxAliveKeepsAlive(t *testing.T) {
 	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 2222); err != nil {
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", "", 4096, 2222); err != nil {
 		t.Fatal(err)
 	}
 	backdateOrchestrator(t, m, "ash", 60)
@@ -192,7 +192,7 @@ func TestReconcile_BothDeadMarksStale(t *testing.T) {
 	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 1111); err != nil {
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", "", 4096, 1111); err != nil {
 		t.Fatal(err)
 	}
 	backdateOrchestrator(t, m, "ash", 60)
@@ -228,7 +228,7 @@ func TestReconcile_TmuxOnlyDead(t *testing.T) {
 	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 0); err != nil {
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", "", 4096, 0); err != nil {
 		t.Fatal(err)
 	}
 	backdateOrchestrator(t, m, "ash", 60)
@@ -256,7 +256,7 @@ func TestReconcile_PidOnlyDead(t *testing.T) {
 	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.StartOrchestrator(ctx, "ash", "", 4096, 2222); err != nil {
+	if _, err := m.StartOrchestrator(ctx, "ash", "", "", 4096, 2222); err != nil {
 		t.Fatal(err)
 	}
 	backdateOrchestrator(t, m, "ash", 60)
@@ -284,7 +284,7 @@ func TestReconcile_NoSignalsSkipped(t *testing.T) {
 	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.StartOrchestrator(ctx, "ash", "", 0, 0); err != nil {
+	if _, err := m.StartOrchestrator(ctx, "ash", "", "", 0, 0); err != nil {
 		t.Fatal(err)
 	}
 	backdateOrchestrator(t, m, "ash", 60)
@@ -310,7 +310,7 @@ func TestReconcile_ProbeErrorSkipsRow(t *testing.T) {
 	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 3333); err != nil {
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", "", 4096, 3333); err != nil {
 		t.Fatal(err)
 	}
 	backdateOrchestrator(t, m, "ash", 60)
@@ -336,7 +336,7 @@ func TestReconcile_BothAliveNoOp(t *testing.T) {
 	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 3333); err != nil {
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", "", 4096, 3333); err != nil {
 		t.Fatal(err)
 	}
 	backdateOrchestrator(t, m, "ash", 60)
@@ -366,7 +366,7 @@ func TestReconcile_RespectsFreshnessWindow(t *testing.T) {
 	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 4444); err != nil {
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", "", 4096, 4444); err != nil {
 		t.Fatal(err)
 	}
 
@@ -395,7 +395,7 @@ func TestReconcile_StaleRowIsIdempotent(t *testing.T) {
 	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 5555); err != nil {
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", "", 4096, 5555); err != nil {
 		t.Fatal(err)
 	}
 	backdateOrchestrator(t, m, "ash", 60)
@@ -425,7 +425,7 @@ func TestReconcile_ConcurrentStartWinsOverReconcile(t *testing.T) {
 	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 9999); err != nil {
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", "", 4096, 9999); err != nil {
 		t.Fatal(err)
 	}
 	backdateOrchestrator(t, m, "ash", 60)
@@ -518,7 +518,7 @@ func TestReconcile_FiresOrchestratorStaleHook(t *testing.T) {
 	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 6666); err != nil {
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", "", 4096, 6666); err != nil {
 		t.Fatal(err)
 	}
 	backdateOrchestrator(t, m, "ash", 60)
@@ -608,10 +608,10 @@ func TestReconcile_HookFailureDoesNotAbortLoop(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 1111); err != nil {
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", "", 4096, 1111); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.StartOrchestrator(ctx, "beth", "tmux-beth", 4097, 2222); err != nil {
+	if _, err := m.StartOrchestrator(ctx, "beth", "tmux-beth", "", 4097, 2222); err != nil {
 		t.Fatal(err)
 	}
 	backdateOrchestrator(t, m, "ash", 60)
@@ -644,7 +644,7 @@ func TestStartOrchestrator_FromStale(t *testing.T) {
 	if _, err := m.CreateOrchestrator(ctx, "ash", "/tmp/ash"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", 4096, 7777); err != nil {
+	if _, err := m.StartOrchestrator(ctx, "ash", "tmux-ash", "", 4096, 7777); err != nil {
 		t.Fatal(err)
 	}
 	backdateOrchestrator(t, m, "ash", 60)
@@ -662,7 +662,7 @@ func TestStartOrchestrator_FromStale(t *testing.T) {
 		t.Fatalf("precondition: state=%s, want stale", o.State)
 	}
 
-	o2, err := m.StartOrchestrator(ctx, "ash", "tmux-ash-2", 4097, 8888)
+	o2, err := m.StartOrchestrator(ctx, "ash", "tmux-ash-2", "", 4097, 8888)
 	if err != nil {
 		t.Fatalf("start from stale: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Adds `--session-id` flag to `coda-core orchestrator start`
- `StartOrchestrator` signature now takes `sessionID string` between `tmuxSession` and `port`
- SQL UPDATE now writes `session_id` column (existed since migration 001 but was never populated)
- All 18 call sites updated; existing tests pass `""` preserving NULL behavior
- New `TestStartOrchestrator_SetsSessionID` verifies round-trip through DB

## Motivation

The v2 message bus (`DBOrchLookup`) returns `running=false` when `session_id` is NULL, blocking HTTP delivery. Shakedown was working around this with manual SQL UPDATEs.

## Follow-up

Shell-layer callsite to pass the real session id from the opencode serve bootstrap is a separate card.